### PR TITLE
Consistency between ensureDirectory() and createDir()

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -50,8 +50,12 @@ class Local extends AbstractAdapter
      */
     protected function ensureDirectory($root)
     {
-        if (is_dir($root) === false) {
-            mkdir($root, 0755, true);
+        if (! is_dir($root)) {
+            $umask = umask(0);
+            
+            mkdir($root, 0777, true);
+            
+            umask($umask);
         }
 
         return realpath($root);
@@ -295,11 +299,17 @@ class Local extends AbstractAdapter
     {
         $location = $this->applyPathPrefix($dirname);
 
+        $umask = umask(0);
+        
         if (! is_dir($location) && ! mkdir($location, 0777, true)) {
-            return false;
+            $return = false;
+        } else {
+            $return = ['path' => $dirname, 'type' => 'dir'];
         }
 
-        return ['path' => $dirname, 'type' => 'dir'];
+        umask($umask);
+
+        return $return;
     }
 
     /**

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -52,9 +52,7 @@ class Local extends AbstractAdapter
     {
         if (! is_dir($root)) {
             $umask = umask(0);
-            
             mkdir($root, 0777, true);
-            
             umask($umask);
         }
 
@@ -298,7 +296,6 @@ class Local extends AbstractAdapter
     public function createDir($dirname, Config $config)
     {
         $location = $this->applyPathPrefix($dirname);
-
         $umask = umask(0);
         
         if (! is_dir($location) && ! mkdir($location, 0777, true)) {
@@ -308,7 +305,7 @@ class Local extends AbstractAdapter
         }
 
         umask($umask);
-
+        
         return $return;
     }
 


### PR DESCRIPTION
Use the same chmod (777) in both, and write the is_dir() check the same way other methods use it.
Also, reset umask to 0 to make mkdir() reliable.