### PR TITLE
Fix Util::pathinfo assuming dirname always exists

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -17,7 +17,12 @@ class Util
     public static function pathinfo($path)
     {
         $pathinfo = pathinfo($path) + compact('path');
-        $pathinfo['dirname'] = static::normalizeDirname($pathinfo['dirname']);
+
+        if (!array_key_exists('dirname', $pathinfo)) {
+            $pathinfo['dirname'] = '';
+        } else {
+            $pathinfo['dirname'] = static::normalizeDirname($pathinfo['dirname']);
+        }
 
         return $pathinfo;
     }


### PR DESCRIPTION
Even though the PHP documentation states that `pathinfo()` will always
return an associative array with certain keys, for certain values
`pathinfo()` returns a sparser array.

E.g. `pathinfo(false)` and `pathinfo('')` return an array with only
'basename' and 'filename' keys on php 5.6.12 and php 5.5.9, possibly
others.