### PR TITLE
Fix listContents().

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -403,7 +403,7 @@ class Local extends AbstractAdapter
         $path = $file->getPathname();
         $path = $this->removePathPrefix($path);
 
-        return trim($path, '\\/');
+        return trim(str_replace('\\', '/', $path), '/');
     }
 
     /**

--- a/tests/FilesystemTests.php
+++ b/tests/FilesystemTests.php
@@ -377,7 +377,42 @@ class FilesystemTests extends ProphecyTestCase
         ];
         $this->prophecy->listContents('', false)->willReturn($rawListing);
         $output = $this->filesystem->listContents('', false);
-        $this->assertCount(4, $output);
+        $this->assertCount(2, $output);
+    }
+
+    public function testListContentsRecursize()
+    {
+        $rawListing = [
+           ['path' => 'other_root/file.txt'],
+           ['path' => 'valid/to_deep/file.txt'],
+           ['path' => 'valid/file.txt'],
+           ['path' => 'valid/a-valid-file.txt'],
+        ];
+        $expected = [
+            Util::pathinfo('valid/a-valid-file.txt'),
+            Util::pathinfo('valid/file.txt'),
+            Util::pathinfo('valid/to_deep/file.txt'),
+        ];
+        $this->prophecy->listContents('valid', true)->willReturn($rawListing);
+        $output = $this->filesystem->listContents('valid', true);
+        $this->assertEquals($expected, $output);
+
+        $expected = [
+            Util::pathinfo('other_root/file.txt'),
+            Util::pathinfo('valid/a-valid-file.txt'),
+            Util::pathinfo('valid/file.txt'),
+            Util::pathinfo('valid/to_deep/file.txt'),
+        ];
+        $this->prophecy->listContents('', true)->willReturn($rawListing);
+        $output = $this->filesystem->listContents('', true);
+        $this->assertEquals($expected, $output);
+    }
+    public function testListContentsSubDirectoryMatches()
+    {
+        $rawListing = [['path' => 'a/dir/file.txt']];
+        $this->prophecy->listContents('dir', true)->willReturn($rawListing);
+        $output = $this->filesystem->listContents('dir', true);
+        $this->assertEquals([], $output);
     }
 
     public function testInvalidPluginCall()


### PR DESCRIPTION
I imagine this issue is getting pretty old, my apologies.

First off, checking for the Local adapter in Filesystem is not nice. The part of this patch that changes that needs to be discussed. I'm replacing back slashes with forward slashes. This is not technically correct, since Linux file names can have backslashes in them, but at some point we're going to have to decide what a valid file path can be. I had actually assumed that `Util::normalizePath()` already did this.

Other bugs fixed:
- Treating the int 0 as a string. (This is debatable, but I think a zero int is much closer to false than a string) This also avoids calling strlen() on every path.
- When a sub-directory matches. I.e. listContents('dir') returns 'a/dir/file.
- Fixed test coverage. The big || list was hiding missing test coverage.

Overall, the logic was very hard to follow.