### PR TITLE
Require ext-mbstring in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "ext-fileinfo": "*",


### PR DESCRIPTION
```Util::contentSize``` makes use of an mb_* function so this library should depend on it.