### PR TITLE
Don't use empty() to check directory length in Ftp adapter.

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -303,7 +303,7 @@ class Ftp extends AbstractFtpAdapter
     {
         $connection = $this->getConnection();
 
-        if (empty($path)) {
+        if ($path === '') {
             return ['type' => 'dir', 'path' => ''];
         }
 

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -80,6 +80,10 @@ function ftp_chdir($connection, $directory)
         return false;
     }
 
+    if ($directory === '0') {
+        return false;
+    }
+
     return true;
 }
 
@@ -122,6 +126,12 @@ function ftp_rawlist($connection, $directory)
     if (strpos($directory, 'file1.txt') !== false) {
         return [
             '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01 file1.txt',
+        ];
+    }
+
+    if ($directory === '0') {
+        return [
+            '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01 0',
         ];
     }
 
@@ -305,6 +315,18 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $metadata);
         $this->assertEquals('file', $metadata['type']);
         $this->assertEquals('file1.txt', $metadata['path']);
+    }
+
+    /**
+     * @depends testInstantiable
+     */
+    public function testGetMetadataForRootFileNamedZero()
+    {
+        $adapter = new Ftp($this->options);
+        $metadata = $adapter->getMetadata('0');
+        $this->assertInternalType('array', $metadata);
+        $this->assertEquals('file', $metadata['type']);
+        $this->assertEquals('0', $metadata['path']);
     }
 
     /**


### PR DESCRIPTION
The patch should be self explanatory. The test case illustrates the problem. I'm not sure if the test case is necessary, but there it is.