### PR TITLE
Fix casing for flysystem webdav adapter

### DIFF
--- a/adapter/webdav.md
+++ b/adapter/webdav.md
@@ -16,6 +16,6 @@ composer require league/flysystem-webdav
 
 ~~~ php
 $client = new Sabre\DAV\Client($settings);
-$adapter = new League\Flysystem\WebDav\WebDavAdapter($client, $pathPrefix /* optional */);
+$adapter = new League\Flysystem\WebDAV\WebDAVAdapter($client, $pathPrefix /* optional */);
 $flysystem = new League\Flysystem\Filesystem($adapter);
 ~~~


### PR DESCRIPTION
Wrong casing for namespace and classname in the doc.