### PR TITLE
Added support for glob patterns on the filesystems that support it

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -217,8 +217,10 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    public function listContents($directory = '', $recursive = false)
+    public function listContents($directory = '', $mode = 0)
     {
+        $recursive = $mode & self::MODE_RECURSIVE;
+
         return $this->listDirectoryContents($directory, $recursive);
     }
 

--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -397,7 +397,7 @@ class AwsS3 extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    public function listContents($dirname = '', $recursive = false)
+    public function listContents($dirname = '', $mode = 0)
     {
         $objectsIterator = $this->client->getIterator('listObjects', [
             'Bucket' => $this->bucket,

--- a/src/Adapter/Copy.php
+++ b/src/Adapter/Copy.php
@@ -225,7 +225,7 @@ class Copy extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    public function listContents($dirname = '', $recursive = false)
+    public function listContents($dirname = '', $mode = 0)
     {
         $listing = [];
         $location = $this->applyPathPrefix($dirname);
@@ -237,8 +237,8 @@ class Copy extends AbstractAdapter
         foreach ($result as $object) {
             $listing[] = $this->normalizeObject($object, $object->path);
 
-            if ($recursive && $object->type == 'dir') {
-                $listing = array_merge($listing, $this->listContents($object->path, $recursive));
+            if ($mode & self::MODE_RECURSIVE && $object->type == 'dir') {
+                $listing = array_merge($listing, $this->listContents($object->path, $mode));
             }
         }
 

--- a/src/Adapter/Dropbox.php
+++ b/src/Adapter/Dropbox.php
@@ -230,7 +230,7 @@ class Dropbox extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    public function listContents($directory = '', $recursive = false)
+    public function listContents($directory = '', $mode = 0)
     {
         $listing = [];
         $directory = trim($directory, '/.');
@@ -244,8 +244,8 @@ class Dropbox extends AbstractAdapter
             $path = $this->removePathPrefix($object['path']);
             $listing[] = $this->normalizeResponse($object, $path);
 
-            if ($recursive && $object['is_dir']) {
-                $listing = array_merge($listing, $this->listContents($path, true));
+            if ($mode & self::MODE_RECURSIVE && $object['is_dir']) {
+                $listing = array_merge($listing, $this->listContents($path, $mode));
             }
         }
 

--- a/src/Adapter/NullAdapter.php
+++ b/src/Adapter/NullAdapter.php
@@ -74,7 +74,7 @@ class NullAdapter extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    public function listContents($directory = '', $recursive = false)
+    public function listContents($directory = '', $mode = 0)
     {
         return [];
     }

--- a/src/Adapter/Rackspace.php
+++ b/src/Adapter/Rackspace.php
@@ -218,7 +218,7 @@ class Rackspace extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    public function listContents($directory = '', $recursive = false)
+    public function listContents($directory = '', $mode = 0)
     {
         $location = $this->applyPathPrefix($directory);
         $response = $this->container->objectList(['prefix' => $location]);

--- a/src/Adapter/ReplicateAdapter.php
+++ b/src/Adapter/ReplicateAdapter.php
@@ -196,9 +196,9 @@ class ReplicateAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function listContents($directory = '', $recursive = false)
+    public function listContents($directory = '', $mode = 0)
     {
-        return $this->source->listContents($directory, $recursive);
+        return $this->source->listContents($directory, $mode);
     }
 
     /**

--- a/src/Adapter/Zip.php
+++ b/src/Adapter/Zip.php
@@ -220,7 +220,7 @@ class Zip extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
-    public function listContents($dirname = '', $recursive = false)
+    public function listContents($dirname = '', $mode = 0)
     {
         $result = [];
 

--- a/src/ReadInterface.php
+++ b/src/ReadInterface.php
@@ -5,6 +5,16 @@ namespace League\Flysystem;
 interface ReadInterface
 {
     /**
+     * @const MODE_RECURSIVE enable recursive mode
+     */
+    const MODE_RECURSIVE = 1;
+
+    /**
+     * @const MODE_GLOB_ENABLE allows glob pattern matching
+     */
+    const MODE_GLOB_ENABLED = 2;
+
+    /**
      * Check whether a file exists
      *
      * @param   string  $path
@@ -31,11 +41,11 @@ interface ReadInterface
     /**
      * List contents of a directory
      *
-     * @param   string  $directory
-     * @param   bool    $recursive
+     * @param   string $directory
+     * @param int $mode
      * @return  array
      */
-    public function listContents($directory = '', $recursive = false);
+    public function listContents($directory = '', $mode = 0);
 
     /**
      * Get all the meta data of a file or directory

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -169,4 +169,36 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->assertFalse(is_dir($this->root.DIRECTORY_SEPARATOR.$dirname));
         $this->assertTrue($this->adapter->rename('file.txt', $dirname.'/file.txt'));
     }
+
+    public function testModeGlobEnabled()
+    {
+        $dummyFile = function ($pattern, $howMany = 6) {
+            return array_map(
+                function ($k, $v) {
+                    return sprintf($k, $v);
+                },
+                array_fill(0, $howMany + 1, $pattern),
+                range(0, $howMany)
+            );
+        };
+
+        $testData = array_merge(
+            $dummyFile('bar/f-00%d.txt'),
+            $dummyFile('baz/f-00%d.txt')
+        );
+
+        $cfg = new Config();
+        $this->adapter->createDir('foo', $cfg);
+        $this->adapter->createDir('bar', $cfg);
+        $this->adapter->createDir('baz', $cfg);
+        foreach ($testData as $path) {
+            $this->adapter->write($path, 'content', $cfg);
+        }
+
+        $contents = $this->adapter->listContents('ba*/f-00*.txt', Local::MODE_GLOB_ENABLED | Local::MODE_RECURSIVE);
+
+        foreach ($contents as $file) {
+            $this->assertContains($file['path'], $testData);
+        }
+    }
 }


### PR DESCRIPTION
Just an idea about giving more flexibility to the filesystems if they support different kind of operations by replacing the boolean parameter in the `listContents` by another one that uses bit mask operations, this way you can add glob behaviour to the local filesystem for example, and exceptions can be thrown if the mode is not supported by the filesystem if needed.

Feel free to review or debate about this, i think that could be a nice addition.

Regards