### PR TITLE
Use dataprovider in testOutsideRootPath

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -89,7 +89,7 @@ class Util
 
         $normalized = static::normalizeRelativePath($normalized);
 
-        if (preg_match('#/\.{2}|^\.{2}/#', $normalized)) {
+        if (preg_match('#/\.{2}|^\.{2}#', $normalized)) {
             throw new LogicException('Path is outside of the defined root, path: ['.$path.'], resolved: ['.$normalized.']');
         }
 

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -86,7 +86,7 @@ class UtilTests extends \PHPUnit_Framework_TestCase
      */
     public function testOutsideRootPath($path)
     {
-        Util::normalizePath('something/../../../hehe');
+        Util::normalizePath($path);
     }
 
     public function pathProvider()


### PR DESCRIPTION
@frankdejonge

Thank you for this great library!


I found  a fix leakage of the following commit.
And, I have fixed it.
https://github.com/thephpleague/flysystem/commit/3108d21339406e71126f209dccf695de01bf5130#diff-0a84506104c31f88ac00dbab7372dd6aR86


In addition, because the test of the following locations fail, I have fixed it.
https://github.com/thephpleague/flysystem/blob/master/tests/UtilTests.php#L79


Thank you.
