### PR TITLE
Suppress warnings generated by mkdir.

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -50,7 +50,7 @@ class Local extends AbstractAdapter
     protected function ensureDirectory($root)
     {
         if (is_dir($root) === false) {
-            mkdir($root, 0755, true);
+            @mkdir($root, 0755, true);
         }
 
         return realpath($root);


### PR DESCRIPTION
When having an illegal path, mkdir will generate a warning which, on some servers, can botch up a JSON response. Suppressing it allows these scenarios to be handled using Exceptions.