### PR TITLE
Doc string fixes.

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -100,15 +100,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Create a file or update if exists.
-     *
-     * @param string $path     path to file
-     * @param string $contents file contents
-     * @param mixed  $config
-     *
-     * @throws FileExistsException
-     *
-     * @return bool success boolean
+     * {@inheritdoc}
      */
     public function put($path, $contents, array $config = [])
     {
@@ -122,13 +114,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Create a file or update if exists using a stream.
-     *
-     * @param string   $path
-     * @param resource $resource
-     * @param mixed    $config
-     *
-     * @return bool success boolean
+     * {@inheritdoc}
      */
     public function putStream($path, $resource, array $config = [])
     {
@@ -142,13 +128,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Read and delete a file.
-     *
-     * @param string $path
-     *
-     * @throws FileNotFoundException
-     *
-     * @return string file contents
+     * {@inheritdoc}
      */
     public function readAndDelete($path)
     {
@@ -166,15 +146,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Update a file.
-     *
-     * @param string $path     path to file
-     * @param string $contents file contents
-     * @param mixed  $config   Config object or visibility setting
-     *
-     * @throws FileNotFoundException
-     *
-     * @return bool success boolean
+     * {@inheritdoc}
      */
     public function update($path, $contents, array $config = [])
     {
@@ -187,15 +159,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Update a file with the contents of a stream.
-     *
-     * @param string   $path
-     * @param resource $resource
-     * @param mixed    $config   Config object or visibility setting
-     *
-     * @throws InvalidArgumentException
-     *
-     * @return bool success boolean
+     * {@inheritdoc}
      */
     public function updateStream($path, $resource, array $config = [])
     {
@@ -212,14 +176,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Read a file.
-     *
-     * @param string $path path to file
-     *
-     * @throws FileNotFoundException
-     *
-     * @return string|false file contents or FALSE when fails
-     *                      to read existing file
+     * {@inheritdoc}
      */
     public function read($path)
     {
@@ -234,11 +191,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Retrieves a read-stream for a path.
-     *
-     * @param string $path
-     *
-     * @return resource|false path resource or false when on failure
+     * {@inheritdoc}
      */
     public function readStream($path)
     {
@@ -253,15 +206,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Rename a file.
-     *
-     * @param string $path    path to file
-     * @param string $newpath new path
-     *
-     * @throws FileExistsException
-     * @throws FileNotFoundException
-     *
-     * @return bool success boolean
+     * {@inheritdoc}
      */
     public function rename($path, $newpath)
     {
@@ -274,12 +219,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Copy a file.
-     *
-     * @param string $path
-     * @param string $newpath
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function copy($path, $newpath)
     {
@@ -292,13 +232,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Delete a file.
-     *
-     * @param string $path path to file
-     *
-     * @throws FileNotFoundException
-     *
-     * @return bool success boolean
+     * {@inheritdoc}
      */
     public function delete($path)
     {
@@ -309,11 +243,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Delete a directory.
-     *
-     * @param string $dirname path to directory
-     *
-     * @return bool success boolean
+     * {@inheritdoc}
      */
     public function deleteDir($dirname)
     {
@@ -338,12 +268,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * List the filesystem contents.
-     *
-     * @param string $directory
-     * @param bool   $recursive
-     *
-     * @return array contents
+     * {@inheritdoc}
      */
     public function listContents($directory = '', $recursive = false)
     {
@@ -367,14 +292,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Get a file's mime-type.
-     *
-     * @param string $path path to file
-     *
-     * @throws FileNotFoundException
-     *
-     * @return string|false file mime-type or FALSE when fails
-     *                      to fetch mime-type from existing file
+     * {@inheritdoc}
      */
     public function getMimetype($path)
     {
@@ -389,14 +307,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Get a file's timestamp.
-     *
-     * @param string $path path to file
-     *
-     * @throws FileNotFoundException
-     *
-     * @return string|false timestamp or FALSE when fails
-     *                      to fetch timestamp from existing file
+     * {@inheritdoc}
      */
     public function getTimestamp($path)
     {
@@ -411,12 +322,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Get a file's visibility.
-     *
-     * @param string $path path to file
-     *
-     * @return string|false visibility (public|private) or FALSE
-     *                      when fails to check it in existing file
+     * {@inheritdoc}
      */
     public function getVisibility($path)
     {
@@ -431,12 +337,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Get a file's size.
-     *
-     * @param string $path path to file
-     *
-     * @return int|false file size or FALSE when fails
-     *                   to check size of existing file
+     * {@inheritdoc}
      */
     public function getSize($path)
     {
@@ -450,12 +351,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Get a file's size.
-     *
-     * @param string $path       path to file
-     * @param string $visibility visibility
-     *
-     * @return bool success boolean
+     * {@inheritdoc}
      */
     public function setVisibility($path, $visibility)
     {
@@ -465,14 +361,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Get a file's metadata.
-     *
-     * @param string $path path to file
-     *
-     * @throws FileNotFoundException
-     *
-     * @return array|false file metadata or FALSE when fails
-     *                     to fetch it from existing file
+     * {@inheritdoc}
      */
     public function getMetadata($path)
     {
@@ -483,12 +372,7 @@ class Filesystem implements FilesystemInterface
     }
 
     /**
-     * Get a file/directory handler.
-     *
-     * @param string  $path
-     * @param Handler $handler
-     *
-     * @return Handler file or directory handler
+     * {@inheritdoc}
      */
     public function get($path, Handler $handler = null)
     {

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -16,137 +16,165 @@ interface FilesystemInterface
     /**
      * Read a file.
      *
-     * @param string $path
+     * @param string $path The path to the file.
      *
-     * @return false|string
+     * @throws FileNotFoundException
+     *
+     * @return string|false The file contents or false on failure.
      */
     public function read($path);
 
     /**
-     * Read a file as a stream.
+     * Retrieves a read-stream for a path.
      *
-     * @param string $path
+     * @param string $path The path to the file.
      *
-     * @return false|resource
+     * @throws FileNotFoundException
+     *
+     * @return resource|false The path resource or false on failure.
      */
     public function readStream($path);
 
     /**
      * List contents of a directory.
      *
-     * @param string $directory
-     * @param bool   $recursive
+     * @param string $directory The directory to list.
+     * @param bool   $recursive Whether to list recursively.
      *
-     * @return array
+     * @return array A list of file metadata.
      */
     public function listContents($directory = '', $recursive = false);
 
     /**
-     * Get all the meta data of a file or directory.
+     * Get a file's metadata.
      *
-     * @param string $path
+     * @param string $path The path to the file.
      *
-     * @return false|array
+     * @throws FileNotFoundException
+     *
+     * @return array|false The file metadata or false on failure.
      */
     public function getMetadata($path);
 
     /**
-     * Get all the meta data of a file or directory.
+     * Get a file's size.
      *
-     * @param string $path
+     * @param string $path The path to the file.
      *
-     * @return false|int
+     * @return int|false The file size or false on failure.
      */
     public function getSize($path);
 
     /**
-     * Get the mime-type of a file.
+     * Get a file's mime-type.
      *
-     * @param string $path
+     * @param string $path The path to the file.
      *
-     * @return false|string
+     * @throws FileNotFoundException
+     *
+     * @return string|false The file mime-type or false on failure.
      */
     public function getMimetype($path);
 
     /**
-     * Get the timestamp of a file.
+     * Get a file's timestamp.
      *
-     * @param string $path
+     * @param string $path The path to the file.
      *
-     * @return false|int
+     * @throws FileNotFoundException
+     *
+     * @return string|false The timestamp or false on failure.
      */
     public function getTimestamp($path);
 
     /**
-     * Get the visibility of a file.
+     * Get a file's visibility.
      *
-     * @param string $path
+     * @param string $path The path to the file.
      *
-     * @return false|string
+     * @throws FileNotFoundException
+     *
+     * @return string|false The visibility (public|private) or false on failure.
      */
     public function getVisibility($path);
 
     /**
      * Write a new file.
      *
-     * @param string $path
-     * @param string $contents
-     * @param array  $config   Config array
+     * @param string $path     The path of the new file.
+     * @param string $contents The file contents.
+     * @param array  $config   An optional configuration array.
      *
-     * @return bool success boolean
+     * @throws FileExistsException
+     *
+     * @return bool True on success, false on failure.
      */
     public function write($path, $contents, array $config = []);
 
     /**
      * Write a new file using a stream.
      *
-     * @param string   $path
-     * @param resource $resource
-     * @param array    $config   config array
+     * @param string   $path     The path of the new file.
+     * @param resource $contents The file handle.
+     * @param array    $config   An optional configuration array.
      *
-     * @return bool success boolean
+     * @throws InvalidArgumentException If $resource is not a file handle.
+     * @throws FileExistsException
+     *
+     * @return bool True on success, false on failure.
      */
     public function writeStream($path, $resource, array $config = []);
 
     /**
-     * Update a file.
+     * Update an existing file.
      *
-     * @param string $path
-     * @param string $contents
-     * @param array  $config   config array
+     * @param string $path     The path of the existing file.
+     * @param string $contents The file contents.
+     * @param array  $config   An optional configuration array.
      *
-     * @return bool success boolean
+     * @throws FileNotFoundException
+     *
+     * @return bool True on success, false on failure.
      */
     public function update($path, $contents, array $config = []);
 
     /**
-     * Update a file using a stream.
+     * Update an existing file using a stream.
      *
-     * @param string   $path
-     * @param resource $resource
-     * @param array    $config   config array
+     * @param string   $path     The path of the existing file.
+     * @param resource $contents The file handle.
+     * @param array    $config   An optional configuration array.
      *
-     * @return bool success boolean
+     * @throws InvalidArgumentException If $resource is not a file handle.
+     * @throws FileNotFoundException
+     *
+     * @return bool True on success, false on failure.
      */
     public function updateStream($path, $resource, array $config = []);
 
     /**
      * Rename a file.
      *
-     * @param string $path
-     * @param string $newpath
+     * @param string $path    Path to the existing file.
+     * @param string $newpath The new path of the file.
      *
-     * @return bool
+     * @throws FileExistsException   Thrown if $newpath exists.
+     * @throws FileNotFoundException Thrown if $path does not exist.
+     *
+     * @return bool True on success, false on failure.
      */
     public function rename($path, $newpath);
 
     /**
      * Copy a file.
      *
-     * @param string $path
-     * @param string $newpath
+     * @param string $path    Path to the existing file.
+     * @param string $newpath The new path of the file.
      *
-     * @return bool
+     * @throws FileExistsException   Thrown if $newpath exists.
+     * @throws FileNotFoundException Thrown if $path does not exist.
+     *
+     * @return bool True on success, false on failure.
      */
     public function copy($path, $newpath);
 
@@ -155,7 +183,9 @@ interface FilesystemInterface
      *
      * @param string $path
      *
-     * @return bool
+     * @throws FileNotFoundException
+     *
+     * @return bool True on success, false on failure.
      */
     public function delete($path);
 
@@ -164,79 +194,81 @@ interface FilesystemInterface
      *
      * @param string $dirname
      *
-     * @return bool
+     * @throws RootViolationException Thrown if $dirname is empty.
+     *
+     * @return bool True on success, false on failure.
      */
     public function deleteDir($dirname);
 
     /**
      * Create a directory.
      *
-     * @param string $dirname directory name
-     * @param array  $config
+     * @param string $dirname The name of the new directory.
+     * @param array  $config  An optional configuration array.
      *
-     * @return bool
+     * @return bool True on success, false on failure.
      */
     public function createDir($dirname, array $config = []);
 
     /**
      * Set the visibility for a file.
      *
-     * @param string $path
-     * @param string $visibility
+     * @param string $path       The path to the file.
+     * @param string $visibility One of 'public' or 'private'.
      *
-     * @return bool success boolean
+     * @return bool True on success, false on failure.
      */
     public function setVisibility($path, $visibility);
 
     /**
      * Create a file or update if exists.
      *
-     * @param string $path     path to file
-     * @param string $contents file contents
-     * @param array  $config
+     * @param string $path     The path to the file.
+     * @param string $contents The file contents.
+     * @param array  $config   An optional configuration array.
      *
-     * @throws FileExistsException
-     *
-     * @return bool success boolean
+     * @return bool True on success, false on failure.
      */
     public function put($path, $contents, array $config = []);
 
     /**
-     * Create a file or update if exists using a stream.
+     * Create a file or update if exists.
      *
-     * @param string   $path
-     * @param resource $resource
-     * @param array    $config
+     * @param string   $path     The path to the file.
+     * @param resource $resource The file handle.
+     * @param array    $config   An optional configuration array.
      *
-     * @return bool success boolean
+     * @throws InvalidArgumentException Thrown if $resource is not a resource.
+     *
+     * @return bool True on success, false on failure.
      */
     public function putStream($path, $resource, array $config = []);
 
     /**
      * Read and delete a file.
      *
-     * @param string $path
+     * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
      *
-     * @return string|false file contents
+     * @return string|false The file contents, or false on failure.
      */
     public function readAndDelete($path);
 
     /**
      * Get a file/directory handler.
      *
-     * @param string  $path
-     * @param Handler $handler
+     * @param string  $path    The path to the file.
+     * @param Handler $handler An optional existing handler to populate.
      *
-     * @return Handler file or directory handler
+     * @return Handler Either a file or directory handler.
      */
     public function get($path, Handler $handler = null);
 
     /**
      * Register a plugin.
      *
-     * @param PluginInterface $plugin
+     * @param PluginInterface $plugin The plugin to register.
      *
      * @return $this
      */


### PR DESCRIPTION
This moves all of of the docs back into FilesystemInterface from Filesystem where appropriate. It also fixes a bunch of docs that were just wrong, or copy-pasted incorrectly. Lastly, it documents all of the exceptions thrown at the moment.