### PR TITLE
Fixed: updateStream method missing in FTP Adapter

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -161,6 +161,11 @@ class Ftp extends AbstractFtpAdapter
     {
         return $this->write($path, $contents, $config);
     }
+    
+    public function updateStream($path, $resource, $config = null) {
+        $this->writeStream($path, $resource, $config);
+    }
+
 
     public function rename($path, $newpath)
     {


### PR DESCRIPTION
Added missing method updateStream to FTP Adapater, that just wrapper for writeStream. FTP will replace file anyway
