### PR TITLE
Handle leading and trailing spaces in ftp file names

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -285,8 +285,11 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
      */
     protected function normalizeObject($item, $base)
     {
-        $item = preg_replace('#\s+#', ' ', trim($item));
-        list($permissions, /* $number */, /* $owner */, /* $group */, $size, /* $month */, /* $day */, /* $time*/, $name) = explode(' ', $item, 9);
+        // split with any number of whitespace but preserve any extra spaces for the filename
+        $regex = '/(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s(.+)/';
+        preg_match($regex, $item, $matches);
+        array_shift($matches);
+        list($permissions, /* $number */, /* $owner */, /* $group */, $size, /* $month */, /* $day */, /* $time*/, $name) = $matches;
         $type = $this->detectType($permissions);
         $path = empty($base) ? $name : $base.$this->separator.$name;
 

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -129,6 +129,16 @@ function ftp_rawlist($connection, $directory)
         ];
     }
 
+    if (strpos($directory, 'spaces') !== false) {
+        return [
+            'drwxr-xr-x   2 ftp      ftp          4096 Feb  6  2012 .',
+            'drwxr-xr-x   4 ftp      ftp          4096 Feb  6 13:58 ..',
+            '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01  file1.txt',
+            '-rw-r--r--   1 ftp      ftp           409 Aug 14 09:01 file2.txt ',
+            '-rw-r--r--   1 ftp      ftp           409 Feb  6 10:06 file 3.txt'
+        ];
+    }
+
     return [
         'drwxr-xr-x   4 ftp      ftp          4096 Nov 24 13:58 .',
         'drwxr-xr-x  16 ftp      ftp          4096 Sep  2 13:01 ..',
@@ -292,6 +302,21 @@ class FtpTests extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($listing);
         $this->assertArrayNotHasKey('timestamp', $listing);
+    }
+
+    /**
+     * @depends testInstantiable
+     */
+    public function testListingLeadingTrailingSpace()
+    {
+        $adapter = new Ftp($this->options);
+
+        $listing = $adapter->listContents('spaces');
+
+        $this->assertNotEmpty($listing);
+        $this->assertEquals('spaces/ file1.txt', $listing[0]['path']);
+        $this->assertEquals('spaces/file2.txt ', $listing[1]['path']);
+        $this->assertEquals('spaces/file 3.txt', $listing[2]['path']);
     }
 
     /**


### PR DESCRIPTION
Currently the FTP adapter truncates any extra whitespace from the result of `ftp_rawlist` which breaks `listContents` when a file name contains a leading or trailing slash