### PR TITLE
BackupAdapter

### DIFF
--- a/src/Adapter/ReplicateAdapter.php
+++ b/src/Adapter/ReplicateAdapter.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace League\Flysystem\Adapter;
+
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Config;
+
+class ReplicateAdapter extends AbstractAdapter
+{
+    /** @var AdapterInterface */
+    protected $replica;
+
+    /** @var AdapterInterface */
+    protected $source;
+
+    /**
+     * Constructor
+     *
+     * @param AdapterInterface $source
+     * @param AdapterInterface $replica
+     */
+    public function __construct(AdapterInterface $source, AdapterInterface $replica)
+    {
+        $this->source = $source;
+        $this->replica = $replica;
+    }
+
+    /**
+     * Returns the replica adapter
+     *
+     * @return AdapterInterface
+     */
+    public function getReplicaAdapter()
+    {
+        return $this->replica;
+    }
+
+    /**
+     * Returns the source adapter
+     *
+     * @return AdapterInterface
+     */
+    public function getSourceAdapter()
+    {
+        return $this->source;
+    }
+
+    /**
+     * Write a new file to the source and replica
+     *
+     * @param   string $path
+     * @param   string $contents
+     * @param   mixed  $config Config object or visibility setting
+     *
+     * @return  false|array  false on failure file meta data on success
+     */
+    public function write($path, $contents, $config = null)
+    {
+        if ( ! $this->source->write($path, $contents, $config)) {
+            return false;
+        }
+
+        return $this->replica->write($path, $contents, $config);
+    }
+
+    /**
+     * Update a file on the source and replica
+     *
+     * @param   string $path
+     * @param   string $contents
+     * @param   mixed  $config Config object or visibility setting
+     *
+     * @return  false|array  false on failure file meta data on success
+     */
+    public function update($path, $contents, $config = null)
+    {
+        if ( ! $this->source->update($path, $contents, $config)) {
+            return false;
+        }
+
+        return $this->replica->update($path, $contents, $config);
+    }
+
+    /**
+     * Rename a file on the source and replica
+     *
+     * @param   string $path
+     * @param   string $newpath
+     *
+     * @return  boolean
+     */
+    public function rename($path, $newpath)
+    {
+        if ( ! $this->source->rename($path, $newpath)) {
+            return false;
+        }
+
+        return $this->replica->rename($path, $newpath);
+    }
+
+    /**
+     * Delete a file on the source and replica
+     *
+     * @param   string $path
+     *
+     * @return  boolean
+     */
+    public function delete($path)
+    {
+        if ( ! $this->source->delete($path)) {
+            return false;
+        }
+
+        return $this->replica->delete($path);
+    }
+
+    /**
+     * Delete a directory on the source and replica
+     *
+     * @param   string $dirname
+     *
+     * @return  boolean
+     */
+    public function deleteDir($dirname)
+    {
+        if ( ! $this->source->deleteDir($dirname)) {
+            return false;
+        }
+
+        return $this->replica->deleteDir($dirname);
+    }
+
+    /**
+     * Create a directory on the source and replica
+     *
+     * @param   string       $dirname directory name
+     * @param   array|Config $options
+     *
+     * @return  bool
+     */
+    public function createDir($dirname, $options = null)
+    {
+        if ( ! $this->source->createDir($dirname, $options)) {
+            return false;
+        }
+
+        return $this->replica->createDir($dirname, $options);
+    }
+
+    /**
+     * Check whether a file exists in the source
+     *
+     * @param   string $path
+     *
+     * @return  bool
+     */
+    public function has($path)
+    {
+        return $this->source->has($path);
+    }
+
+    /**
+     * Read a file from the source
+     *
+     * @param   string $path
+     *
+     * @return  false|array
+     */
+    public function read($path)
+    {
+        return $this->source->read($path);
+    }
+
+    /**
+     * List contents of a directory from the source
+     *
+     * @param   string $directory
+     * @param   bool   $recursive
+     *
+     * @return  array
+     */
+    public function listContents($directory = '', $recursive = false)
+    {
+        return $this->source->listContents($directory, $recursive);
+    }
+
+    /**
+     * Get all the meta data of a file or directory from the source
+     *
+     * @param   string $path
+     *
+     * @return  false|array
+     */
+    public function getMetadata($path)
+    {
+        return $this->source->getMetadata($path);
+    }
+
+    /**
+     * Get all the size of a file or directory from the source
+     *
+     * @param   string $path
+     *
+     * @return  false|array
+     */
+    public function getSize($path)
+    {
+        return $this->source->getSize($path);
+    }
+
+    /**
+     * Get the mimetype of a file from the source
+     *
+     * @param   string $path
+     *
+     * @return  false|array
+     */
+    public function getMimetype($path)
+    {
+        return $this->source->getMimetype($path);
+    }
+
+    /**
+     * Get the timestamp of a file from the source
+     *
+     * @param   string $path
+     *
+     * @return  false|array
+     */
+    public function getTimestamp($path)
+    {
+        return $this->source->getTimestamp($path);
+    }
+}

