### PR TITLE
Use getter in removePathPrefix

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -75,11 +75,11 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function removePathPrefix($path)
     {
-        if ($this->pathPrefix === null) {
+        if ($this->getPathPrefix() === null) {
             return $path;
         }
 
-        $length = strlen($this->pathPrefix);
+        $length = strlen($this->getPathPrefix());
 
         return substr($path, $length);
     }


### PR DESCRIPTION
Currently if you override `getPathPrefix` it won't be used in `removePathPrefix`