### PR TITLE
Allow for absolute paths to be used.

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -45,6 +45,24 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
+     * Determine if the path contains the prefix.
+     *
+     * @param string  $path
+     *
+     * @return boolean
+     */
+    public function hasPathPrefix($path)
+    {
+        $pathPrefix = $this->getPathPrefix();
+
+        if ($pathPrefix === null) {
+            return true;
+        }
+
+        return substr($path, 0, strlen($pathPrefix)) === $pathPrefix;
+    }
+
+    /**
      * Prefix a path.
      *
      * @param string $path
@@ -53,6 +71,10 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function applyPathPrefix($path)
     {
+        if ($this->hasPathPrefix($path)) {
+            return $path;
+        }
+
         $path = ltrim($path, '\\/');
 
         if (strlen($path) === 0) {
@@ -75,6 +97,10 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function removePathPrefix($path)
     {
+        if (!$this->hasPathPrefix($path)) {
+            return $path;
+        }
+
         $pathPrefix = $this->getPathPrefix();
 
         if ($pathPrefix === null) {

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -271,6 +271,27 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->adapter->applyPathPrefix(''));
     }
 
+    public function testApplyPathPrefixToAbsolute()
+    {
+        $this->adapter->setPathPrefix('/foo');
+        $this->assertEquals('/foo/bar', $this->adapter->applyPathPrefix('/foo/bar'));
+    }
+
+    public function testRemovePathPrefix()
+    {
+        $this->adapter->setPathPrefix('/foo');
+        $this->assertEquals('/baz/bar', $this->adapter->removePathPrefix('/baz/bar'));
+        $this->assertEquals('bar', $this->adapter->removePathPrefix('/foo/bar'));
+    }
+
+    public function testHasPathPrefix()
+    {
+        $this->adapter->setPathPrefix('/foo');
+        $this->assertTrue($this->adapter->hasPathPrefix('/foo/bar'));
+        $this->assertFalse($this->adapter->hasPathPrefix('/baz/bar'));
+        $this->assertFalse($this->adapter->hasPathPrefix('foo/bar'));
+    }
+
     public function testConstructorWithLink()
     {
         $target = __DIR__.'/files/';


### PR DESCRIPTION
This PR does two things:
1 - Fixes the `League\Flysystem\Adapter\AbstractAdapter@removePathPrefix` method. Previously if you passed a path that did not actually contain the prefix then it would just strip the length of the prefix from the beginning of the path. In order to accomplish this the method `hasPathPrefix` was added.
2 - Allows the `League\Flysystem\Adapter\AbstractAdapter@applyPathPrefix` to accept absolute paths. This also employs the new `hasPathPrefix` method to check if it already has the prefix so that it doesn't add it again.
Below I have included an example of something I was working on today which made it somewhat hacky to get an absolute path from a Faker method and pipe it into a Filesystem method (this is in a Laravel seeder).
```php
$this->files->move($this->files->getDriver()->getAdapter()->removePathPrefix($faker->image($avatarDir)), $this->files->getDriver()->getAdapter()->removePathPrefix($avatarDir) . '/' . $user->id . '.jpg');
```
As you can see I have to get the driver from Laravel, then get the adapter from Flysystem and then finally call `removePathPrefix` (which I found out wasn't even checking if it had the prefix already). I then have to do it again on the directory path I got from the config. This is quite a lot to try to do something simple. Below is how it would look after this PR.
```php
$this->files->move($faker->image($avatarDir), $avatarDir . '/' . $user->id . '.jpg');
```
The move method will try to add the prefix, but will skip it once detecting that it's already there. This is much cleaner and what I expected the functionality to be.