### PR TITLE
Allow FTP deleteDir function to be recursive on multiple levels

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -227,14 +227,14 @@ class Ftp extends AbstractFtpAdapter
     public function deleteDir($dirname)
     {
         $connection = $this->getConnection();
-        $contents = array_reverse($this->listDirectoryContents($dirname));
+        $contents = $this->listDirectoryContents($dirname, false);
 
         foreach ($contents as $object) {
             if ($object['type'] === 'file') {
                 if (! ftp_delete($connection, $object['path'])) {
                     return false;
                 }
-            } elseif (! ftp_rmdir($connection, $object['path'])) {
+            } elseif (! $this->deleteDir($object['path'])) {
                 return false;
             }
         }


### PR DESCRIPTION
Hi

Currently the implementation of deleteDir assumes that the ftp_rawlist returns with an array with all files at the end. However, that seems not to be the case for all FTP servers. I have tested both on a synology FTP and pureftp server. 

I have changed the function to be recursive instead of relaying on the server to return the array correctly. 

Also the ftp_rmdir throws an exception when the file it tries to delete does not exist. I have changed the code to return false instead, to be aligned with the other specification.

PS: I am sorry if I mess something up, this is my very first pull request. 