### PR TITLE
Prevent duplicate listing of directories.

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -195,7 +195,11 @@ class Util
                 $parent = static::dirname($parent);
             }
 
+<<<<<<< HEAD
             if ($object['type'] == 'dir') {
+=======
+            if (isset($object['type']) && $object['type'] === 'dir') {
+>>>>>>> Prevent duplicate listing of directories.
                 $listedDirectories[] = $object['path'];
             }
         }

--- a/src/Util.php
+++ b/src/Util.php
@@ -180,6 +180,7 @@ class Util
     public static function emulateDirectories(array $listing)
     {
         $directories = [];
+        $listedDirectories = [];
 
         foreach ($listing as $object) {
             if (empty($object['dirname'])) {
@@ -193,9 +194,13 @@ class Util
 
                 $parent = static::dirname($parent);
             }
+
+            if ($object['type'] == 'dir') {
+                $listedDirectories[] = $object['path'];
+            }
         }
 
-        $directories = array_unique($directories);
+        $directories = array_diff(array_unique($directories), array_unique($listedDirectories));
 
         foreach ($directories as $directory) {
             $listing[] = static::pathinfo($directory) + ['type' => 'dir'];


### PR DESCRIPTION
If folders are created using AWS console in an S3 bucket, they will have their own listing there and will appear in the original $listing array. This patch ensures that the folders are not listed twice, if that is the case.