### PR TITLE
Local Adapter Fixes

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -19,6 +19,9 @@ class Local extends AbstractAdapter
         'private' => 0700,
     );
 
+    /**
+     * @var  string  $pathSeparator
+     */
     protected $pathSeparator = DIRECTORY_SEPARATOR;
 
     /**

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -114,6 +114,6 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
 
     public function testGetPathPrefix()
     {
-        $this->assertEquals(realpath(__DIR__.'/files') . '/', $this->adapter->getPathPrefix());
+        $this->assertEquals(realpath(__DIR__.'/files') . DIRECTORY_SEPARATOR, $this->adapter->getPathPrefix());
     }
 }


### PR DESCRIPTION
Ok, so this the first fix for #210.

It brings the tests to the following state on windows:

```
PHPUnit 4.1.4 by Sebastian Bergmann.

Configuration read from C:\Users\Graham\Documents\GitHub\flysystem\phpunit.xml

...............................................................  63 / 286 ( 22%)
...............................................F.....F......... 126 / 286 ( 44%)
.............F...............E................................. 189 / 286 ( 66%)
............................................................... 252 / 286 ( 88%)
..................................

Time: 6.71 seconds, Memory: 17.25Mb

There was 1 error:

1) League\Flysystem\Adapter\LocalAdapterTests::testReadStream
unlink(C:\Users\Graham\Documents\GitHub\flysystem\tests\files\file.txt): Permission denied

C:\Users\Graham\Documents\GitHub\flysystem\src\Adapter\Local.php:234
C:\Users\Graham\Documents\GitHub\flysystem\tests\LocalAdapterTests.php:51

--

There were 3 failures:

1) League\Flysystem\FilesystemTests::testImplicitDirs with data set #0 (League\Flysystem\Filesystem, League\Flysystem\Adapter\Local, League\Flysystem\Cache\Memory)
Failed asserting that false is true.

C:\Users\Graham\Documents\GitHub\flysystem\tests\FilesystemTests.php:236

2) League\Flysystem\FilesystemTests::testVisibility with data set #0 (League\Flysystem\Filesystem, League\Flysystem\Adapter\Local, League\Flysystem\Cache\Memory)
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'private'
+'public'

C:\Users\Graham\Documents\GitHub\flysystem\tests\FilesystemTests.php:304

3) League\Flysystem\FilesystemTests::testGet with data set #0 (League\Flysystem\Filesystem, League\Flysystem\Adapter\Local, League\Flysystem\Cache\Memory)
Failed asserting that actual size 3 matches expected size 1.

C:\Users\Graham\Documents\GitHub\flysystem\tests\FilesystemTests.php:535

FAILURES!
Tests: 286, Assertions: 501, Failures: 3, Errors: 1.
```
