### PR TITLE
Pull request/dont cache empty objects

### DIFF
--- a/src/Cache/AbstractCache.php
+++ b/src/Cache/AbstractCache.php
@@ -70,11 +70,11 @@ abstract class AbstractCache implements CacheInterface
         $directories = [$directory];
 
         foreach ($contents as $index => $object) {
-			if (empty($object['path'])) {
-				continue;
-			}
+            if (empty($object['path'])) {
+               continue;
+            }
 
-			$object = $this->updateObject($object['path'], $object);
+            $object = $this->updateObject($object['path'], $object);
             $contents[$index] = $object;
 
             if (! empty($directory) && strpos($object['path'], $directory) === false) {

--- a/src/Cache/AbstractCache.php
+++ b/src/Cache/AbstractCache.php
@@ -70,7 +70,11 @@ abstract class AbstractCache implements CacheInterface
         $directories = [$directory];
 
         foreach ($contents as $index => $object) {
-            $object = $this->updateObject($object['path'], $object);
+			if (empty($object['path'])) {
+				continue;
+			}
+
+			$object = $this->updateObject($object['path'], $object);
             $contents[$index] = $object;
 
             if (! empty($directory) && strpos($object['path'], $directory) === false) {


### PR DESCRIPTION
Sometimes AWS S3 would return a bogus object with path set to false and no dirname key in the array, which would make AbstractCache::has() choke, because $path was set to false and, subsequently, Util::pathinfo would choke, because the array returned by pathinfo() would not have the "dirname" key set in the response array.