### PR TITLE
Fixes an issue uploading 'dot prefixed' directories with the FTP adapter

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -283,9 +283,11 @@ class Ftp extends AbstractFtpAdapter
         // List the current directory
         $listing = ftp_nlist($connection, '.');
 
-        $listing = array_map(function ($item) {
-            return ltrim($item, './');
-        }, $listing);
+        foreach ($listing as $k => $item) {
+            if (in_array($item, ['.', '..'])) {
+                unset($listing[$k]);
+            }
+        }
 
         if (in_array($directory, $listing)) {
             return true;


### PR DESCRIPTION
After the ltrim on the directory listings on 287, directories with a dot prefix will not match on 290. This causes the FTP adapter to try and create a directory that already exists which results in an error.