### PR TITLE
Allow setting 'StorageClass' and 'ServerSideEncryption' during S3 upload

### DIFF
--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -28,6 +28,7 @@ class AwsS3 extends AbstractAdapter
         'Cache-Control',
         'Expires',
         'StorageClass',
+        'ServerSideEncryption',
     );
 
     /**


### PR DESCRIPTION
Added extra meta options so that developer can set  'StorageClass' and 'ServerSideEncryption' during S3 upload.
