### PR TITLE
Use stream_copy_to_stream().

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -104,9 +104,7 @@ class Local extends AbstractAdapter
             return false;
         }
 
-        while (! feof($resource)) {
-            fwrite($stream, fread($resource, 1024), 1024);
-        }
+        stream_copy_to_stream($resource, $stream);
 
         if (! fclose($stream)) {
             return false;

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -10,25 +10,17 @@ function fopen($result, $mode)
         return false;
     }
 
-    if (substr($result, -5) === 'dummy') {
-        return fopen('data://text/plain,', $mode);
+    if (substr($result, -10) === 'fail.close') {
+        return \fopen('data://text/plain,fail.close', $mode);
     }
 
     return call_user_func_array('fopen', func_get_args());
 }
 
-function fwrite($result)
-{
-    if (is_string($result)) {
-        return 'dummy';
-    }
-
-    return call_user_func_array('fwrite', func_get_args());
-}
-
 function fclose($result)
 {
-    if (is_resource($result) && stream_get_meta_data($result)['stream_type'] === 'RFC2397') {
+    if (is_resource($result) && stream_get_contents($result) === 'fail.close') {
+        \fclose($result);
         return false;
     }
 
@@ -155,7 +147,7 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
     public function testFailingStreamCalls()
     {
         $this->assertFalse($this->adapter->writeStream('false', tmpfile(), new Config()));
-        $this->assertFalse($this->adapter->writeStream('dummy', tmpfile(), new Config()));
+        $this->assertFalse($this->adapter->writeStream('fail.close', tmpfile(), new Config()));
     }
 
     public function testNullPrefix()

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -4,14 +4,14 @@ namespace League\Flysystem\Adapter;
 
 use League\Flysystem\Config;
 
-function fopen($result)
+function fopen($result, $mode)
 {
     if (substr($result, -5) === 'false') {
         return false;
     }
 
     if (substr($result, -5) === 'dummy') {
-        return 'dummy';
+        return fopen('data://text/plain,', $mode);
     }
 
     return call_user_func_array('fopen', func_get_args());
@@ -28,7 +28,7 @@ function fwrite($result)
 
 function fclose($result)
 {
-    if (is_string($result) and substr($result, -5) === 'dummy') {
+    if (is_resource($result) && stream_get_meta_data($result)['stream_type'] === 'RFC2397') {
         return false;
     }
 


### PR DESCRIPTION
In the Local adapter, we're doing fwrite(fread(..., 1024), 1024). This should use stream_copy_to_stream(). Is there a reason that it's not currently doing this?