### PR TITLE
Changes in the way some paths are normalized

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -108,7 +108,7 @@ class Util
     public static function normalizeRelativePath($path)
     {
         // Path remove self referring paths ("/./").
-        $path = preg_replace('#/\.(?=/)|^\./|\./$#', '', $path);
+        $path = preg_replace('#/\.(?=/)|^\./|/\./?$#', '', $path);
 
         // Regex for resolving relative paths
         $regex = '#/*[^/\.]+/\.\.#Uu';

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -94,6 +94,10 @@ class UtilTests extends \PHPUnit_Framework_TestCase
         return [
             ['/dirname/', 'dirname'],
             ['dirname/..', ''],
+            ['dirname/../', ''],
+            ['dirname./', 'dirname.'],
+            ['dirname/./', 'dirname'],
+            ['dirname/.', 'dirname'],
             ['./dir/../././', ''],
             ['00004869/files/other/10-75..stl', '00004869/files/other/10-75..stl'],
             ['/dirname//subdir///subsubdir', 'dirname/subdir/subsubdir'],


### PR DESCRIPTION
The current regex that handles the removal of self referring parts in the path doesn't seem to work properly in some cases:

Examples:
```php
$path = Util::normalizePath("dirname./");
// Expected:    
$path == "dirname.";
// Actual:           
$path == "dirname";

$path = Util::normalizePath("dirname/.");
// Expected:    
$path == "dirname";
// Actual:          
$path == "dirname/.";

$path = Util::normalizePath("dirname/../");
// Expected:    
$path == "";
// Actual:          
$path == "dirname/.";
```

With this change the regex will replace "." at the end of the path only if it's after a "/ " and it's followed by either a "/" or the end of the string