### PR TITLE
Recursion did not fully work on Dropbox Adapter

### DIFF
--- a/src/Adapter/Dropbox.php
+++ b/src/Adapter/Dropbox.php
@@ -259,7 +259,7 @@ class Dropbox extends AbstractAdapter
             $listing[] = $this->normalizeObject($object, $path);
 
             if ($recursive && $object['is_dir']) {
-                $listing = array_merge($listing, $this->listContents($path));
+                $listing = array_merge($listing, $this->listContents($path, true));
             }
         }
 


### PR DESCRIPTION
listContents method called itself, but did not pass in the $recursive argument, so would only ever go 1 level.
