### PR TITLE
Add League\Flysystem\Tests for test namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "League\\Flysystem\\Stub\\": "stub/"
+            "League\\Flysystem\\Stub\\": "stub/",
+            "League\\Flysystem\\Tests\\": "tests/"
         }
     },
     "suggest": {

--- a/tests/AbstractCacheTest.php
+++ b/tests/AbstractCacheTest.php
@@ -1,8 +1,10 @@
 <?php
 
-use League\Flysystem;
+namespace League\Flysystem\Tests;
 
+use League\Flysystem;
 use League\Flysystem\Cache\Memory;
+use PHPUnit_Framework_TestCase;
 
 class AbstractCacheTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/AdapterCacheTests.php
+++ b/tests/AdapterCacheTests.php
@@ -1,6 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Cache\Adapter;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class AdapterCacheTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/AwsS3Tests.php
+++ b/tests/AwsS3Tests.php
@@ -1,8 +1,12 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Adapter\AwsS3 as Adapter;
 use Aws\S3\Enum\Group;
 use Aws\S3\Enum\Permission;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class StreamMock
 {

--- a/tests/ConfigTests.php
+++ b/tests/ConfigTests.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Config;
+use PHPUnit_Framework_TestCase;
 
 class ConfigTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/CopyTests.php
+++ b/tests/CopyTests.php
@@ -1,6 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Adapter\Copy;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class CopyFile {}
 class CopyRevision {}

--- a/tests/DropboxTests.php
+++ b/tests/DropboxTests.php
@@ -1,6 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Adapter\Dropbox;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class DropboxTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/EventableFilesystemTests.php
+++ b/tests/EventableFilesystemTests.php
@@ -1,7 +1,13 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
+use League\Flysystem\Event\After;
+use League\Flysystem\Event\Before;
 use League\Flysystem\EventableFilesystem;
 use League\Flysystem\Config;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class EventableFilesystemTests extends PHPUnit_Framework_TestCase
 {
@@ -155,7 +161,7 @@ class EventableFilesystemTests extends PHPUnit_Framework_TestCase
 
     public function testBeforeEvent()
     {
-        $before = new League\Flysystem\Event\Before($filesystem = $this->getMockeryMock('filesystem'), 'methodName', $arguments = ['argu' => 'ment']);
+        $before = new Before($filesystem = $this->getMockeryMock('filesystem'), 'methodName', $arguments = ['argu' => 'ment']);
         $this->assertSame($filesystem, $before->getFilesystem());
         $this->assertEquals('methodName', $before->getMethod());
         $this->assertEquals($arguments, $before->getArguments());
@@ -165,7 +171,7 @@ class EventableFilesystemTests extends PHPUnit_Framework_TestCase
 
     public function testAfterEvent()
     {
-        $before = new League\Flysystem\Event\After($filesystem = $this->getMockeryMock('filesystem'), 'methodName', $arguments = ['argu' => 'ment']);
+        $before = new After($filesystem = $this->getMockeryMock('filesystem'), 'methodName', $arguments = ['argu' => 'ment']);
         $this->assertSame($filesystem, $before->getFilesystem());
     }
 

--- a/tests/FileTests.php
+++ b/tests/FileTests.php
@@ -1,15 +1,19 @@
 <?php
 
-namespace League\Flysystem;
+namespace League\Flysystem\Tests;
 
-class FileTests extends \PHPUnit_Framework_TestCase
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use PHPUnit_Framework_TestCase;
+
+class FileTests extends PHPUnit_Framework_TestCase
 {
     protected $filesystem;
 
     public function setup()
     {
         clearstatcache();
-        $fs = new Adapter\Local(__DIR__.'/');
+        $fs = new Local(__DIR__.'/');
         $fs->deleteDir('files');
         $fs->createDir('files');
         $fs->write('file.txt', 'contents');

--- a/tests/FilesystemTests.php
+++ b/tests/FilesystemTests.php
@@ -1,15 +1,21 @@
 <?php
 
-namespace League\Flysystem;
+namespace League\Flysystem\Tests;
 
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Cache\Memory;
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Cache\Noop;
 use Mockery;
+use PHPUnit_Framework_TestCase;
 
-class FilesystemTests extends \PHPUnit_Framework_TestCase
+class FilesystemTests extends PHPUnit_Framework_TestCase
 {
     public function setup()
     {
         clearstatcache();
-        $fs = new Adapter\Local(__DIR__.'/');
+        $fs = new Local(__DIR__.'/');
         $fs->deleteDir('files');
         $fs->createDir('files');
     }
@@ -21,7 +27,7 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
 
     public function testInstantiable()
     {
-        $instance = new Filesystem($adapter = new Adapter\Local(__DIR__.'/files/deeper'), $cache = new Cache\Memory);
+        $instance = new Filesystem($adapter = new Local(__DIR__.'/files/deeper'), $cache = new Memory);
     }
 
     public function testAbstractAdapterCopy()
@@ -36,8 +42,8 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
 
     public function filesystemProvider()
     {
-        $adapter = new Adapter\Local(__DIR__.'/files');
-        $cache = new Cache\Memory;
+        $adapter = new Local(__DIR__.'/files');
+        $cache = new Memory;
         $filesystem = new Filesystem($adapter, $cache);
 
         return array(
@@ -192,7 +198,7 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
      */
     public function testFileExists()
     {
-        $filesystem = new Filesystem(new Adapter\Local(__DIR__));
+        $filesystem = new Filesystem(new Local(__DIR__));
         $filesystem->write('FilesystemTests.php', 'something');
     }
 
@@ -243,8 +249,8 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
 
     public function metaProvider()
     {
-        $adapter = new Adapter\Local(__DIR__.'/files');
-        $cache = new Cache\Memory;
+        $adapter = new Local(__DIR__.'/files');
+        $cache = new Memory;
         $filesystem = new Filesystem($adapter, $cache);
 
         return array(
@@ -337,13 +343,13 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
 
     public function testRenameFailure()
     {
-        $cache = new Cache\Memory(__DIR__);
+        $cache = new Memory(__DIR__);
         $this->assertFalse($cache->rename('something', 'to.this'));
     }
 
     public function testCacheStorage()
     {
-        $cache = new Cache\Memory(__DIR__);
+        $cache = new Memory(__DIR__);
         $input = array(array('contents' => 'hehe', 'filename' => 'with contents'), array('filename' => 'no contents'));
         $expected = array(array('filename' => 'with contents'), array('filename' => 'no contents'));
         $json = json_encode(array(array(),array()));
@@ -357,7 +363,7 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
 
     public function testAutosave()
     {
-        $cache = new Cache\Memory(__DIR__);
+        $cache = new Memory(__DIR__);
         $this->assertTrue($cache->getAutosave());
         $cache->setAutosave(false);
         $this->assertFalse($cache->getAutosave());
@@ -386,8 +392,8 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
      */
     public function testAdapterFail($method, $hasfile)
     {
-        $mock = \Mockery::mock('League\Flysystem\Adapter\AbstractAdapter');
-        $cachemock = \Mockery::mock('League\Flysystem\Cache\AbstractCache');
+        $mock = Mockery::mock('League\Flysystem\Adapter\AbstractAdapter');
+        $cachemock = Mockery::mock('League\Flysystem\Cache\AbstractCache');
         $cachemock->shouldReceive('load')->andReturn(array());
         $cachemock->shouldReceive('has')->andReturn(null);
         $cachemock->shouldReceive('isComplete')->andReturn(false);
@@ -405,8 +411,8 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
 
     public function testFailingPut()
     {
-        $mock = \Mockery::mock('League\Flysystem\Adapter\AbstractAdapter');
-        $cachemock = \Mockery::mock('League\Flysystem\Cache\AbstractCache');
+        $mock = Mockery::mock('League\Flysystem\Adapter\AbstractAdapter');
+        $cachemock = Mockery::mock('League\Flysystem\Cache\AbstractCache');
         $cachemock->shouldReceive('load')->andReturn(array());
         $cachemock->shouldReceive('has')->andReturn(false);
         $cachemock->shouldReceive('isComplete')->andReturn(false);
@@ -437,7 +443,7 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
 
     public function testNoop()
     {
-        $filesystem = new Filesystem(new Adapter\Local(__DIR__.'/files'), new Cache\Noop);
+        $filesystem = new Filesystem(new Local(__DIR__.'/files'), new Noop);
         $filesystem->write('test.txt', 'contents');
         $this->assertTrue($filesystem->has('test.txt'));
         $this->assertInternalType('array', $filesystem->listContents());

--- a/tests/FlysystemStreamTests.php
+++ b/tests/FlysystemStreamTests.php
@@ -1,6 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Filesystem;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class FlysystemStreamTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace League\Flysystem\Adapter;
+namespace League\Flysystem\Tests;
+
+use League\Flysystem\Adapter\Ftp;
+use PHPUnit_Framework_TestCase;
 
 function ftp_ssl_connect($host)
 {
@@ -166,7 +169,7 @@ function ftp_chmod($connection, $mode, $path)
     return true;
 }
 
-class FtpTests extends \PHPUnit_Framework_TestCase
+class FtpTests extends PHPUnit_Framework_TestCase
 {
     protected $options = array(
         'host' => 'example.org',

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace League\Flysystem\Adapter;
+namespace League\Flysystem\Tests;
+
+use League\Flysystem\Adapter\Local;
+use PHPUnit_Framework_TestCase;
 
 function fopen($result)
 {
@@ -33,7 +36,7 @@ function fclose($result)
     return call_user_func_array('fclose', func_get_args());
 }
 
-class LocalAdapterTests extends \PHPUnit_Framework_TestCase
+class LocalAdapterTests extends PHPUnit_Framework_TestCase
 {
     protected $adapter;
     protected $root;

--- a/tests/MemcachedTests.php
+++ b/tests/MemcachedTests.php
@@ -1,6 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Cache\Memcached;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class MemcachedTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/MountManagerTests.php
+++ b/tests/MountManagerTests.php
@@ -1,6 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\MountManager;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class MountManagerTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullAdapterTests.php
+++ b/tests/NullAdapterTests.php
@@ -1,7 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Adapter\NullAdapter;
 use League\Flysystem\Filesystem;
+use PHPUnit_Framework_TestCase;
 
 class NullAdapterTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PluginTests.php
+++ b/tests/PluginTests.php
@@ -1,8 +1,12 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\PluginInterface;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemInterface;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class MyPlugin implements PluginInterface
 {

--- a/tests/PredisTests.php
+++ b/tests/PredisTests.php
@@ -1,6 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Cache\Predis;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class PredisTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/RackspaceTests.php
+++ b/tests/RackspaceTests.php
@@ -1,9 +1,13 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
+use ArrayIterator;
 use Guzzle\Http\Exception\ClientErrorResponseException;
 use League\Flysystem\Adapter\Rackspace;
 use League\Flysystem\Config;
-use Mockery\Mock;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class RackspaceTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/ReplicateAdapterTests.php
+++ b/tests/ReplicateAdapterTests.php
@@ -1,10 +1,12 @@
 <?php
 
-namespace League\Flysystem\Adapter;
+namespace League\Flysystem\Tests;
 
+use League\Flysystem\Adapter\ReplicateAdapter;
 use Mockery;
+use PHPUnit_Framework_TestCase;
 
-class ReplicateAdapterTests extends \PHPUnit_Framework_TestCase
+class ReplicateAdapterTests extends PHPUnit_Framework_TestCase
 {
     protected $adapter;
     protected $source;

--- a/tests/SftpTests.php
+++ b/tests/SftpTests.php
@@ -1,7 +1,11 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Adapter\Sftp;
 use League\Flysystem\Filesystem;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class SftpTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/StashTest.php
+++ b/tests/StashTest.php
@@ -1,6 +1,10 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Cache\Stash;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class StashTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/UtilMimeTests.php
+++ b/tests/UtilMimeTests.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace League\Flysystem\Util;
+namespace League\Flysystem\Tests;
+
+use League\Flysystem\Util\MimeType;
+use PHPUnit_Framework_TestCase;
 
 $passthru = true;
 
@@ -14,7 +17,7 @@ function class_exists($class_name, $autoload = true) {
     return false;
 }
 
-class MimeTests extends \PHPUnit_Framework_TestCase
+class MimeTests extends PHPUnit_Framework_TestCase
 {
     public function testNoFinfoFallback()
     {

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -1,8 +1,12 @@
 <?php
 
-namespace League\Flysystem;
+namespace League\Flysystem\Tests;
 
-class UtilTests extends \PHPUnit_Framework_TestCase
+use League\Flysystem\Config;
+use League\Flysystem\Util;
+use PHPUnit_Framework_TestCase;
+
+class UtilTests extends PHPUnit_Framework_TestCase
 {
     public function testEmulateDirectories()
     {

--- a/tests/WebDavTests.php
+++ b/tests/WebDavTests.php
@@ -1,7 +1,11 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Adapter\WebDav as Adapter;
 use League\Flysystem\Filesystem;
+use Mockery;
+use PHPUnit_Framework_TestCase;
 
 class WebDavTests extends PHPUnit_Framework_TestCase
 {

--- a/tests/ZipTests.php
+++ b/tests/ZipTests.php
@@ -1,20 +1,25 @@
 <?php
 
+namespace League\Flysystem\Tests;
+
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Adapter\Zip;
+use Mockery;
+use PHPUnit_Framework_TestCase;
+use ZipArchive;
 
 class ZipTests extends PHPUnit_Framework_TestCase
 {
     public function zipProvider()
     {
         return array(
-            array(new League\Flysystem\Adapter\Zip(__DIR__.'/files/tester.zip', new ZipArchive))
+            array(new Zip(__DIR__.'/files/tester.zip', new ZipArchive))
         );
     }
 
     public function testInstance()
     {
-        $adapter = new League\Flysystem\Adapter\Zip(__DIR__.'/files/tester.zip', new ZipArchive);
+        $adapter = new Zip(__DIR__.'/files/tester.zip', new ZipArchive);
         $this->assertInstanceOf('League\Flysystem\AdapterInterface', $adapter);
     }
 


### PR DESCRIPTION
Use `League\Flysystem\Tests` for `tests/`.
