### PR TITLE
Optimize put() and putStream() to call has() only once.

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -105,12 +105,13 @@ class Filesystem implements FilesystemInterface
     public function put($path, $contents, array $config = [])
     {
         $path = Util::normalizePath($path);
+        $config = $this->prepareConfig($config);
 
         if ($this->has($path)) {
-            return $this->update($path, $contents, $config);
+            return (bool) $this->getAdapter()->update($path, $contents, $config);
         }
 
-        return $this->write($path, $contents, $config);
+        return (bool) $this->getAdapter()->write($path, $contents, $config);
     }
 
     /**
@@ -118,13 +119,19 @@ class Filesystem implements FilesystemInterface
      */
     public function putStream($path, $resource, array $config = [])
     {
-        $path = Util::normalizePath($path);
-
-        if ($this->has($path)) {
-            return $this->updateStream($path, $resource, $config);
+        if (! is_resource($resource)) {
+            throw new InvalidArgumentException(__METHOD__.' expects argument #2 to be a valid resource.');
         }
 
-        return $this->writeStream($path, $resource, $config);
+        $path = Util::normalizePath($path);
+        $config = $this->prepareConfig($config);
+        Util::rewindStream($resource);
+
+        if ($this->has($path)) {
+            return (bool) $this->getAdapter()->updateStream($path, $resource, $config);
+        }
+
+        return (bool) $this->getAdapter()->writeStream($path, $resource, $config);
     }
 
     /**

--- a/tests/FilesystemTests.php
+++ b/tests/FilesystemTests.php
@@ -133,6 +133,12 @@ class FilesystemTests extends ProphecyTestCase
         fclose($stream);
     }
 
+    public function testPutStreamInvalid()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $this->filesystem->putStream('path.txt', '__INVALID__');
+    }
+
     public function testWriteStreamInvalid()
     {
         $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
`Filesystem::put()` and `Filesystem::putStream()` both call `Filesystem::has()` and then the appropriate `write()` or `update()` call. This duplicates calls to `has()` in the `assertPresent()` or `assertAbsent()` calls. For a minor amount of code duplication, we can save a whole round trip to the filesystem.