### PR TITLE
add link to google cloud storage adapter in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Want to get started quickly? Check out some of these integrations:
 * Redis (through Predis): https://github.com/danhunsaker/flysystem-redis
 * Fallback: https://github.com/Litipk/flysystem-fallback-adapter
 * Memory: https://github.com/thephpleague/flysystem-memory
+* Google Cloud Storage: https://github.com/Superbalist/flysystem-google-storage
 
 ## Caching
 


### PR DESCRIPTION
We needed to have both AWS V3 and Google Storage adapters in place simultaneously, so the V2 driver was not an option as a work-around. - see https://github.com/thephpleague/flysystem/issues/448