### PR TITLE
Allow retrieving the Filesystem from the Handler.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## 1.0.5 - UNRELEASED
 
 * [Filesystem::listContent] Emulated directories didn't respect the natural sorting, this is now corrected in the listContents method.
+* [Handler] Added getter for the Filesystem.
 
 ## 1.0.4 - 2015-06-07
 

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -71,6 +71,16 @@ abstract class Handler
 
         return $this;
     }
+    
+    /**
+     * Retrieve the Filesystem object.
+     *
+     * @return FilesystemInterface
+     */
+    public function getFilesystem()
+    {
+        return $this->filesystem;
+    }
 
     /**
      * Set the entree path.

--- a/tests/HandlerTests.php
+++ b/tests/HandlerTests.php
@@ -141,4 +141,13 @@ class HandlerTests extends ProphecyTestCase
         $output = $dir->getContents(true);
         $this->assertEquals($listing, $output);
     }
+
+    public function testGetFilesystem()
+    {
+        $prophecy = $this->prophesize('League\Flysystem\FilesystemInterface');
+        $filesystem = $prophecy->reveal();
+        $dir = new Directory(null, 'path');
+        $dir->setFilesystem($filesystem);
+        $this->assertEquals($filesystem, $dir->getFilesystem());
+    }
 }


### PR DESCRIPTION
This is an absolute must for any project approaching complex!

Here's one particular issue I ran into: https://github.com/anomalylabs/files-module/blob/master/src/Adapter/AdapterFilesystem.php#L193

That class wraps the Filesystem class ONLY to keep a database in sync. The disk MUST be set on the Filesystem because there are different disks (Laravel disks) using different adapters and I need to know if file1 is on disk A or B for instance when I sync. 

The problem here is that now that I have a hard dependency on the disk (in construct) I have a hard dependency on the Filesystem. And when copying or moving from the mount manager - there very well may be a different source Filesystem. Sure, I could resolve it from the path, but it makes a ton more sense having it on the Handle. OOP FTW!

Thanks for considering!