### PR TITLE
Allow Ftp::getMetadata() to work on directories.

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -301,7 +301,19 @@ class Ftp extends AbstractFtpAdapter
      */
     public function getMetadata($path)
     {
-        $listing = ftp_rawlist($this->getConnection(), $path);
+        if (!strlen($path)) {
+            return ['type' => 'dir', 'path' => ''];
+        }
+
+        $connection = $this->getConnection();
+
+        if (@ftp_chdir($connection, $path)) {
+            $this->setConnectionRoot();
+
+            return ['type' => 'dir', 'path' => $path];
+        }
+        
+        $listing = ftp_rawlist($connection, $path);
 
         if (empty($listing)) {
             return false;

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -66,7 +66,7 @@ class Filesystem implements FilesystemInterface
     {
         $path = Util::normalizePath($path);
 
-        return (bool) $this->adapter->has($path);
+        return (bool) $this->getAdapter()->has($path);
     }
 
     /**
@@ -78,7 +78,7 @@ class Filesystem implements FilesystemInterface
         $this->assertAbsent($path);
         $config = $this->prepareConfig($config);
 
-        return (bool) $this->adapter->write($path, $contents, $config);
+        return (bool) $this->getAdapter()->write($path, $contents, $config);
     }
 
     /**
@@ -96,7 +96,7 @@ class Filesystem implements FilesystemInterface
 
         Util::rewindStream($resource);
 
-        return (bool) $this->adapter->writeStream($path, $resource, $config);
+        return (bool) $this->getAdapter()->writeStream($path, $resource, $config);
     }
 
     /**
@@ -183,7 +183,7 @@ class Filesystem implements FilesystemInterface
 
         $this->assertPresent($path);
 
-        return (bool) $this->adapter->update($path, $contents, $config);
+        return (bool) $this->getAdapter()->update($path, $contents, $config);
     }
 
     /**
@@ -208,7 +208,7 @@ class Filesystem implements FilesystemInterface
         $this->assertPresent($path);
         Util::rewindStream($resource);
 
-        return (bool) $this->adapter->updateStream($path, $resource, $config);
+        return (bool) $this->getAdapter()->updateStream($path, $resource, $config);
     }
 
     /**
@@ -226,7 +226,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if (! ($object = $this->adapter->read($path))) {
+        if (! ($object = $this->getAdapter()->read($path))) {
             return false;
         }
 
@@ -245,7 +245,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if (! $object = $this->adapter->readStream($path)) {
+        if (! $object = $this->getAdapter()->readStream($path)) {
             return false;
         }
 
@@ -270,7 +270,7 @@ class Filesystem implements FilesystemInterface
         $this->assertPresent($path);
         $this->assertAbsent($newpath);
 
-        return (bool) $this->adapter->rename($path, $newpath);
+        return (bool) $this->getAdapter()->rename($path, $newpath);
     }
 
     /**
@@ -288,7 +288,7 @@ class Filesystem implements FilesystemInterface
         $this->assertPresent($path);
         $this->assertAbsent($newpath);
 
-        return $this->adapter->copy($path, $newpath);
+        return $this->getAdapter()->copy($path, $newpath);
     }
 
     /**
@@ -305,7 +305,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        return $this->adapter->delete($path);
+        return $this->getAdapter()->delete($path);
     }
 
     /**
@@ -323,7 +323,7 @@ class Filesystem implements FilesystemInterface
             throw new RootViolationException('Root directories can not be deleted.');
         }
 
-        return (bool) $this->adapter->deleteDir($dirname);
+        return (bool) $this->getAdapter()->deleteDir($dirname);
     }
 
     /**
@@ -334,7 +334,7 @@ class Filesystem implements FilesystemInterface
         $dirname = Util::normalizePath($dirname);
         $config = $this->prepareConfig($config);
 
-        return (bool) $this->adapter->createDir($dirname, $config);
+        return (bool) $this->getAdapter()->createDir($dirname, $config);
     }
 
     /**
@@ -348,7 +348,7 @@ class Filesystem implements FilesystemInterface
     public function listContents($directory = '', $recursive = false)
     {
         $directory = Util::normalizePath($directory);
-        $contents = $this->adapter->listContents($directory, $recursive);
+        $contents = $this->getAdapter()->listContents($directory, $recursive);
         $mapper = function ($entry) use ($directory, $recursive) {
             $entry = $entry + Util::pathinfo($entry['path']);
 
@@ -381,7 +381,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if (! $object = $this->adapter->getMimetype($path)) {
+        if (! $object = $this->getAdapter()->getMimetype($path)) {
             return false;
         }
 
@@ -403,7 +403,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if (! $object = $this->adapter->getTimestamp($path)) {
+        if (! $object = $this->getAdapter()->getTimestamp($path)) {
             return false;
         }
 
@@ -423,7 +423,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if (($object = $this->adapter->getVisibility($path)) === false) {
+        if (($object = $this->getAdapter()->getVisibility($path)) === false) {
             return false;
         }
 
@@ -442,7 +442,7 @@ class Filesystem implements FilesystemInterface
     {
         $path = Util::normalizePath($path);
 
-        if (($object = $this->adapter->getSize($path)) === false || !isset($object['size'])) {
+        if (($object = $this->getAdapter()->getSize($path)) === false || !isset($object['size'])) {
             return false;
         }
 
@@ -461,7 +461,7 @@ class Filesystem implements FilesystemInterface
     {
         $path = Util::normalizePath($path);
 
-        return (bool) $this->adapter->setVisibility($path, $visibility);
+        return (bool) $this->getAdapter()->setVisibility($path, $visibility);
     }
 
     /**
@@ -479,7 +479,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        return $this->adapter->getMetadata($path);
+        return $this->getAdapter()->getMetadata($path);
     }
 
     /**

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -66,9 +66,12 @@ function ftp_login($connection)
     return true;
 }
 
-function ftp_chdir($connection)
+function ftp_chdir($connection, $directory)
 {
     if ($connection === 'chdir.fail') {
+        return false;
+    }
+    if ($directory === 'not.found') {
         return false;
     }
 


### PR DESCRIPTION
When calling Ftp::getMetadata() on a directory, it returns the metadata for the first file in the directory.

This doesn't really gather any metadata at this point, my thought was once we determined the path is a directory, we could call ftp_rawlist() on the parent directory to actually gather metadata.

Starting with this to see if it's a reasonable idea, or if I'm just completely wrong.