### PR TITLE
Trying to guess MIME Type using file extension for "plain/text"

### DIFF
--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -81,7 +81,7 @@ class AwsS3 extends AbstractAdapter
 
         $options = $this->getOptions($path, array(
             'Body' => $contents,
-            'ContentType' => Util::contentMimetype($contents),
+            'ContentType' => Util::guessMimeType($path, $contents),
             'ContentLength' => Util::contentSize($contents),
         ));
 

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -121,7 +121,7 @@ class Ftp extends AbstractFtpAdapter
     public function write($path, $contents, $config = null)
     {
         $this->ensureDirectory(Util::dirname($path));
-        $mimetype = Util::contentMimetype($contents);
+        $mimetype = Util::guessMimeType($path, $contents);
         $config = Util::ensureConfig($config);
         $stream = $contents;
 
@@ -247,7 +247,7 @@ class Ftp extends AbstractFtpAdapter
             return false;
         }
 
-        $metadata['mimetype'] = Util::contentMimetype($metadata['contents']);
+        $metadata['mimetype'] = Util::guessMimeType($path, $metadata['contents']);
 
         return $metadata;
     }

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -174,7 +174,7 @@ class Local extends AbstractAdapter
     public function update($path, $contents, $config = null)
     {
         $location = $this->prefix($path);
-        $mimetype = Util::contentMimetype($contents);
+        $mimetype = Util::guessMimeType($path, $contents);
 
         if (($size = file_put_contents($location, $contents, LOCK_EX)) === false) {
             return false;

--- a/src/Adapter/Sftp.php
+++ b/src/Adapter/Sftp.php
@@ -217,7 +217,7 @@ class Sftp extends AbstractFtpAdapter
             return false;
         }
 
-        $data['mimetype'] = Util::contentMimetype($data['contents']);
+        $data['mimetype'] = Util::guessMimeType($path, $data['contents']);
 
         return $data;
     }

--- a/src/Adapter/Zip.php
+++ b/src/Adapter/Zip.php
@@ -190,7 +190,7 @@ class Zip extends AbstractAdapter
             return false;
         }
 
-        $data['mimetype'] = Util::contentMimetype($data['contents']);
+        $data['mimetype'] = Util::guessMimeType($path, $data['contents']);
 
         return $data;
     }

--- a/src/Cache/AbstractCache.php
+++ b/src/Cache/AbstractCache.php
@@ -288,7 +288,7 @@ abstract class AbstractCache implements CacheInterface
             return false;
         }
 
-        $mimetype = Util::contentMimetype($contents);
+        $mimetype = Util::guessMimeType($path, $contents);
         $this->cache[$path]['mimetype'] = $mimetype;
 
         return $mimetype;

--- a/src/Util.php
+++ b/src/Util.php
@@ -121,16 +121,25 @@ class Util
     }
 
     /**
-     * Get content mimetype from buffer
+     * Guess MIME Type based on the path of the file and it's content
      *
-     * @param   string  $content
-     * @return  string  mimetype
+     * @param  string $path
+     * @param  string $content
+     * @return string|null     MIME Type or NULL if no extension detected
      */
