### PR TITLE
Don't rewrite if the pointer is already 0

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -115,7 +115,9 @@ class Local extends AbstractAdapter
      */
     public function writeStream($path, $resource, $config = null)
     {
-        rewind($resource);
+        if(ftell($resource) !== 0) {
+            rewind($resource);
+        }
         $config = Util::ensureConfig($config);
         $location = $this->prefix($path);
         $this->ensureDirectory(dirname($location));


### PR DESCRIPTION
Not all streams support rewind(), this prevents the error "rewind(): stream does not support seeking".
