### PR TITLE
Fix timestamp from FTP adapter

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -288,18 +288,17 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
         $item = preg_replace('#\s+#', ' ', trim($item));
         list($permissions, /* $number */, /* $owner */, /* $group */, $size, $month, $day, $time, $name) = explode(' ', $item, 9);
         $type = $this->detectType($permissions);
-        $timestamp = ftp_mdtm($this->getConnection(), $name);
         $path = empty($base) ? $name : $base.$this->separator.$name;
 
         if ($type === 'dir') {
-            return compact('type', 'path', 'timestamp');
+            return compact('type', 'path');
         }
 
         $permissions = $this->normalizePermissions($permissions);
         $visibility = $permissions & 0044 ? AdapterInterface::VISIBILITY_PUBLIC : AdapterInterface::VISIBILITY_PRIVATE;
         $size = (int) $size;
 
-        return compact('type', 'path', 'visibility', 'size', 'timestamp');
+        return compact('type', 'path', 'visibility', 'size');
     }
 
     /**
@@ -383,7 +382,8 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
      */
     public function getTimestamp($path)
     {
-        return $this->getMetadata($path);
+        $timestamp = ftp_mdtm($this->getConnection(), $path);
+        return ( $timestamp !== -1) ? ['timestamp' => $timestamp] : false;
     }
 
     /**

--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -288,7 +288,7 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
         $item = preg_replace('#\s+#', ' ', trim($item));
         list($permissions, /* $number */, /* $owner */, /* $group */, $size, $month, $day, $time, $name) = explode(' ', $item, 9);
         $type = $this->detectType($permissions);
-        $timestamp = strtotime($month.' '.$day.' '.$time);
+        $timestamp = ftp_mdtm($this->getConnection(), $name);
         $path = empty($base) ? $name : $base.$this->separator.$name;
 
         if ($type === 'dir') {

--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -286,7 +286,7 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
     protected function normalizeObject($item, $base)
     {
         $item = preg_replace('#\s+#', ' ', trim($item));
-        list($permissions, /* $number */, /* $owner */, /* $group */, $size, $month, $day, $time, $name) = explode(' ', $item, 9);
+        list($permissions, /* $number */, /* $owner */, /* $group */, $size, /* $month */, /* $day */, /* $time*/, $name) = explode(' ', $item, 9);
         $type = $this->detectType($permissions);
         $path = empty($base) ? $name : $base.$this->separator.$name;
 

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -111,6 +111,17 @@ function ftp_rawlist($connection, $directory)
         ];
     }
 
+    if (strpos($directory, 'lastfiledir') !== false) {
+        return [
+            'drwxr-xr-x   2 ftp      ftp          4096 Feb  6  2012 .',
+            'drwxr-xr-x   4 ftp      ftp          4096 Feb  6 13:58 ..',
+            '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01 file1.txt',
+            '-rw-r--r--   1 ftp      ftp           409 Aug 14 09:01 file2.txt',
+            '-rw-r--r--   1 ftp      ftp           409 Feb  6 10:06 file3.txt',
+            '-rw-r--r--   1 ftp      ftp           409 Mar 20  2014 file4.txt',
+        ];
+    }
+
     return [
         'drwxr-xr-x   4 ftp      ftp          4096 Nov 24 13:58 .',
         'drwxr-xr-x  16 ftp      ftp          4096 Sep  2 13:01 ..',
@@ -129,6 +140,31 @@ function ftp_rawlist($connection, $directory)
     ];
 }
 
