### PR TITLE
Add getBucket method to S3 adapter

### DIFF
--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -89,6 +89,16 @@ class AwsS3 extends AbstractAdapter
     }
 
     /**
+     * Get the S3Client bucket
+     *
+     * @return  string
+     */
+    public function getBucket()
+    {
+        return $this->bucket;
+    }
+
+    /**
      * Get the S3Client instance
      *
      * @return  S3Client

--- a/tests/AwsS3Tests.php
+++ b/tests/AwsS3Tests.php
@@ -47,6 +47,13 @@ class AwsS3Tests extends PHPUnit_Framework_TestCase
         $this->assertTrue($adapter->has('something'));
     }
 
+    public function testGetBucket()
+    {
+        $mock = $this->getS3Client();
+        $adapter = new Adapter($mock, 'bucket');
+        $this->assertEquals('bucket', $adapter->getBucket());
+    }
+
     public function testGetClient()
     {
         $mock = $this->getS3Client();


### PR DESCRIPTION
Sometimes you want to get the bucket name from your S3 adapter. For example in this situation (see @jeremeamia's reply): http://stackoverflow.com/questions/25323753/laravel-league-flysystem-getting-file-url-with-aws-s3

It would be even cooler if the adapter supported the getObjectUrl call easier. Can I send in a PR for that?
