### PR TITLE
Fix abstract adapter copy method.

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -177,14 +177,17 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function copy($path, $newpath)
     {
-        $stream = $this->readStream($path);
+        $stream = $this->readStream($path)['stream'];
 
         if ( ! is_resource($stream)) {
             return false;
         }
 
         $result = $this->writeStream($newpath, $stream);
-        fclose($stream);
+
+        if (is_resource($stream)) {
+            fclose($stream);
+        }
 
         if ( ! $result) {
             return false;

--- a/tests/FilesystemTests.php
+++ b/tests/FilesystemTests.php
@@ -27,7 +27,7 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
     public function testAbstractAdapterCopy()
     {
         $mock = Mockery::mock('League\Flysystem\Adapter\AbstractAdapter[readStream,writeStream]');
-        $mock->shouldReceive('readStream')->andReturn(false, tmpfile(), tmpfile());
+        $mock->shouldReceive('readStream')->andReturn(false, ['stream' => tmpfile()], ['stream' => tmpfile()]);
         $mock->shouldReceive('writeStream')->andReturn(false, true);
         $this->assertFalse($mock->copy('something', 'other'));
         $this->assertFalse($mock->copy('something', 'other'));


### PR DESCRIPTION
The abstract adapter `copy` method wasn't expecting the correct output from `readStream`. It was attempting to use the array returned by `readStream` as a resource directly. Instead, I changed it to use the `stream` key from the result array.

Also need to check that the stream is still a resource before closing. Copying Rackspace files will fail if you don't do this because the stream is longer a resource once the copy takes place. Anyways, a good sanity check.

Fixed abstract adapter copy test to return the array output from mocked `readStream` method.
