### PR TITLE
Add force save section to ZipArchive adapter docs

### DIFF
--- a/adapter/zip-archive.md
+++ b/adapter/zip-archive.md
@@ -20,3 +20,11 @@ use League\Flysystem\ZipArchive\ZipArchiveAdapter;
 
 $filesystem = new Filesystem(new ZipArchiveAdapter(__DIR__.'/path/to/archive.zip'));
 ~~~
+
+### Force Save
+
+When creating a new zip file it will only be saved at the end of the PHP request because the ZipArchive library relies on an internal `__destruct` method to be called. You can force the saving of the zip file before the end of the request by called the `close` method on the archive through the adapter.
+
+~~~ php
+$filesystem->getAdapter()->getArchive()->close();
+~~~


### PR DESCRIPTION
Added a section which explains how you can force a newly created zip to be saved before the end of a PHP request.