### PR TITLE
Raise Mockery Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "~2.5",
         "predis/predis": "~0.8.4",
-        "mockery/mockery": "~0.8.0",
+        "mockery/mockery": "~0.9.0",
         "dropbox/dropbox-sdk": "~1.1.1",
         "rackspace/php-opencloud": "~1.9.1",
         "sabre/dav": "~1.8.7",


### PR DESCRIPTION
Let's use 0.9 rather than 0.8. Your current version constraint says select any 0.8.x version provided it is 0.8.0 or greater. I am updating it so now it says select any 0.9.x version provided it is 0.9.0 or greater.
