### PR TITLE
close #317 added shared plugins behaviour in the mount manager

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -48,6 +48,17 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
+     * @param PluginInterface $plugin
+     * @return bool
+     */
+    public function hasPlugin(PluginInterface $plugin)
+    {
+        return array_filter($this->plugins, function (PluginInterface $innerPlugin) use ($plugin) {
+            return is_a($innerPlugin, get_class($plugin));
+        }) > 0;
+    }
+
+    /**
      * Get the Adapter
      *
      * @return  AdapterInterface  adapter

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -222,4 +222,12 @@ interface FilesystemInterface
      * @return  $this
      */
     public function addPlugin(PluginInterface $plugin);
+
+    /**
+     * Checks for a registered plugin
+     *
+     * @param PluginInterface $plugin
+     * @return mixed
+     */
+    public function hasPlugin(PluginInterface $plugin);
 }

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -55,6 +55,11 @@ class MountManager
     protected $filesystems = array();
 
     /**
+     * @var array|PluginInterface[]
+     */
+    protected $sharedPlugins = array();
+
+    /**
      * Constructor
      *
      * @param   array  $filesystems
@@ -62,6 +67,26 @@ class MountManager
     public function __construct(array $filesystems = array())
     {
         $this->mountFilesystems($filesystems);
+    }
+
+    /**
+     * @param FilesystemInterface $filesystem
+     */
+    protected function setPluginsToFilesystem(FilesystemInterface $filesystem)
+    {
+        foreach ($this->sharedPlugins as $plugin) {
+            if (!$filesystem->hasPlugin($plugin)) {
+                $filesystem->addPlugin(clone $plugin);
+            }
+        }
+    }
+
+    /**
+     * @param PluginInterface $plugin
+     */
+    public function addSharedPlugin(PluginInterface $plugin)
+    {
+        $this->sharedPlugins[] = $plugin;
     }
 
     /**
@@ -110,7 +135,9 @@ class MountManager
             throw new LogicException('No filesystem mounted with prefix ' . $prefix);
         }
 
-        return $this->filesystems[$prefix];
+        $filesystem = $this->filesystems[$prefix];
+        $this->setPluginsToFilesystem($filesystem);
+        return $filesystem;
     }
 
     /**


### PR DESCRIPTION
added a shared variable for the plugins to be installed in the filesystems if this plugin is not found in that filesystem, this way the plugin can be instantiated in all the filesystems without need to be installed one by one.
