### PR TITLE
Check if size is set

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -535,7 +535,7 @@ class Filesystem implements FilesystemInterface
             return $cached;
         }
 
-        if (($object = $this->adapter->getSize($path)) === false) {
+        if (($object = $this->adapter->getSize($path)) === false || !isset($object['size'])) {
             return false;
         }
 


### PR DESCRIPTION
Fixes 'Undefined index: size' when size is not set (on a directory for example)
I'm not sure if this is intended behavior, but I listed all paths and ran getSize(), but gave an error on a directory. The object was returned, but not with the size..
