### PR TITLE
Unlink links to directories

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -363,10 +363,15 @@ class Local extends AbstractAdapter
 
         /** @var SplFileInfo $file */
         foreach ($contents as $file) {
-            if ($file->getType() !== 'dir') {
-                unlink($file->getRealPath());
-            } else {
-                rmdir($file->getRealPath());
+            switch ($file->getType()) {
+                case 'dir':
+                    rmdir($file->getRealPath());
+                    break;
+                case 'link':
+                    unlink($file->getPathname());
+                    break;
+                default:
+                    unlink($file->getRealPath());
             }
         }
 


### PR DESCRIPTION
When implementing a cleanup method I noticed that directories that linked to external resources where not cleared by `Local::deleteDir()` method. This commit fixes that particular problem (target directories are not deleted, only links are removed).