+function ftp_mdtm($connection, $path)
+{
+    switch ($path) {
+        case 'file1.txt':
+            return 1408438882;
+            break;
+
+        case 'file2.txt':
+            return 1408006883;
+            break;
+
+        case 'file3.txt':
+            return 1423217165;
+            break;
+
+        case 'file4.txt':
+            return 1395305765;
+            break;
+
+        default:
+            return 1395305765;
+            break;
+    }
+
+}
 function ftp_mkdir($connection, $dirname)
 {
     if (strpos($dirname, 'mkdir.fail') !== false) {
@@ -213,6 +249,22 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $adapter->writeStream('unknowndir/file.txt', tmpfile(), new Config(['visibility' => 'public'])));
         $this->assertInternalType('array', $adapter->updateStream('unknowndir/file.txt', tmpfile(), new Config()));
         $this->assertInternalType('array', $adapter->getTimestamp('some/file.ext'));
+    }
+
+    public function testGetLasFile()
+    {
+        $adapter = new Ftp($this->options);
+
+        $listing = $adapter->listContents('lastfiledir');
+
+        $last_modified_file = null;
+        foreach ($listing as $file) {
+            if (empty($last_modified_file) or $last_modified_file['timestamp'] < $file['timestamp']) {
+                $last_modified_file = $file;
+            }
+        }
+
+        $this->assertEquals('lastfiledir/file3.txt', $last_modified_file['path']);
     }
 
     /**

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -143,24 +143,27 @@ function ftp_rawlist($connection, $directory)
 function ftp_mdtm($connection, $path)
 {
     switch ($path) {
-        case 'file1.txt':
+        case 'lastfiledir/file1.txt':
             return 1408438882;
             break;
 
-        case 'file2.txt':
+        case 'lastfiledir/file2.txt':
             return 1408006883;
             break;
 
-        case 'file3.txt':
+        case 'lastfiledir/file3.txt':
             return 1423217165;
             break;
 
-        case 'file4.txt':
+        case 'lastfiledir/file4.txt':
             return 1395305765;
             break;
 
+        case 'some/file.ext':
+            return 1408438882;
+            break;
         default:
-            return 1395305765;
+            return -1;
             break;
     }
 
@@ -259,12 +262,23 @@ class FtpTests extends \PHPUnit_Framework_TestCase
 
         $last_modified_file = null;
         foreach ($listing as $file) {
-            if (empty($last_modified_file) or $last_modified_file['timestamp'] < $file['timestamp']) {
+            if (empty($last_modified_file)
+                or $adapter->getTimestamp($last_modified_file['path']) < $adapter->getTimestamp($file['path'])) {
                 $last_modified_file = $file;
             }
         }
 
         $this->assertEquals('lastfiledir/file3.txt', $last_modified_file['path']);
+    }
+
+    public function testListingDoNotIncludeTimestamp()
+    {
+        $adapter = new Ftp($this->options);
+
+        $listing = $adapter->listContents('');
+
+        $this->assertNotEmpty($listing);
+        $this->assertArrayNotHasKey('timestamp', $listing);
     }
 
     /**

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -254,6 +254,9 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $adapter->getTimestamp('some/file.ext'));
     }
 
+    /**
+     * @depends testInstantiable
+     */
     public function testGetLasFile()
     {
         $adapter = new Ftp($this->options);
@@ -271,6 +274,9 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('lastfiledir/file3.txt', $last_modified_file['path']);
     }
 
+    /**
+     * @depends testInstantiable
+     */
     public function testListingDoNotIncludeTimestamp()
     {
         $adapter = new Ftp($this->options);


### PR DESCRIPTION
What does this Pull Request Do?
-------------------------------
The way the timestamp is calculated
```php
$timestamp = strtotime($month.' '.$day.' '.$time);
```

forgets that the FTP server don't show the year if the date is +-6 months. So, was calculating a wrong timestamp somethimes.

What I did was ask for the timestamp to the FTP server using
```php
$timestamp = ftp_mdtm($this->getConnection(), $name);
```
This solves the problem. Now you can do things like get the last file in a `listContents()` safely.

**Changelog**
`listContents()` no longer returns the `timestamp` because was inaccurate and using `ftp_mdtm()` could led to a huge performance penalty.  To get the timestamp you have to explicitly ask for it using `getTimestamp()`.

How should this be manually tested?
-----------------------------------
I added test to this.

Any background context?
-----------------------
I need for a project to search for the last file in many FTP accounts. This week I started using the library(which is awesome, thanks!!) and started to have issues about the files I was downloading and processing. Finally saw the issue, the `timestamp`, and here one way I propose to fix it.

Any extra info?
---------------
This fix has a performance issue if the directory have lots of files, becouse, instead of using only one LIST, we'll be adding one MODTIME call to the server for each file. So, we'll end with `N` roundtrips more (`N` number of files in the directory).

Options:
Another option would be to check the date and see if it's +-6 month, and fix it if necessary. It's easy if we get the current date of the server we are running, but to do it properly we should use the date of the FTP server we are in. We can do this by writing a file to check the FTP server's date, but (1) we could be breaking read-only implementa and (2) if we do it do it in the `normalizeObject()` method is as bad for performance (3) if we do it before normalizing, we have to carry the date with us, changing the parameters we actually have for all the other methods until we get to `normalizeObject()`.

Hope you find this useful! ;)