### PR TITLE
A bunch of stuff for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,17 @@ env:
 
 before_install:
   - mkdir tests/files
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then rm phpunit.xml; fi;'
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then mv phpunit.hhvm.xml phpunit.xml; fi;'
+  - if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then rm phpunit.xml; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then mv phpunit.hhvm.xml phpunit.xml; fi
 
 install:
   - travis_retry composer update $COMPOSER_OPTS
 
 script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then bin/phpunit; fi;'
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then bin/phpunit --coverage-text --coverage-clover coverage.xml; fi;'
+  - if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then bin/phpunit; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then bin/phpunit --coverage-text --coverage-clover coverage.xml; fi
   - bin/phpspec run
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi;'
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,17 @@ php:
 
 sudo: false
 
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+
 before_install:
   - mkdir tests/files
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then rm phpunit.xml; fi;'
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then mv phpunit.hhvm.xml phpunit.xml; fi;'
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer update $COMPOSER_OPTS
 
 script:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then bin/phpunit; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 5.6
   - hhvm
 
+sudo: false
+
 before_install:
   - mkdir tests/files
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "hhvm" ]; then rm phpunit.xml; fi;'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.1",
         "mockery/mockery": "~0.9",
         "predis/predis": "~1.0",
         "tedivm/stash": "~0.12.0",


### PR DESCRIPTION
* Use `composer update` to test against the highest dependencies
* Also test against the lowest supported dependencies
* Added testing on the upcoming php release (7.0)
* Use [container-based](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) travis builds 
* Removed `bash -c` calls that aren't required on Travis

Doing this uncovered an [issue](https://travis-ci.org/duncan3dc/flysystem/builds/52409522) in the dependencies, where it was stated the phpunit 4.0 was required, when actually 4.1 is required. so I've bumped that requirement in `composer.json`