### PR TITLE
Fixed path normalization in Adapter\Dropbox::normalizeObject()

### DIFF
--- a/src/Adapter/Dropbox.php
+++ b/src/Adapter/Dropbox.php
@@ -280,7 +280,7 @@ class Dropbox extends AbstractAdapter
 
     protected function normalizeObject($object, $path = null)
     {
-        $result = array('path' => $path ?: trim($object['path'], '/'));
+        $result = array('path' => trim($path ?: $object['path'], '/'));
 
         if (isset($object['modified'])) {
             $result['timestamp'] = strtotime($object['modified']);


### PR DESCRIPTION
I use Dropbox adapter with directory prefix set. There was an issue with directory contents listing due to paths being prepended with `/` for content entries returned by adapter. All files were omitted in [this line](https://github.com/thephpleague/flysystem/blob/master/src/Cache/AbstractCache.php#L83) because `$object['dirname']` and `$directory` paths were different (`$object['dirname']` contained `/` on the beginning). This small fix resolved this issue.
