### PR TITLE
Remove abstract on Util class

### DIFF
--- a/src/Flysystem/Util.php
+++ b/src/Flysystem/Util.php
@@ -8,14 +8,6 @@ use LogicException;
 class Util
 {
     /**
-     * @codeCoverageIgnore
-     */
-    private function __construct()
-    {
-        throw new LogicException('Instantiation forbidden');
-    }
-
-    /**
      * Get normalized pathinfo
      *
      * @param   string  $path

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -4,12 +4,6 @@ namespace Flysystem;
 
 class UtilTests extends \PHPUnit_Framework_TestCase
 {
-    public function testCannotInstanciate()
-    {
-        $utilReflection = new \ReflectionClass('Flysystem\Util');
-        $this->assertFalse($utilReflection->isInstantiable());
-    }
-
     public function testEmulateDirectories()
     {
         $input = array(array('dirname' => '', 'filename' => 'dummy'), array('dirname' => 'something', 'filename' => 'dummy'));


### PR DESCRIPTION
I think Util should not be declared abstract, it's really a concrete class.
Forbid instanciation excplicitly with a private constructor instead.
Oh well, maybe this is too picky for nothing but I think it makes more OOP sense
