### PR TITLE
Remove dependency on mbstring.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "ext-mbstring": "*"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "ext-fileinfo": "*",

--- a/src/Util.php
+++ b/src/Util.php
@@ -142,7 +142,7 @@ class Util
      */
     public static function contentSize($contents)
     {
-        return mb_strlen($contents, '8bit');
+        return defined('MB_OVERLOAD_STRING') ? mb_strlen($contents, '8bit') : strlen($contents);
     }
 
     /**


### PR DESCRIPTION
Sorry to be inundating you with pull requests. Thanks for taking them!

As far as I can tell, the only reason there's a dependency on mbstring is because of the mb_strlen($contents, '8bit') call in Util.

I would prefer just documenting that 'mbstring.func_overload' is unsupported, as it's only for legacy apps, but this would work and be backwards compatible.

Are there other adapters that require mbstring?

We could cache the results of ini_get() as well, but that might be overkill.