### PR TITLE
drop dep on deprecated prophecy-phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,9 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "~4.8 || ~5.0",
         "mockery/mockery": "~0.9",
-        "phpspec/phpspec": "^2.2",
-        "phpspec/prophecy-phpunit": "~1.0"
+        "phpspec/phpspec": "^2.2"
     },
     "autoload": {
         "psr-4": {

--- a/tests/FilesystemTests.php
+++ b/tests/FilesystemTests.php
@@ -4,10 +4,9 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\Util;
 use Prophecy\Argument;
 use Prophecy\Argument\Token\TypeToken;
-use Prophecy\PhpUnit\ProphecyTestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 
-class FilesystemTests extends ProphecyTestCase
+class FilesystemTests extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var ObjectProphecy

--- a/tests/GetWithMetadataTests.php
+++ b/tests/GetWithMetadataTests.php
@@ -2,10 +2,9 @@
 
 
 use League\Flysystem\Plugin\GetWithMetadata;
-use Prophecy\PhpUnit\ProphecyTestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 
-class GetWithMetadataTests extends ProphecyTestCase
+class GetWithMetadataTests extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var ObjectProphecy

--- a/tests/HandlerTests.php
+++ b/tests/HandlerTests.php
@@ -3,9 +3,8 @@
 
 use League\Flysystem\Directory;
 use League\Flysystem\File;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class HandlerTests extends ProphecyTestCase
+class HandlerTests extends \PHPUnit_Framework_TestCase
 {
     public function testFileRead()
     {

--- a/tests/ListFilesTests.php
+++ b/tests/ListFilesTests.php
@@ -2,9 +2,8 @@
 
 
 use League\Flysystem\Plugin\ListFiles;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class ListFilesTests extends ProphecyTestCase
+class ListFilesTests extends \PHPUnit_Framework_TestCase
 {
     private $filesystem;
     private $actualFilesystem;

--- a/tests/ListPathsTests.php
+++ b/tests/ListPathsTests.php
@@ -2,9 +2,8 @@
 
 
 use League\Flysystem\Plugin\ListPaths;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class ListPathsTests extends ProphecyTestCase
+class ListPathsTests extends \PHPUnit_Framework_TestCase
 {
     private $filesystem;
     private $actualFilesystem;

--- a/tests/ListWithTests.php
+++ b/tests/ListWithTests.php
@@ -3,9 +3,8 @@
 namespace League\Flysystem\Adapter;
 
 use League\Flysystem\Plugin\ListWith;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class ListWithTests extends ProphecyTestCase
+class ListWithTests extends \PHPUnit_Framework_TestCase
 {
     public function testHandle()
     {


### PR DESCRIPTION
Prophecy test cases are supported by PHPUnit since version 4.5.
So phpspec/prophecy-phpunit is deprecated and unneeded.

Also allow PHPUnit 5 (tested with PHPUnit 5.1.4, PHP 5.6.17 and 7.0.2)
