### PR TITLE
Rely on ReadInterface contract for getSize().

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -526,7 +526,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $cached = $this->cache->getSize($path);
 
-        if (is_int($cached)) {
+        if ($cached !== false) {
             return $cached;
         }
 


### PR DESCRIPTION
The return type in the cache impl was fixed recently, therefore we can rely on the contract
