### PR TITLE
Fixed links to anchor tags

### DIFF
--- a/core-concepts.md
+++ b/core-concepts.md
@@ -11,9 +11,9 @@ the way it does, several concepts require some explanation.
 
 ## Overview
 
-* [Adapters](./#adapters)
-* [Relative Paths](./#relative-paths)
-* [Files first](./#files-first)
+* [Adapters](#adapters)
+* [Relative Paths](#relative-paths)
+* [Files first](#files-first)
 
 ## Adapters
 


### PR DESCRIPTION
### Fixed

- Links to anchor tags

--
On this page, the links to the anchor tags are broken: http://flysystem.thephpleague.com/core-concepts/