### PR TITLE
Fixing nonescaped regex chars

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -88,7 +88,7 @@ class Util
         $normalized = preg_replace('#\p{C}+|^\./#u', '', $path);
         $normalized = static::normalizeRelativePath($normalized);
 
-        if (preg_match('#/\.{2}|^\.{2}/|^..$#', $normalized)) {
+        if (preg_match('#/\.{2}|^\.{2}/|^\.{2}$#', $normalized)) {
             throw new LogicException('Path is outside of the defined root, path: ['.$path.'], resolved: ['.$normalized.']');
         }
 


### PR DESCRIPTION
Fixes a bug where any two digit filename causes an error. (In our case, the filename was the ID of the file in our database e.g. "35")