### PR TITLE
Quick and dirty fix for Util::guessMimeType(). Fixed #607

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -155,7 +155,7 @@ class Util
     {
         $mimeType = MimeType::detectByContent($content);
 
-        if (empty($mimeType) || in_array($mimeType, ['text/plain', 'application/x-empty'])) {
+        if (empty($mimeType) || in_array($mimeType, self::getUnreliableMimeTypes())) {
             $extension = pathinfo($path, PATHINFO_EXTENSION);
 
             if ($extension) {
@@ -252,6 +252,19 @@ class Util
         $stat = fstat($resource);
 
         return $stat['size'];
+    }
+
+
+    /**
+     * @return array
+     */
+    protected static function getUnreliableMimeTypes()
+    {
+        return [
+            'application/x-empty',
+            'text/plain',
+            'text/x-asm'
+        ];
     }
 
     /**

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -120,6 +120,7 @@ class UtilTests extends \PHPUnit_Framework_TestCase
     public function pathAndContentProvider()
     {
         return [
+            ['/some/file.css', '.event { background: #000; } ', 'text/css'],
             ['/some/file.css', 'body { background: #000; } ', 'text/css'],
             ['/some/file.txt', 'body { background: #000; } ', 'text/plain'],
             ['/1x1', base64_decode('R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='), 'image/gif'],


### PR DESCRIPTION
This fixes the mime type guessing [issue](https://github.com/thephpleague/flysystem/issues/607). Apparently Finfo cannot be trusted. 