-    public static function contentMimetype($content)
+    public static function guessMimeType($path, $content)
     {
-        $finfo = new Finfo(FILEINFO_MIME_TYPE);
+        $mimeType = Util\MimeType::detectByContent($content);
 
-        return $finfo->buffer($content);
+        if (empty($mimeType) || $mimeType === 'text/plain') {
+            $extension = pathinfo($path, PATHINFO_EXTENSION);
+            
+            if ($extension) {
+                $mimeType = Util\MimeType::detectByFileExtension($extension) ?: $mimeType;
+            }
+        }
+
+        return $mimeType;
     }
 
     /**

--- a/src/Util/MimeType.php
+++ b/src/Util/MimeType.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace League\Flysystem\Util;
+
+class MimeType
+{
+    /**
+     * Detects MIME Type based on given content
+     *
+     * @param  string $content
+     * @return string|null     MIME Type or NULL if no extension detected
+     */
+    public static function detectByContent($content)
+    {
+        $finfo = new \Finfo(FILEINFO_MIME_TYPE);
+        $mimeType = $finfo->buffer($content);
+
+        return $mimeType ?: null;
+    }
+
+    /**
+     * Detects MIME Type based on file extension
+     *
+     * @param  string $extension
+     * @return string|null       MIME Type or NULL if no extension detected
+     */
+    public static function detectByFileExtension($extension)
+    {
+        $mimeType = null;
+        $extensionToMimeTypeMap = self::getExtenionToMimeTypeMap();
+        
+        if (isset($extensionToMimeTypeMap[$extension])) {
+            $mimeType = $extensionToMimeTypeMap[$extension];
+        }
+
+        return $mimeType;
+    }
+
+    /**
+     * @return array Map of file extension to MIME Type
+     */
+    public static function getExtenionToMimeTypeMap()
+    {
+        return array(
+            'hqx'   => 'application/mac-binhex40',
+            'cpt'   => 'application/mac-compactpro',
+            'csv'   => 'text/x-comma-separated-values',
+            'bin'   => 'application/octet-stream',
+            'dms'   => 'application/octet-stream',
+            'lha'   => 'application/octet-stream',
+            'lzh'   => 'application/octet-stream',
+            'exe'   => 'application/octet-stream',
+            'class' => 'application/octet-stream',
+            'psd'   => 'application/x-photoshop',
+            'so'    => 'application/octet-stream',
+            'sea'   => 'application/octet-stream',
+            'dll'   => 'application/octet-stream',
+            'oda'   => 'application/oda',
+            'pdf'   => 'application/pdf',
+            'ai'    => 'application/pdf',
+            'eps'   => 'application/postscript',
+            'ps'    => 'application/postscript',
+            'smi'   => 'application/smil',
+            'smil'  => 'application/smil',
+            'mif'   => 'application/vnd.mif',
+            'xls'   => 'application/vnd.ms-excel',
+            'ppt'   => 'application/powerpoint',
+            'pptx'  => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            'wbxml' => 'application/wbxml',
+            'wmlc'  => 'application/wmlc',
+            'dcr'   => 'application/x-director',
+            'dir'   => 'application/x-director',
+            'dxr'   => 'application/x-director',
+            'dvi'   => 'application/x-dvi',
+            'gtar'  => 'application/x-gtar',
+            'gz'    => 'application/x-gzip',
+            'gzip'  => 'application/x-gzip',
+            'php'   => 'application/x-httpd-php',
+            'php4'  => 'application/x-httpd-php',
+            'php3'  => 'application/x-httpd-php',
+            'phtml' => 'application/x-httpd-php',
+            'phps'  => 'application/x-httpd-php-source',
+            'js'    => 'application/javascript',
+            'swf'   => 'application/x-shockwave-flash',
+            'sit'   => 'application/x-stuffit',
+            'tar'   => 'application/x-tar',
+            'tgz'   => 'application/x-tar',
+            'z'     => 'application/x-compress',
+            'xhtml' => 'application/xhtml+xml',
+            'xht'   => 'application/xhtml+xml',
+            'zip'   => 'application/x-zip',
+            'rar'   => 'application/x-rar',
+            'mid'   => 'audio/midi',
+            'midi'  => 'audio/midi',
+            'mpga'  => 'audio/mpeg',
+            'mp2'   => 'audio/mpeg',
+            'mp3'   => 'audio/mpeg',
+            'aif'   => 'audio/x-aiff',
+            'aiff'  => 'audio/x-aiff',
+            'aifc'  => 'audio/x-aiff',
+            'ram'   => 'audio/x-pn-realaudio',
+            'rm'    => 'audio/x-pn-realaudio',
+            'rpm'   => 'audio/x-pn-realaudio-plugin',
+            'ra'    => 'audio/x-realaudio',
+            'rv'    => 'video/vnd.rn-realvideo',
+            'wav'   => 'audio/x-wav',
+            'jpg'   => 'image/jpeg',
+            'jpeg'  => 'image/jpeg',
+            'jpe'   => 'image/jpeg',
+            'png'   => 'image/png',
+            'gif'   => 'image/gif',
+            'bmp'   => 'image/bmp',
+            'tiff'  => 'image/tiff',
+            'tif'   => 'image/tiff',
+            'css'   => 'text/css',
+            'html'  => 'text/html',
+            'htm'   => 'text/html',
+            'shtml' => 'text/html',
+            'txt'   => 'text/plain',
+            'text'  => 'text/plain',
+            'log'   => 'text/plain',
+            'rtx'   => 'text/richtext',
+            'rtf'   => 'text/rtf',
+            'xml'   => 'application/xml',
+            'xsl'   => 'application/xml',
+            'mpeg'  => 'video/mpeg',
+            'mpg'   => 'video/mpeg',
+            'mpe'   => 'video/mpeg',
+            'qt'    => 'video/quicktime',
+            'mov'   => 'video/quicktime',
+            'avi'   => 'video/x-msvideo',
+            'movie' => 'video/x-sgi-movie',
+            'doc'   => 'application/msword',
+            'docx'  => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'dot'   => 'application/msword',
+            'dotx'  => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'xlsx'  => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'word'  => 'application/msword',
+            'xl'    => 'application/excel',
+            'eml'   => 'message/rfc822',
+            'json'  => 'application/json',
+            'pem'   => 'application/x-x509-user-cert',
+            'p10'   => 'application/x-pkcs10',
+            'p12'   => 'application/x-pkcs12',
+            'p7a'   => 'application/x-pkcs7-signature',
+            'p7c'   => 'application/pkcs7-mime',
+            'p7m'   => 'application/pkcs7-mime',
+            'p7r'   => 'application/x-pkcs7-certreqresp',
+            'p7s'   => 'application/pkcs7-signature',
+            'crt'   => 'application/x-x509-ca-cert',
+            'crl'   => 'application/pkix-crl',
+            'der'   => 'application/x-x509-ca-cert',
+            'kdb'   => 'application/octet-stream',
+            'pgp'   => 'application/pgp',
+            'gpg'   => 'application/gpg-keys',
+            'sst'   => 'application/octet-stream',
+            'csr'   => 'application/octet-stream',
+            'rsa'   => 'application/x-pkcs7',
+            'cer'   => 'application/pkix-cert',
+            '3g2'   => 'video/3gpp2',
+            '3gp'   => 'video/3gp',
+            'mp4'   => 'video/mp4',
+            'm4a'   => 'audio/x-m4a',
+            'f4v'   => 'video/mp4',
+            'webm'  => 'video/webm',
+            'aac'   => 'audio/x-acc',
+            'm4u'   => 'application/vnd.mpegurl',
+            'm3u'   => 'text/plain',
+            'xspf'  => 'application/xspf+xml',
+            'vlc'   => 'application/videolan',
+            'wmv'   => 'video/x-ms-wmv',
+            'au'    => 'audio/x-au',
+            'ac3'   => 'audio/ac3',
+            'flac'  => 'audio/x-flac',
+            'ogg'   => 'audio/ogg',
+            'kmz'   => 'application/vnd.google-earth.kmz',
+            'kml'   => 'application/vnd.google-earth.kml+xml',
+            'ics'   => 'text/calendar',
+            'zsh'   => 'text/x-scriptzsh',
+            '7zip'  => 'application/x-7z-compressed',
+            'cdr'   => 'application/cdr',
+            'wma'   => 'audio/x-ms-wma',
+            'jar'   => 'application/java-archive',
+        );
+    }
+}

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -93,4 +93,22 @@ class UtilTests extends \PHPUnit_Framework_TestCase
         $result = Util::normalizePath($input);
         $this->assertEquals($expected, $result);
     }
+
+    public function pathAndContentProvider()
+    {
+        return array(
+            array('/some/file.css', 'body { background: #000; } ', 'text/css'),
+            array('/some/file.txt', 'body { background: #000; } ', 'text/plain'),
+            array('/1x1', base64_decode('R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='), 'image/gif')
+        );
+    }
+
+    /**
+     * @dataProvider  pathAndContentProvider
+     */
+    public function testGuessMimeType($path, $content, $expected)
+    {
+        $mimeType = Util::guessMimeType($path, $content);
+        $this->assertEquals($expected, $mimeType);
+    }
 }


### PR DESCRIPTION
When putting CSS to AWS S3 "Fileinfo" returns the MIME Type "plain/text". That pull request creates a feature of guessing MIME Type using extension when that situation occurs, so S3 will have a proper MIME Type setup for object.
