### PR TITLE
New glob plugin for file finding by glob pattern

### DIFF
--- a/src/Plugin/Glob.php
+++ b/src/Plugin/Glob.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace League\Flysystem\Plugin;
+
+/**
+ * Class Glob
+ * @package League\Flysystem\Plugin
+ */
+class Glob extends AbstractPlugin
+{
+    /**
+     * Get the method name
+     *
+     * @return  string
+     */
+    public function getMethod()
+    {
+        return 'glob';
+    }
+
+    /**
+     * @param $path
+     */
+    protected function yieldGlob($path)
+    {
+        foreach ($this->filesystem->listContents('', true) as $file) {
+            if (fnmatch($path, $file['path'])) {
+                yield $file;
+            }
+        }
+    }
+
+    /**
+     * @param $path
+     * @return array
+     */
+    protected function returnGlob($path)
+    {
+        $out = array();
+        foreach ($this->filesystem->listContents('', true) as $file) {
+            if (fnmatch($path, $file['path'])) {
+                $out[] = $file;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param string $path
+     * @param bool $useGenerator
+     * @return array|void
+     */
+    public function handle($path = '', $useGenerator = false)
+    {
+        if (!$useGenerator) {
+            return $this->returnGlob($path);
+        }
+
+        return $this->yieldGlob($path);
+    }
+}

--- a/tests/plugins/GlobTest.php
+++ b/tests/plugins/GlobTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Class GlobTest
+ */
+class GlobTest extends PHPUnit_Framework_TestCase
+{
+    protected $validSamples = array(
+        array(
+            'dirname' => '',
+            'basename' => 'some-file.txt',
+            'extension' => 'txt',
+            'filename' => 'some-file',
+            'path' => 'some-file.txt',
+        ),
+        array(
+            'dirname' => 'some-folder',
+            'basename' => 'some-file.txt',
+            'extension' => 'txt',
+            'filename' => 'some-file',
+            'path' => 'some-folder/some-file.txt',
+        ),
+    );
+
+    protected function getFsWithGlobPlugin()
+    {
+        $glob = new \League\Flysystem\Plugin\Glob();
+
+        $adapter = \Mockery::mock('\League\Flysystem\AdapterInterface')->makePartial();
+        //$adapter = new \League\Flysystem\Adapter\Local('/home/marc/Desktop');
+        /** @var \League\Flysystem\Filesystem $fs */
+        $fs = new \League\Flysystem\Filesystem($adapter);
+        $fs->addPlugin($glob);
+
+        $adapter->shouldReceive('listContents')
+            ->once()
+            ->with('', true)
+            ->andReturn($this->validSamples);
+
+        return $fs;
+    }
+
+    public function testArrayGlob()
+    {
+        $fs = $this->getFsWithGlobPlugin();
+
+        $result = $fs->glob('*.txt');
+
+        $this->assertTrue(is_array($result));
+
+        foreach ($result as $file) {
+            $this->assertContains($file, $this->validSamples);
+        }
+    }
+
+    /**
+     * @requires PHP 5.5
+     */
+    public function testYieldOnGlob()
+    {
+        $fs = $this->getFsWithGlobPlugin();
+
+        $result = $fs->glob('*.txt', true);
+        $this->assertTrue($result instanceof Generator);
+
+        foreach ($result as $file) {
+            $this->assertContains($file, $this->validSamples);
+        }
+    }
+}


### PR DESCRIPTION
Hi, the plugins works fine, but there are serious memory performance related issues because the files are traversed twice, i added a generator way to test if i can improve the performance a little bit but seems to be that the yield behaviour would need to be on a lower abstraction layer to achieve some serious improvements. BTW it works if the volume traversed has not much files, or the plugin is modified to work only in a single folder with not that many files. If i find some spare time between company tickets i might be able to help optimizing the list contents to yield the results if the php version supports it.