### PR TITLE
Increase scrutinizer timeout.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,7 +19,7 @@ checks:
     fix_doc_comments: true
 tools:
   external_code_coverage:
-    timeout: 600
+    timeout: 1200
     runs: 3
   php_code_coverage: false
   php_code_sniffer:


### PR DESCRIPTION
Scrutinizer keeps failing my pull requests. Let's increase the timeout.

I guess we'll see if this is long enough :).