### PR TITLE
Fix getMetadata in FTP adapter for hidden files in unix systems

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -337,7 +337,7 @@ class Ftp extends AbstractFtpAdapter
             return ['type' => 'dir', 'path' => $path];
         }
 
-        $listing = ftp_rawlist($connection, str_replace('*', '\\*', $path));
+        $listing = ftp_rawlist($connection, '-A' . ' ' . str_replace('*', '\\*', $path));
 
         if (empty($listing)) {
             return false;

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -145,6 +145,8 @@ function ftp_raw($connection, $command)
 
 function ftp_rawlist($connection, $directory)
 {
+    $directory = str_replace("-A ", "", $directory);
+    
     if (strpos($directory, 'fail.rawlist') !== false) {
         return false;
     }


### PR DESCRIPTION
Hi!

With adapter for FTP, when you list a directory, it will return hidden files correctly. But when you try check if exists (with has method) or get its content or, definitely, you use a method that uses the method getMetadata then doesn't work.

This resolves #601 