### PR TITLE
Cleanup documentation

### DIFF
--- a/adapter/aws-s3-v2.md
+++ b/adapter/aws-s3-v2.md
@@ -12,16 +12,18 @@ title: Aws S3 Adapter V2
 composer require league/flysystem-aws-s3-v2
 ~~~
 
+## Usage
+
 ~~~ php
 use Aws\S3\S3Client;
 use League\Flysystem\AwsS3v2\AwsS3Adapter;
 use League\Flysystem\Filesystem;
 
-$client = S3Client::factory(array(
+$client = S3Client::factory([
     'key'    => '[your key]',
     'secret' => '[your secret]',
-    'region' => '[aws-region]'
-));
+    'region' => '[aws-region]',
+]);
 
 $adapter = new AwsS3Adapter($client, 'bucket-name', 'optional-prefix');
 

--- a/adapter/aws-s3-v3.md
+++ b/adapter/aws-s3-v3.md
@@ -12,6 +12,8 @@ title: Aws S3 Adapter V3
 composer require league/flysystem-aws-s3-v3
 ~~~
 
+## Usage
+
 ~~~ php
 use Aws\S3\S3Client;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;

--- a/adapter/azure.md
+++ b/adapter/azure.md
@@ -12,11 +12,9 @@ title: Azure Blob Storage
 composer require league/flysystem-azure
 ~~~
 
-# Usage
+## Usage
 
 ~~~ php
-<?php
-
 use WindowsAzure\Common\ServicesBuilder;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Azure\AzureAdapter;

--- a/adapter/ftp.md
+++ b/adapter/ftp.md
@@ -6,11 +6,17 @@ title: FTP Adapter
 
 # FTP Adapter
 
+## Installation
+
+Comes with the main Flysystem package.
+
+## Usage
+
 ~~~ php
 use League\Flysystem\Filesystem;
 use League\Flysystem\Adapter\Ftp as Adapter;
 
