### PR TITLE
Don't depend on fclose() of temp stream for return value to write() in Ftp adapter.

### DIFF
--- a/src/Adapter/NullAdapter.php
+++ b/src/Adapter/NullAdapter.php
@@ -5,7 +5,6 @@ namespace League\Flysystem\Adapter;
 use League\Flysystem\Adapter\Polyfill\StreamedCopyTrait;
 use League\Flysystem\Adapter\Polyfill\StreamedTrait;
 use League\Flysystem\Config;
-use League\Flysystem\Util;
 
 class NullAdapter extends AbstractAdapter
 {
@@ -30,7 +29,6 @@ class NullAdapter extends AbstractAdapter
     public function write($path, $contents, Config $config)
     {
         $type = 'file';
-        $config = Util::ensureConfig($config);
         $result = compact('contents', 'type', 'size', 'path');
 
         if ($visibility = $config->get('visibility')) {

--- a/tests/UtilMimeTests.php
+++ b/tests/UtilMimeTests.php
@@ -24,4 +24,9 @@ class UtilMimeTests extends \PHPUnit_Framework_TestCase
         $this->assertNull(MimeType::detectByContent('string'));
         $passthru = true;
     }
+
+    public function testNoExtension()
+    {
+        $this->assertNull(MimeType::detectByFileExtension(''));
+    }
 }


### PR DESCRIPTION
A few things are happening here.
- The return value of fclose() in Ftp::write() shouldn't affect the return value of the call. Even if we can't close our temp file, the write was still successful.
- I changed tmpfil() to a temp stream, since that will keep up to 2MB in memory, and the $contents is already in memory anyway.
- Removed the setVisibility() call in write() since writeStream() calls it anyway. No need to make the request twice.
- Removed some stray calls to Util::ensureConfig() that aren't necessary since the type hint doesn't accept null. I did a quick search, and found one in NullAdapter as well.
- Moved the mime-type guessing to the end, no reason to do it if the call fails.

If you think any of these are wrong, or should be done in a follow up, let me know and I'll gladly break it up.