### PR TITLE
Fixes `AwsS3::listContents()` not returning all contents

### DIFF
--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -355,12 +355,12 @@ class AwsS3 extends AbstractAdapter
      */
     public function listContents($dirname = '', $recursive = false)
     {
-        $result = $this->client->listObjects(array(
+        $objectsIterator = $this->client->getIterator('listObjects', array(
             'Bucket' => $this->bucket,
             'Prefix' => $this->prefix($dirname),
-        ))->getAll(array('Contents'));
+        ));
 
-        $contents = isset($result['Contents']) ? $result['Contents'] : array();
+        $contents = iterator_to_array($objectsIterator);
         $result = array_map(array($this, 'normalizeObject'), $contents);
 
         return Util::emulateDirectories($result);


### PR DESCRIPTION
Created other pull-request from proper account.
See: http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingObjectKeysUsingPHP.html
