### PR TITLE
Allow Ftp::getMetadata() to work for directories.

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -302,6 +302,19 @@ class Ftp extends AbstractFtpAdapter
     public function getMetadata($path)
     {
         $listing = ftp_rawlist($this->getConnection(), $path);
+        if (!strlen($path)) {
+            return ['type' => 'dir', 'path' => ''];
+        }
+
+        $connection = $this->getConnection();
+
+        if (@ftp_chdir($connection, $path)) {
+            $this->setConnectionRoot();
+
+            return ['type' => 'dir', 'path' => $path];
+        }
+
+        $listing = ftp_rawlist($connection, $path);
 
         if (empty($listing)) {
             return false;

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -66,9 +66,12 @@ function ftp_login($connection)
     return true;
 }
 
-function ftp_chdir($connection)
+function ftp_chdir($connection, $directory)
 {
     if ($connection === 'chdir.fail') {
+        return false;
+    }
+    if ($directory === 'not.found') {
         return false;
     }
 


### PR DESCRIPTION
When calling Ftp::getMetadata() on a directory, it returns the metadata for the first file in the directory.

This doesn't really gather any metadata at this point, my thought was once we determined the path is a directory, we could call ftp_rawlist() on the parent directory to actually gather metadata.

Starting with this to see if it's a reasonable idea, or if I'm just completely wrong.