### PR TITLE
A file of size zero never gets its metadata cached.

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -524,9 +524,9 @@ class Filesystem implements FilesystemInterface
     public function getSize($path)
     {
         $path = Util::normalizePath($path);
-
         $size = $this->cache->getSize($path);
-        if (isset($size) && $size !== false) {
+
+        if ($size !== false) {
             return $size;
         }
 


### PR DESCRIPTION
One thing I cannot get my head around, is cache->getSize($path) will return the size of a file for the path, while adapter->getSize($path) will return the full metadata array for the file path.

I discovered the above non-caching issue because my adapter->getSize() was returning an integer (i.e. the file size) instead of the metadata array, and that let to an error as it tried to cache the integer over the top of the object metadata for the path.

Is there a reason for these two methods acting so wildly different?
