### PR TITLE
fix negative filesizes on 32-bit systems

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -326,7 +326,7 @@ class Filesystem implements FilesystemInterface
             return false;
         }
 
-        return (int) $object['size'];
+        return (float) $object['size'];
     }
 
     /**

--- a/tests/FileTests.php
+++ b/tests/FileTests.php
@@ -222,6 +222,25 @@ class FileTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals($size, $file->getSize());
     }
 
+    public function testLargeFilesize()
+    {
+        $adapter = $this->getMock('League\Flysystem\AdapterInterface');
+        $adapter
+            ->expects($this->once())
+            ->method('getSize')
+            ->with('large.txt')
+            ->willReturn(array (
+                'type' => 'file',
+                'path' => 'file.txt',
+                'timestamp' => 12345678,
+                'size' => (float)3116473263,
+            ));
+        $filesystem = new Filesystem($adapter);
+        /** @var File $file */
+        $size = $filesystem->getSize('large.txt');
+        $this->assertEquals((float)3116473263, $size);
+    }
+
     public function testDelete()
     {
         $file = $this->getFile();


### PR DESCRIPTION
on 32-bit systems the `(int)` cast will return negative file sizes for a file with more that 2gb.

    pi@odroid-server:~$ file /usr/bin/file
    /usr/bin/file: ELF 32-bit LSB  executable, ARM, EABI5 version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 2.6.32, BuildID[sha1]=f8aff96d2e3830bde0d9296568c4d160f50d8378, stripped

the attached test fails with

    1) League\Flysystem\FileTests::testLargeFilesize
    Failed asserting that -1178494033 matches expected 3116473263.