### PR TITLE
Fixing AWS S3 `listContents()` not returning directories if fake on haven't been created

### DIFF
--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -399,7 +399,7 @@ class AwsS3 extends AbstractAdapter
         $directories = array();
 
         // Creating list of directories
-        foreach ($contents as &$object) {
+        foreach ($contents as $object) {
             if (!empty($object['dirname']) && !isset($directories[$object['dirname']])) {
                 $directories[$object['dirname']] = true;
             }


### PR DESCRIPTION
AWS S3 `listContents()` haven't returned directories if "fake" directory haven't been created previously (an empty file uploaded with trailing slash in the key). Fixed in pull request.
