### PR TITLE
Normalizes multiple directory separators in normalizePath

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -72,12 +72,11 @@ class Util
      * Normalize path
      *
      * @param string $path
-     * @param string $separator
      *
      * @return string
      * @throws LogicException
      */
-    public static function normalizePath($path, $separator = DIRECTORY_SEPARATOR)
+    public static function normalizePath($path)
     {
         // Remove any kind of funky unicode whitespace
         $normalized = preg_replace('#\p{C}+|^\./#u', '', $path);
@@ -99,9 +98,10 @@ class Util
         /**
          * Replace multiple separators with a single separator
          */
-        $normalized = preg_replace('#' . $separator . '{2,}#', $separator, $normalized);
+        $normalized = preg_replace('#\\\{2,}#', '\\', trim($normalized, '\\'));
+        $normalized = preg_replace('#/{2,}#', '/', trim($normalized, '/'));
 
-        return trim($normalized, $separator);
+        return $normalized;
     }
 
     /**

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -83,6 +83,10 @@ class UtilTests extends \PHPUnit_Framework_TestCase
             array('dirname/..', ''),
             array('./dir/../././', ''),
             array('/dirname//subdir///subsubdir', 'dirname/subdir/subsubdir'),
+            array('\dirname\\\\subdir\\\\\\subsubdir', 'dirname\subdir\subsubdir'),
+            array('\\\\some\shared\\\\drive', 'some\shared\drive'),
+            array('C:\dirname\\\\subdir\\\\\\subsubdir', 'C:\dirname\subdir\subsubdir'),
+            array('C:\\\\dirname\subdir\\\\subsubdir', 'C:\dirname\subdir\subsubdir'),
         );
     }
 


### PR DESCRIPTION
This accounts for the scenario where a path may contain two or more consecutive directory separators in a path.
