### PR TITLE
Remove S3 objects with no path at all, that appear when using path prefi...

### DIFF
--- a/src/Adapter/AwsS3.php
+++ b/src/Adapter/AwsS3.php
@@ -411,6 +411,10 @@ class AwsS3 extends AbstractAdapter
         $contents = iterator_to_array($objectsIterator);
         $result = array_map([$this, 'normalizeResponse'], $contents);
 
+        $result = array_filter($result, function ($value) {
+            return $value['path'] !== false;
+        });
+
         return Util::emulateDirectories($result);
     }
 


### PR DESCRIPTION
...x and listing objects.

When getting the list of objects for an S3 in a scenario where you want to list the contents of a folder/, S3 returns an object for the containing folder/ as well, resulting in an object with path set to false after AbstractAdapter::removePathPrefix() is called, which trips up the caching logic, not to mention that the containing object should not be there at all in the first place.