### PR TITLE
Allow access to dropbox client

### DIFF
--- a/src/Adapter/Dropbox.php
+++ b/src/Adapter/Dropbox.php
@@ -250,6 +250,11 @@ class Dropbox extends AbstractAdapter
     {
         return $this->getMetadata($path);
     }
+    
+    public function getClient()
+    {
+        return $this->client;
+    }
 
     public function listContents($directory = '', $recursive = false)
     {


### PR DESCRIPTION
This is just a method that allows access to the Dropbox Client so you can access some of the more advanced file operations if needed.
