### PR TITLE
Overridden read() method in FilesystemInterface

### DIFF
--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -45,6 +45,17 @@ interface FilesystemInterface extends AdapterInterface
     public function read($path);
 
     /**
+     * Write a file
+     *
+     * @param  string              $path     path to file
+     * @param  string              $contents file contents
+     * @param  mixed               $config
+     * @throws FileExistsException
+     * @return boolean             success boolean
+     */
+    public function write($path, $contents, $config = null);
+
+    /**
      * List all files in the directory
      *
      * @param string      $directory


### PR DESCRIPTION
 since the return type in the Filesystem is different from the one returned by all Adapters. See #287
