### PR TITLE
[FTP] Support windows

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -25,7 +25,7 @@ class Ftp extends AbstractFtpAdapter
         'password', 'ssl', 'timeout',
         'root', 'permPrivate',
         'permPublic', 'passive',
-        'transferMode',
+        'transferMode', 'systemType',
     ];
 
     /**

--- a/src/NotSupportedException.php
+++ b/src/NotSupportedException.php
@@ -19,4 +19,17 @@ class NotSupportedException extends RuntimeException
 
         return new static($message.$file->getPathname());
     }
+
+    /**
+     * Create a new exception for a link.
+     *
+     * @param  string $systemType
+     * @return static
+     */
+    public static function forFtpSystemType($systemType)
+    {
+        $message = "The FTP system type '$systemType' is currently not supported.";
+
+        return new static($message);
+    }
 }

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -76,7 +76,7 @@ function ftp_chdir($connection, $directory)
         return false;
     }
 
-    if ($directory === 'file1.txt') {
+    if (in_array($directory, ['file1.txt', 'file2.txt', 'dir1'])) {
         return false;
     }
 
@@ -132,6 +132,18 @@ function ftp_rawlist($connection, $directory)
     if ($directory === '0') {
         return [
             '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01 0',
+        ];
+    }
+
+    if (strpos($directory, 'file2.txt') !== false) {
+        return [
+            '05-23-15  12:09PM                  684 file2.txt',
+        ];
+    }
+
+    if (strpos($directory, 'dir1') !== false) {
+        return [
+            '2015-05-23  12:09       <DIR>          dir1',
         ];
     }
 
@@ -327,6 +339,26 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $metadata);
         $this->assertEquals('file', $metadata['type']);
         $this->assertEquals('0', $metadata['path']);
+    }
+
+    /**
+     * @depends testInstantiable
+     */
+    public function testGetWindowsMetadata()
+    {
+        $adapter = new Ftp($this->options);
+        $metadata = $adapter->getMetadata('file2.txt');
+        $this->assertInternalType('array', $metadata);
+        $this->assertEquals('file', $metadata['type']);
+        $this->assertEquals('file2.txt', $metadata['path']);
+        $this->assertEquals(1432382940, $metadata['timestamp']);
+        $this->assertEquals('public', $metadata['visibility']);
+        $this->assertEquals(684, $metadata['size']);
+
+        $metadata = $adapter->getMetadata('dir1');
+        $this->assertEquals('dir', $metadata['type']);
+        $this->assertEquals('dir1', $metadata['path']);
+        $this->assertEquals(1432382940, $metadata['timestamp']);
     }
 
     /**


### PR DESCRIPTION
This is an attempt at support for Windows FTP systems, by trying multiple parsers. (See #451)

 - First try to parse as Unix
 - If fails, parse as Windows
 - If fails, empty array (or in future, more parsers)

This modifies the Unix (current) parser by adding a check to see if the format is as expected, to prevent an exception.

Windows parser is a modified version, based on the one from @kinncj in the mentioned PR. This adds support for short+long date format. 

I've added tests for the windows lines, which only proves that it doesn't throw an exception (like before), but should probably check the desired output also.

Haven't actually tested this on a 'live' Windows server, so could use some testing.

/cc @kinncj @frederikbosch @jelrikvh @JLeitchSCO 