### PR TITLE
Distinguish between file and directory permissions in the local adapter

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -16,8 +16,14 @@ use SplFileInfo;
 class Local extends AbstractAdapter
 {
     protected static $permissions = [
-        'public' => 0744,
-        'private' => 0700,
+        'file' => [
+            'public' => 0744,
+            'private' => 0700,
+        ],
+        'dir' => [
+            'public' => 0755,
+            'private' => 0700,
+        ]
     ];
 
     /**
@@ -59,7 +65,7 @@ class Local extends AbstractAdapter
     {
         if (! is_dir($root)) {
             $umask = umask(0);
-            mkdir($root, 0777, true);
+            mkdir($root, static::$permissions['dir']['public'], true);
             umask($umask);
         }
 
@@ -294,7 +300,8 @@ class Local extends AbstractAdapter
     public function setVisibility($path, $visibility)
     {
         $location = $this->applyPathPrefix($path);
-        chmod($location, static::$permissions[$visibility]);
+        $type = is_dir($location) ? 'dir' : 'file';
+        chmod($location, static::$permissions[$type][$visibility]);
 
         return compact('visibility');
     }
@@ -306,8 +313,9 @@ class Local extends AbstractAdapter
     {
         $location = $this->applyPathPrefix($dirname);
         $umask = umask(0);
+        $visibility = $config->get('visibility', 'public');
 
-        if (! is_dir($location) && ! mkdir($location, 0777, true)) {
+        if (! is_dir($location) && ! mkdir($location, static::$permissions['dir'][$visibility], true)) {
             $return = false;
         } else {
             $return = ['path' => $dirname, 'type' => 'dir'];

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -228,6 +228,15 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->createDir('fail.plz', new Config()));
     }
 
+    public function testCreateDirDefaultVisibility()
+    {
+        $this->adapter->createDir('test-dir', new Config());
+        $output = $this->adapter->getVisibility('test-dir');
+        $this->assertInternalType('array', $output);
+        $this->assertArrayHasKey('visibility', $output);
+        $this->assertEquals('public', $output['visibility']);
+    }
+
     public function testDeleteDir()
     {
         $this->adapter->write('nested/dir/path.txt', 'contents', new Config());
@@ -237,7 +246,7 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->assertFalse(is_dir(__DIR__.'/files/nested/dir'));
     }
 
-    public function testVisibilityPublic()
+    public function testVisibilityPublicFile()
     {
         if (IS_WINDOWS) {
             $this->markTestSkipped("Visibility not supported on Windows.");
@@ -251,7 +260,21 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('public', $output['visibility']);
     }
 
-    public function testVisibilityPrivate()
+    public function testVisibilityPublicDir()
+    {
+        if (IS_WINDOWS) {
+            $this->markTestSkipped("Visibility not supported on Windows.");
+        }
+
+        $this->adapter->createDir('public-dir', new Config());
+        $this->adapter->setVisibility('public-dir', 'public');
+        $output = $this->adapter->getVisibility('public-dir');
+        $this->assertInternalType('array', $output);
+        $this->assertArrayHasKey('visibility', $output);
+        $this->assertEquals('public', $output['visibility']);
+    }
+
+    public function testVisibilityPrivateFile()
     {
         if (IS_WINDOWS) {
             $this->markTestSkipped("Visibility not supported on Windows.");
@@ -260,6 +283,20 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->adapter->write('path.txt', 'contents', new Config());
         $this->adapter->setVisibility('path.txt', 'private');
         $output = $this->adapter->getVisibility('path.txt');
+        $this->assertInternalType('array', $output);
+        $this->assertArrayHasKey('visibility', $output);
+        $this->assertEquals('private', $output['visibility']);
+    }
+
+    public function testVisibilityPrivateDir()
+    {
+        if (IS_WINDOWS) {
+            $this->markTestSkipped("Visibility not supported on Windows.");
+        }
+
+        $this->adapter->createDir('private-dir', new Config());
+        $this->adapter->setVisibility('private-dir', 'private');
+        $output = $this->adapter->getVisibility('private-dir');
         $this->assertInternalType('array', $output);
         $this->assertArrayHasKey('visibility', $output);
         $this->assertEquals('private', $output['visibility']);


### PR DESCRIPTION
Closes #522.

This implements the permissions `0755` (public) and `0700` (private) for directories in contrast to `0744` and `0700` for files. Previously, files and directories were treated the same but `0744` is useless for directories.

Also, this sets `0755` instead of the insecure `0777` as default permissions for all newly created directories (including the root directory). 