### PR TITLE
Change readme.md to README.md in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,4 +13,4 @@
 /phpunit.xml export-ignore
 /phpunit.hhvm.xml export-ignore
 /changelog.md export-ignore
-/readme.md export-ignore
+/README.md export-ignore


### PR DESCRIPTION
`.gitattributes` is case sensitive, so `readme.md` does not work, the file is still included with a `composer install`.