### PR TITLE
Fixex getSize() to return false instead of null

### DIFF
--- a/src/Cache/AbstractCache.php
+++ b/src/Cache/AbstractCache.php
@@ -278,6 +278,7 @@ abstract class AbstractCache implements CacheInterface
         if (isset($this->cache[$path]['size'])) {
             return $this->cache[$path]['size'];
         }
+
         return false;
     }
 


### PR DESCRIPTION
Adhere to ReadInterface's contract to return false for not existing entries
