### PR TITLE
Adapter/Ftp::deleteDir now returns boolean

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -177,6 +177,13 @@ class Ftp extends AbstractFtpAdapter
         return ftp_delete($this->getConnection(), $path);
     }
 
+    /**
+     * Removes a directory
+     *
+     * @param   string       $dirname directory name
+     *
+     * @return  bool
+     */
     public function deleteDir($dirname)
     {
         $connection = $this->getConnection();
@@ -184,13 +191,17 @@ class Ftp extends AbstractFtpAdapter
 
         foreach ($contents as $object) {
             if ($object['type'] === 'file') {
-                ftp_delete($connection, $object['path']);
+                if (!ftp_delete($connection, $object['path'])) {
+                    return false;
+                }
             } else {
-                ftp_rmdir($connection, $object['path']);
+                if (!ftp_rmdir($connection, $object['path'])) {
+                    return false;
+                }
             }
         }
 
-        ftp_rmdir($connection, $dirname);
+        return ftp_rmdir($connection, $dirname);
     }
 
     /**

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -16,8 +16,12 @@ function ftp_delete()
     return true;
 }
 
-function ftp_rmdir()
+function ftp_rmdir($connection, $dirname)
 {
+    if (strpos($dirname, 'rmdir.fail') !== false) {
+        return false;
+    }
+
     return true;
 }
 
@@ -190,6 +194,8 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertFalse($adapter->setVisibility('chmod.fail', 'private'));
         $this->assertTrue($adapter->rename('a','b'));
         $this->assertTrue($adapter->delete('a'));
+        $this->assertFalse($adapter->deleteDir('some.nested/rmdir.fail'));
+        $this->assertTrue($adapter->deleteDir('a/directory'));
         $result = $adapter->read('something.txt');
         $this->assertEquals('contents', $result['contents']);
         $result = $adapter->getMimetype('something.txt');


### PR DESCRIPTION
`Adapter\Ftp::deleteDir` must return boolean, as per `AdapterInterface::deleteDir` specification.
