### PR TITLE
local adapter timestamp for directories

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -417,10 +417,13 @@ class Local extends AbstractAdapter
      */
     protected function normalizeFileInfo($path, SplFileInfo $file)
     {
-        $normalized = array('type' => $file->getType(), 'path' => $path);
+        $normalized = array(
+            'type' => $file->getType(),
+            'path' => $path,
+            'timestamp' => $file->getMTime()
+        );
 
         if ($normalized['type'] === 'file') {
-            $normalized['timestamp'] = $file->getMTime();
             $normalized['size'] = $file->getSize();
         }
 


### PR DESCRIPTION
I'm not sure if there was some reason not to include timestamp for directories but this adds that functionality.
