### PR TITLE
remove size from write method in null adapter

### DIFF
--- a/src/Adapter/NullAdapter.php
+++ b/src/Adapter/NullAdapter.php
@@ -29,7 +29,7 @@ class NullAdapter extends AbstractAdapter
     public function write($path, $contents, Config $config)
     {
         $type = 'file';
-        $result = compact('contents', 'type', 'size', 'path');
+        $result = compact('contents', 'type', 'path');
 
         if ($visibility = $config->get('visibility')) {
             $result['visibility'] = $visibility;


### PR DESCRIPTION
There is no variable size so compact can't return it