### PR TITLE
Docblock mistake

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -55,7 +55,7 @@ class Filesystem implements FilesystemInterface
     /**
      * Get the Config
      *
-     * @return  AdapterInterface  adapter
+     * @return  Config  config object
      */
     public function getConfig()
     {


### PR DESCRIPTION
The docblock for `getConfig()` said it returned an AdapterInterface, which it doesn't. At least, I'm pretty sure it doesn't.
