### PR TITLE
Add ext-fileinfo to composer required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "ext-fileinfo": "*"
     },
     "require-dev": {
         "league/event": "~1.0",


### PR DESCRIPTION
Without this extension I get a `Fatal error: Class 'Finfo'`. Adding a check to composer seems the simplest way of preventing this pain.