-$filesystem = new Filesystem(new Adapter(array(
+$filesystem = new Filesystem(new Adapter([
     'host' => 'ftp.example.com',
     'username' => 'username',
     'password' => 'password',
@@ -21,5 +27,5 @@ $filesystem = new Filesystem(new Adapter(array(
     'passive' => true,
     'ssl' => true,
     'timeout' => 30,
-)));
+]));
 ~~~

--- a/adapter/gridfs.md
+++ b/adapter/gridfs.md
@@ -6,6 +6,14 @@ title: FTP Adapter
 
 # GridFS Adapter
 
+## Installation
+
+~~~ bash
+composer require league/flysystem-gridfs
+~~~
+
+## Usage
+
 ~~~ php
 use League\Flysystem\GridFS\GridFSAdapter;
 use League\Flysystem\Filesystem;

--- a/adapter/local.md
+++ b/adapter/local.md
@@ -6,6 +6,12 @@ title: Local Adapter
 
 # Local Adapter
 
+## Installation
+
+Comes with the main Flysystem package.
+
+## Usage
+
 ~~~ php
 use League\Flysystem\Filesystem;
 use League\Flysystem\Adapter\Local as Adapter;

--- a/adapter/null-test.md
+++ b/adapter/null-test.md
@@ -6,6 +6,12 @@ title: Null Adapter
 
 # Null Adapter
 
+## Installation
+
+Comes with the main Flysystem package.
+
+## Usage
+
 Acts like /dev/null
 
 ~~~ php

--- a/adapter/phpcr.md
+++ b/adapter/phpcr.md
@@ -32,14 +32,14 @@ use Jackalope\RepositoryFactoryDoctrineDBAL;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\DriverManager;
 
-$connection = DriverManager::getConnection(array(
+$connection = DriverManager::getConnection([
     'driver' => 'pdo_sqlite',
     'path'   => '/path/to/sqlite.db',
-));
+]);
 $factory = new RepositoryFactoryDoctrineDBAL();
-$repository = $factory->getRepository(array(
+$repository = $factory->getRepository([
     'jackalope.doctrine_dbal_connection' => $connection,
-));
+]);
 $session = $repository->login(new SimpleCredentials('', ''));
 
 // this part looks the same regardless of your phpcr implementation.

--- a/adapter/rackspace.md
+++ b/adapter/rackspace.md
@@ -20,10 +20,10 @@ use OpenCloud\Rackspace;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Rackspace\RackspaceAdapter;
 
-$client = new OpenStack(Rackspace::UK_IDENTITY_ENDPOINT, array(
+$client = new OpenStack(Rackspace::UK_IDENTITY_ENDPOINT, [
     'username' => ':username',
     'password' => ':password',
-));
+]);
 
 $store = $client->objectStoreService('cloudFiles', 'LON');
 $container = $store->getContainer('flysystem');

--- a/adapter/sftp.md
+++ b/adapter/sftp.md
@@ -18,7 +18,7 @@ composer require league/flysystem-sftp
 use League\Flysystem\Filesystem;
 use League\Flysystem\Sftp\SftpAdapter;
 
-$filesystem = new Filesystem(new SftpAdapter(array(
+$filesystem = new Filesystem(new SftpAdapter([
     'host' => 'example.com',
     'port' => 21,
     'username' => 'username',
@@ -26,5 +26,5 @@ $filesystem = new Filesystem(new SftpAdapter(array(
     'privateKey' => 'path/to/or/contents/of/privatekey',
     'root' => '/path/to/root',
     'timeout' => 10,
-)));
+]));
 ~~~

--- a/caching.md
+++ b/caching.md
@@ -19,7 +19,7 @@ This package supplies an Adapter decorator which acts as a caching proxy.
 
 The CachedAdapter (the decorator) caches anything but the file contents. This keeps the cache small enough to be benefitial and covers all the filesystem inspection operations.
 
-# Memory Caching
+## Memory Caching
 
 The easiest way to boost the performance of Flysystem is to add Memory caching.
 This type of caching will cache everything in the lifetime of the current process (cli-job or http-request).

--- a/integrations.md
+++ b/integrations.md
@@ -8,13 +8,13 @@ title: Integrations
 
 Want to get started quickly? Check out some of these bridging packages:
 
-* Laravel integration: https://github.com/GrahamCampbell/Laravel-Flysystem
-* Symfony integration: https://github.com/1up-lab/OneupFlysystemBundle
-* Zend Framework integration: https://github.com/bushbaby/BsbFlysystem
-* CakePHP integration: https://github.com/WyriHaximus/FlyPie
-* Silex integration: https://github.com/WyriHaximus/SliFly
-* Yii 2 integration: https://github.com/creocoder/yii2-flysystem
-* Backup manager: https://github.com/heybigname/backup-manager
+* [Laravel integration](https://github.com/GrahamCampbell/Laravel-Flysystem)
+* [Symfony integration](https://github.com/1up-lab/OneupFlysystemBundle)
+* [Zend Framework integration](https://github.com/bushbaby/BsbFlysystem)
+* [CakePHP integration](https://github.com/WyriHaximus/FlyPie)
+* [Silex integration](https://github.com/WyriHaximus/SliFly)
+* [Yii 2 integration](https://github.com/creocoder/yii2-flysystem)
+* [Backup manager](https://github.com/heybigname/backup-manager)
 
 ### Other integrations
 

--- a/mount-manager.md
+++ b/mount-manager.md
@@ -18,10 +18,10 @@ $s3 = new League\Flysystem\Filesystem($s3Adapter);
 $local = new League\Flysystem\Filesystem($localAdapter);
 
 // Add them in the constructor
-$manager = new League\Flysystem\MountManager(array(
+$manager = new League\Flysystem\MountManager([
     'ftp' => $ftp,
     's3' => $s3,
-));
+]);
 
 // Or mount them later
 $manager->mountFilesystem('local', $local);

--- a/recipes.md
+++ b/recipes.md
@@ -14,7 +14,6 @@ a problem. Please consider contributing a recipe. Contributions are very welcome
 ### Plain PHP Upload
 
 ~~~ php
-<?php
 $stream = fopen($_FILES[$uploadname]['tmp_name'], 'r+');
 $filesystem->writeStream('uploads/'.$_FILES[$uploadname]['name'], $stream);
 fclose($stream);
@@ -23,14 +22,13 @@ fclose($stream);
 ### Symfony Upload
 
 ~~~ php
-<?php
 /** @var Symfony\Component\HttpFoundation\Request $request */
 /** @var Symfony\Component\HttpFoundation\File\UploadedFile $file */
 $file = $request->files->get($uploadname);
 
 if ($file->isValid()) {
     $stream = fopen($file->getRealPath(), 'r+');
-    $filesystem->writeStream('uploads/', $stream);
+    $filesystem->writeStream('uploads/'.$file->getClientOriginalName(), $stream);
     fclose($stream);
 }
 ~~~
@@ -66,12 +64,11 @@ class UploadController extends Controller {
 ### Laravel 4/5 - Static-Access Proxy
 
 ~~~ php
-<?php
 $file = Request::file($uploadname);
 
 if ($file->isValid()) {
     $stream = fopen($file->getRealPath(), 'r+');
-    $filesystem->writeStream('uploads/', $stream);
+    $filesystem->writeStream('uploads/'.$file->getClientOriginalName(), $stream);
     fclose($stream);
 }
 ~~~

--- a/upgrade-to-1.0.0.md
+++ b/upgrade-to-1.0.0.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 permalink: /upgrade-to-1.0.0/
-title: Caching
+title: Upgrade to 1.0.0
 ---
 
 # Upgrade to 1.0.0
@@ -15,14 +15,14 @@ In order to have better dependency management, and to remove some of the
 version contstraints, some of the adapters have been moved out or the main
 repository. These adapters are:
 
-* AwsS3: AWS SDK V2 Adapter - [docs](/adapter/aws-s3-v2/)
-* AwsS3V3: AWS SDK V3 Adapter - [docs](/adapter/aws-s3-v3/)
-* Dropbox: [docs](/adapter/dropbox/)
-* Rackspace: [docs](/adapter/rackspace/)
-* GridFS: [docs](/adapter/gridfs/)
-* Sftp: [docs](/adapter/sftp/)
-* WebDAV: [docs](/adapter/webdav/)
-* ZipArchive: [docs](/adapter/zip-archive/)
+* [AwsS3: AWS SDK V2 Adapter](/adapter/aws-s3-v2/)
+* [AwsS3V3: AWS SDK V3 Adapter](/adapter/aws-s3-v3/)
+* [Dropbox](/adapter/dropbox/)
+* [Rackspace](/adapter/rackspace/)
+* [GridFS](/adapter/gridfs/)
+* [Sftp](/adapter/sftp/)
+* [WebDAV](/adapter/webdav/)
+* [ZipArchive](/adapter/zip-archive/)
 
 ##  Caching
 


### PR DESCRIPTION
Cleaned up the docs a bit after reading through them earlier today. Just some small things.

- Added the same titles to all the different adapter docs
- Converted arrays to short syntax (since Flysystem requires PHP >=5.4)
- Fixed some titles
- Removed the `<?php` opening tag from all code blocks except for the two where you were displaying an entire file
- Added some missing code for 2 recipes
- Tweaked 2 lists with links (this was a personal choice, I can always change it back if you want)

One suggestion: I'd add links to the main docs in each adapter's readme instead of keeping install/usage notes in both main docs and each readme. Things can get outdated real fast currently.

Hope you like :)