### PR TITLE
Fixed Error On Windows

### DIFF
--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -48,6 +48,7 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('stream', $result);
         $this->assertInternalType('resource', $result['stream']);
+        fclose($result['stream']);
         $adapter->delete('file.txt');
     }
 


### PR DESCRIPTION
We were trying to delete a file when we still had it open. I'll have to assume linux was ok was this because the stream was maybe closed by the garbage collector??? I really don't know how linux wasn't failing too!

---

This is another fix for #214.

Current output:

```
PHPUnit 4.1.4 by Sebastian Bergmann.

Configuration read from C:\Users\Graham\Documents\GitHub\flysystem\phpunit.xml

...............................................................  63 / 286 ( 22%)
...............................................F.....F......... 126 / 286 ( 44%)
.............F................................................. 189 / 286 ( 66%)
............................................................... 252 / 286 ( 88%)
..................................

Time: 6.74 seconds, Memory: 17.00Mb

There were 3 failures:

1) League\Flysystem\FilesystemTests::testImplicitDirs with data set #0 (League\Flysystem\Filesystem, League\Flysystem\Adapter\Local, League\Flysystem\Cache\Memory)
Failed asserting that false is true.

C:\Users\Graham\Documents\GitHub\flysystem\tests\FilesystemTests.php:236

2) League\Flysystem\FilesystemTests::testVisibility with data set #0 (League\Flysystem\Filesystem, League\Flysystem\Adapter\Local, League\Flysystem\Cache\Memory)
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'private'
+'public'

C:\Users\Graham\Documents\GitHub\flysystem\tests\FilesystemTests.php:304

3) League\Flysystem\FilesystemTests::testGet with data set #0 (League\Flysystem\Filesystem, League\Flysystem\Adapter\Local, League\Flysystem\Cache\Memory)
Failed asserting that actual size 3 matches expected size 1.

C:\Users\Graham\Documents\GitHub\flysystem\tests\FilesystemTests.php:535

FAILURES!
Tests: 286, Assertions: 501, Failures: 3.
```
