### PR TITLE
NotSupportingVisibilityTrait should not throw exceptions.

### DIFF
--- a/src/Adapter/Polyfill/NotSupportingVisibilityTrait.php
+++ b/src/Adapter/Polyfill/NotSupportingVisibilityTrait.php
@@ -2,7 +2,7 @@
 
 namespace League\Flysystem\Adapter\Polyfill;
 
-use LogicException;
+use League\Flysystem\AdapterInterface;
 
 trait NotSupportingVisibilityTrait
 {
@@ -10,12 +10,10 @@ trait NotSupportingVisibilityTrait
      * Get the visibility of a file.
      *
      * @param string $path
-     *
-     * @throws LogicException
      */
     public function getVisibility($path)
     {
-        throw new LogicException(get_class($this).' does not support visibility. Path: '.$path);
+        return ['visibility' => AdapterInterface::VISIBILITY_PUBLIC];
     }
 
     /**
@@ -23,11 +21,13 @@ trait NotSupportingVisibilityTrait
      *
      * @param string $path
      * @param string $visibility
-     *
-     * @throws LogicException
      */
     public function setVisibility($path, $visibility)
     {
-        throw new LogicException(get_class($this).' does not support visibility. Path: '.$path.', visibility: '.$visibility);
+        if ($visibility === AdapterInterface::VISIBILITY_PUBLIC) {
+            return ['visibility' => AdapterInterface::VISIBILITY_PUBLIC];
+        }
+
+        return false;
     }
 }

--- a/tests/NotSupportingVisivilityTests.php
+++ b/tests/NotSupportingVisivilityTests.php
@@ -2,21 +2,26 @@
 
 namespace League\Flysystem\Adapter;
 
+use League\Flysystem\AdapterInterface;
 use League\Flysystem\Stub\NotSupportingVisibilityStub;
 
 class NotSupportingVisivilityTests extends \PHPUnit_Framework_TestCase
 {
     public function testGetVisibility()
     {
-        $this->setExpectedException('LogicException');
         $stub = new NotSupportingVisibilityStub();
-        $stub->getVisibility('path.txt');
+        $result = $stub->getVisibility('path.txt');
+        $this->assertSame(['visibility' => AdapterInterface::VISIBILITY_PUBLIC], $result);
     }
 
     public function testSetVisibility()
     {
-        $this->setExpectedException('LogicException');
         $stub = new NotSupportingVisibilityStub();
-        $stub->setVisibility('path.txt', 'public');
+
+        $result = $stub->setVisibility('path.txt', AdapterInterface::VISIBILITY_PUBLIC);
+        $this->assertSame(['visibility' => AdapterInterface::VISIBILITY_PUBLIC], $result);
+
+        // Setting to private is un-supported.
+        $this->assertFalse($stub->setVisibility('path.txt', AdapterInterface::VISIBILITY_PRIVATE));
     }
 }


### PR DESCRIPTION
This might be considered an API break, while it shouldn't break any existing code, it could break someone's tests.

The fact that `NotSupportingVisibilityTrait` throws exceptions makes things more difficult to work with than necessary. For one, it's not documented on the AdapterInterface that it's possible to throw an exception. 
Another is that it ruins the abstraction of the API. To code for all adapters, I have to catch this exception, but this isn't exceptional behavior. Does this logic extend to all methods on the AdapterInterface? Theoretically, I would have to defend against a LogicException with every method call.

LogicExceptions imply that I have to change my code, but to keep it adapter agnostic, I can't.

I think a better approach is to treat all files as public. We just assume that if there's no visibility setting, then it's always public.