### PR TITLE
FIX for FTP Filezilla Server compatibility

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -275,7 +275,7 @@ class Ftp extends AbstractFtpAdapter
             return false;
         }
 
-        return $object[1];
+        return $object[0];
     }
 
     public function getMimetype($path)


### PR DESCRIPTION
FIX function GetMetadata, if remote FTP command STAT unrecognized then call ftp_rawlist
