### PR TITLE
Added link to Litipk's Fallback adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Want to get started quickly? Check out some of these integrations:
 * PHPCR: https://github.com/thephpleague/flysystem-phpcr
 * Azure Blob Storage
 * NullAdapter
+* Fallback: https://github.com/Litipk/flysystem-fallback-adapter
 
 ## Caching
 


### PR DESCRIPTION
The linked adapter has'nt a high testing coverage yet, but it's in progress. The idea of the adapter is to use the main adapter whenever is possible, and only using the fallback adapter when it's impossible to find a file using the main one.