--- a/tests/ReplicateAdapterTests.php
+++ b/tests/ReplicateAdapterTests.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace League\Flysystem\Adapter;
+
+use Mockery;
+use Mockery\MockInterface;
+
+class ReplicateAdapterTests extends \PHPUnit_Framework_TestCase
+{
+    public function teardown()
+    {
+        $cleanupAdapter = new Local(__DIR__ . '/files');
+        $cleanupAdapter->deleteDir('replica');
+        $cleanupAdapter->deleteDir('source');
+    }
+
+    public function testWrite()
+    {
+        $filename = 'replicate_test_file.txt';
+        $fileContent = 'content';
+
+        $adapter = $this->getReplicateAdapter();
+
+        $adapter->write($filename, $fileContent);
+
+        $sourceContents = $adapter->getSourceAdapter()->read($filename);
+
+        $this->assertEquals($fileContent, $sourceContents['contents']);
+        $this->assertEquals($filename, $sourceContents['path']);
+        $this->assertEquals($sourceContents, $adapter->getReplicaAdapter()->read($filename));
+    }
+
+    public function testWriteFail()
+    {
+        $filename = 'replicate_test_file.txt';
+        $fileContent = 'content';
+
+        $mockedAdapter = $this->getMockedAdapter();
+        $mockedAdapter->shouldReceive('write')
+            ->with($filename, $fileContent, null)
+            ->once()
+            ->andReturn(false);
+
+        $adapter = $this->getReplicateAdapter($mockedAdapter);
+
+        $result = $adapter->write($filename, $fileContent);
+
+        $this->assertFalse($result);
+    }
+
+    public function testUpdate()
+    {
+        $filename = 'replicate_test_file.txt';
+        $fileContent = 'content';
+        $fileContentNew = 'newcontent';
+
+        $adapter = $this->getReplicateAdapter();
+
+        $adapter->write($filename, $fileContent);
+
+        $sourceContents = $adapter->getSourceAdapter()->read($filename);
+
+        $this->assertEquals($fileContent, $sourceContents['contents']);
+        $this->assertEquals($sourceContents, $adapter->getReplicaAdapter()->read($filename));
+
+        $adapter->update($filename, $fileContentNew);
+
+        $sourceContents = $adapter->getSourceAdapter()->read($filename);
+
+        $this->assertEquals($fileContentNew, $sourceContents['contents']);
+        $this->assertEquals($sourceContents, $adapter->getReplicaAdapter()->read($filename));
+    }
+
+    public function testUpdateFail()
+    {
+        $filename = 'replicate_test_file.txt';
+        $fileContent = 'newcontent';
+
+        $mockedAdapter = $this->getMockedAdapter();
+        $mockedAdapter->shouldReceive('update')
+            ->with($filename, $fileContent, null)
+            ->once()
+            ->andReturn(false);
+
+        $adapter = $this->getReplicateAdapter($mockedAdapter);
+
+        $result = $adapter->update($filename, $fileContent);
+
+        $this->assertFalse($result);
+    }
+
+    public function testRename()
+    {
+        $filename = 'replicate_test_file.txt';
+        $filenameNew = 'new_replicate_test_file.txt';
+        $fileContent = 'content';
+
+        $adapter = $this->getReplicateAdapter();
+
+        $adapter->write($filename, $fileContent);
+
+        $this->assertTrue($adapter->getSourceAdapter()->has($filename));
+        $this->assertTrue($adapter->getReplicaAdapter()->has($filename));
+
+        $adapter->rename($filename, $filenameNew);
+
+        $this->assertTrue($adapter->getSourceAdapter()->has($filenameNew));
+        $this->assertTrue($adapter->getReplicaAdapter()->has($filenameNew));
+
+        $this->assertFalse($adapter->getSourceAdapter()->has($filename));
+        $this->assertFalse($adapter->getReplicaAdapter()->has($filename));
+    }
+
+    public function testRenameFail()
+    {
+        $filename = 'replicate_test_file.txt';
+        $filenameNew = 'new_replicate_test_file.txt';
+
+        $mockedAdapter = $this->getMockedAdapter();
+        $mockedAdapter->shouldReceive('rename')
+            ->with($filename, $filenameNew)
+            ->once()
+            ->andReturn(false);
+
+        $adapter = $this->getReplicateAdapter($mockedAdapter);
+
+        $result = $adapter->rename($filename, $filenameNew);
+
+        $this->assertFalse($result);
+    }
+
+    public function testDelete()
+    {
+        $filename = 'replicate_test_file.txt';
+        $fileContent = 'content';
+
+        $adapter = $this->getReplicateAdapter();
+
+        $adapter->write($filename, $fileContent);
+
+        $this->assertTrue($adapter->getSourceAdapter()->has($filename));
+        $this->assertTrue($adapter->getReplicaAdapter()->has($filename));
+
+        $adapter->delete($filename);
+
+        $this->assertFalse($adapter->getSourceAdapter()->has($filename));
+        $this->assertFalse($adapter->getReplicaAdapter()->has($filename));
+    }
+
+    public function testDeleteFail()
+    {
+        $filename = 'replicate_test_file.txt';
+
+        $mockedAdapter = $this->getMockedAdapter();
+        $mockedAdapter->shouldReceive('delete')
+            ->with($filename)
+            ->once()
+            ->andReturn(false);
+
+        $adapter = $this->getReplicateAdapter($mockedAdapter);
+
+        $result = $adapter->delete($filename);
+
+        $this->assertFalse($result);
+    }
+
+    public function testCreateDir()
+    {
+        $subdir = 'subdir';
+
+        $adapter = $this->getReplicateAdapter();
+
+        $adapter->createDir($subdir);
+
+        $dirFilter = function ($object) use ($subdir) {
+            return $object['type'] === 'dir' && $object['path'] === $subdir;
+        };
+
+        $sourceContents = $adapter->getSourceAdapter()->listContents();
+        $replicaContents = $adapter->getReplicaAdapter()->listContents();
+
+        $this->assertNotEmpty(array_filter($sourceContents, $dirFilter));
+        $this->assertNotEmpty(array_filter($replicaContents, $dirFilter));
+    }
+
+    public function testCreateDirFail()
+    {
+        $subdir = 'subdir';
+
+        $mockedAdapter = $this->getMockedAdapter();
+        $mockedAdapter->shouldReceive('createDir')
+            ->with($subdir, null)
+            ->once()
+            ->andReturn(false);
+
+        $adapter = $this->getReplicateAdapter($mockedAdapter);
+
+        $result = $adapter->createDir($subdir);
+
+        $this->assertFalse($result);
+    }
+
+    public function testDeleteDir()
+    {
+        $subdir = 'subdir';
+
+        $adapter = $this->getReplicateAdapter();
+
+        $adapter->createDir($subdir);
+
+        $adapter->deleteDir($subdir);
+
+        $dirFilter = function ($object) use ($subdir) {
+            return $object['type'] === 'dir' && $object['path'] === $subdir;
+        };
+
+        $sourceContents = $adapter->getSourceAdapter()->listContents();
+        $replicaContents = $adapter->getReplicaAdapter()->listContents();
+
+        $this->assertEmpty(array_filter($sourceContents, $dirFilter));
+        $this->assertEmpty(array_filter($replicaContents, $dirFilter));
+    }
+
+    public function testDeleteDirFail()
+    {
+        $subdir = 'subdir';
+
+        $mockedAdapter = $this->getMockedAdapter();
+        $mockedAdapter->shouldReceive('deleteDir')
+            ->with($subdir)
+            ->once()
+            ->andReturn(false);
+
+        $adapter = $this->getReplicateAdapter($mockedAdapter);
+
+        $result = $adapter->deleteDir($subdir);
+
+        $this->assertFalse($result);
+    }
+
+    public function testHas()
+    {
+        $filename = 'replicate_test_file.txt';
+
+        $mockedSourceAdapter = $this->getMockedAdapter();
+        $mockedSourceAdapter->shouldReceive('has')
+            ->with($filename)
+            ->once();
+
+        $mockedReplicaAdapter = $this->getMockedAdapter();
+        $mockedReplicaAdapter->shouldReceive('has')
+            ->never();
+
+        $adapter = $this->getReplicateAdapter($mockedSourceAdapter, $mockedReplicaAdapter);
+
+        $adapter->has($filename);
+    }
+
+    public function testRead()
+    {
+        $filename = 'replicate_test_file.txt';
+
+        $mockedSourceAdapter = $this->getMockedAdapter();
+        $mockedSourceAdapter->shouldReceive('read')
+            ->with($filename)
+            ->once();
+
+        $mockedReplicaAdapter = $this->getMockedAdapter();
+        $mockedReplicaAdapter->shouldReceive('read')
+            ->never();
+
+        $adapter = $this->getReplicateAdapter($mockedSourceAdapter, $mockedReplicaAdapter);
+
+        $adapter->read($filename);
+    }
+
+    public function testListContents()
+    {
+        $directory = '';
+        $recursive = false;
+
+        $mockedSourceAdapter = $this->getMockedAdapter();
+        $mockedSourceAdapter->shouldReceive('listContents')
+            ->with($directory, $recursive)
+            ->once();
+
+        $mockedReplicaAdapter = $this->getMockedAdapter();
+        $mockedReplicaAdapter->shouldReceive('read')
+            ->never();
+
+        $adapter = $this->getReplicateAdapter($mockedSourceAdapter, $mockedReplicaAdapter);
+
+        $adapter->listContents($directory, $recursive);
+    }
+
+    public function testGetMetadata()
+    {
+        $filename = 'replicate_test_file.txt';
+
+        $mockedSourceAdapter = $this->getMockedAdapter();
+        $mockedSourceAdapter->shouldReceive('getMetadata')
+            ->with($filename)
+            ->once();
+
+        $mockedReplicaAdapter = $this->getMockedAdapter();
+        $mockedReplicaAdapter->shouldReceive('getMetadata')
+            ->never();
+
+        $adapter = $this->getReplicateAdapter($mockedSourceAdapter, $mockedReplicaAdapter);
+
+        $adapter->getMetadata($filename);
+    }
+
+    public function testGetSize()
+    {
+        $filename = 'replicate_test_file.txt';
+
+        $mockedSourceAdapter = $this->getMockedAdapter();
+        $mockedSourceAdapter->shouldReceive('getSize')
+            ->with($filename)
+            ->once();
+
+        $mockedReplicaAdapter = $this->getMockedAdapter();
+        $mockedReplicaAdapter->shouldReceive('getSize')
+            ->never();
+
+        $adapter = $this->getReplicateAdapter($mockedSourceAdapter, $mockedReplicaAdapter);
+
+        $adapter->getSize($filename);
+    }
+
+    public function testGetMimetype()
+    {
+        $filename = 'replicate_test_file.txt';
+
+        $mockedSourceAdapter = $this->getMockedAdapter();
+        $mockedSourceAdapter->shouldReceive('getMimetype')
+            ->with($filename)
+            ->once();
+
+        $mockedReplicaAdapter = $this->getMockedAdapter();
+        $mockedReplicaAdapter->shouldReceive('getMimetype')
+            ->never();
+
+        $adapter = $this->getReplicateAdapter($mockedSourceAdapter, $mockedReplicaAdapter);
+
+        $adapter->getMimetype($filename);
+    }
+
+    public function testGetTimestamp()
+    {
+        $filename = 'replicate_test_file.txt';
+
+        $mockedSourceAdapter = $this->getMockedAdapter();
+        $mockedSourceAdapter->shouldReceive('getTimestamp')
+            ->with($filename)
+            ->once();
+
+        $mockedReplicaAdapter = $this->getMockedAdapter();
+        $mockedReplicaAdapter->shouldReceive('getTimestamp')
+            ->never();
+
+        $adapter = $this->getReplicateAdapter($mockedSourceAdapter, $mockedReplicaAdapter);
+
+        $adapter->getTimestamp($filename);
+    }
+    
+    /**
+     * @param mixed $source
+     * @param mixed $replica
+     *
+     * @return ReplicateAdapter
+     */
+    protected function getReplicateAdapter($source = null, $replica = null)
+    {
+        if (!$source) {
+            $source = new Local(__DIR__ . '/files/source');
+        }
+
+        if (!$replica) {
+            $replica = new Local(__DIR__ . '/files/replica');
+        }
+
+        return new ReplicateAdapter($source, $replica);
+    }
+
+    /**
+     * @return MockInterface
+     */
+    protected function getMockedAdapter()
+    {
+        return Mockery::mock(
+            '\League\Flysystem\Adapter\Local[write,update,rename,delete,deleteDir,createDir,has,read,listContents,getMetadata,getSize,getMimetype,getTimestamp]',
+            array(
+                __DIR__ . '/files'
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a BackupAdapter which simply mirrors create, update, and delete operations from a source adapter to a backup adapter.  This adapter can serve as a migration tool when a user wants to move from one source to another, local files to S3 for example.
