### PR TITLE
Add Gaufrette Adapter to list of Adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Want to get started quickly? Check out some of these integrations:
 * Memory: https://github.com/thephpleague/flysystem-memory
 * Google Cloud Storage: https://github.com/Superbalist/flysystem-google-storage
 * SinaAppEngine Storage: https://github.com/litp/flysystem-sae-storage
+* Gaufrette: https://github.com/jenkoian/flysystem-gaufrette
 
 ## Caching
 


### PR DESCRIPTION
Gaufrette recently added a flysystem adapter (https://github.com/KnpLabs/Gaufrette/pull/390) so I've created an adapter going in the other direction to simply reciprocate the love (plus I think it can be useful). 

https://github.com/jenkoian/flysystem-gaufrette