### PR TITLE
Ftp Adapter bug fix

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -307,15 +307,18 @@ class Ftp extends AbstractFtpAdapter
         // List the current directory
         $listing = ftp_nlist($connection, '.');
 
-        foreach ($listing as $key => $item) {
-            if (preg_match('~^\./.*~', $item)) {
-                $listing[$key] = substr($item, 2);
+        if( is_array( $listing ) )
+        {         
+            foreach ($listing as $key => $item) {
+                if (preg_match('~^\./.*~', $item)) {
+                    $listing[$key] = substr($item, 2);
+                }
             }
-        }
 
-        if (in_array($directory, $listing)) {
-            return true;
-        }
+            if (in_array($directory, $listing)) {
+                return true;
+            }
+        }    
 
         return (boolean) ftp_mkdir($connection, $directory);
     }

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -305,20 +305,17 @@ class Ftp extends AbstractFtpAdapter
     protected function createActualDirectory($directory, $connection)
     {
         // List the current directory
-        $listing = ftp_nlist($connection, '.');
-
-        if( is_array( $listing ) )
-        {         
-            foreach ($listing as $key => $item) {
-                if (preg_match('~^\./.*~', $item)) {
-                    $listing[$key] = substr($item, 2);
-                }
+        $listing = ftp_nlist($connection, '.') ?: [];
+        
+        foreach ($listing as $key => $item) {
+            if (preg_match('~^\./.*~', $item)) {
+                $listing[$key] = substr($item, 2);
             }
+        }
 
-            if (in_array($directory, $listing)) {
-                return true;
-            }
-        }    
+        if (in_array($directory, $listing)) {
+            return true;
+        }
 
         return (boolean) ftp_mkdir($connection, $directory);
     }


### PR DESCRIPTION
In function createActualDirectory ( class FTP ) in FTP.php file is bug. There is a listing of directories with php function ftp_nlist and after that we iterate them. But when ftp_nlist goes to directory that it need to be created recursively it returning false and for-each statement is falling.