### PR TITLE
Bugfix "Undefined offset: 8" in some unix FTPs

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -347,6 +347,10 @@ class Ftp extends AbstractFtpAdapter
             return false;
         }
 
+        if (preg_match('/^total [0-9]*$/', $listing[0])) {
+            array_shift($listing);
+        }
+
         return $this->normalizeObject($listing[0], '');
     }
 

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -106,7 +106,7 @@ function ftp_chdir($connection, $directory)
         return false;
     }
 
-    if (in_array($directory, ['file1.txt', 'file2.txt', 'dir1'])) {
+    if (in_array($directory, ['file1.txt', 'file2.txt', 'dir1', 'file1.with-total-line.txt'])) {
         return false;
     }
 
@@ -208,6 +208,13 @@ function ftp_rawlist($connection, $directory)
             'drwxr-xr-x   4 ftp      ftp          4096 Feb  6 13:58 ..',
             '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01  file1.txt',
 
+        ];
+    }
+
+    if (strpos($directory, 'file1.with-total-line.txt') !== false) {
+        return [
+            'total 0',
+            '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01 file1.txt',
         ];
     }
 
@@ -410,6 +417,16 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $metadata);
         $this->assertEquals('file', $metadata['type']);
         $this->assertEquals('0', $metadata['path']);
+    }
+
+    /**
+     * @depends testInstantiable
+     */
+    public function testGetMetadataIgnoresInvalidTotalLine()
+    {
+        $adapter = new Ftp($this->options);
+        $metadata = $adapter->getMetadata('file1.with-total-line.txt');
+        $this->assertEquals('file1.txt', $metadata['path']);
     }
 
     /**


### PR DESCRIPTION
Some FTP return "total 0" line as the first item of the `ftp_rawlist`. If this is the case the array is shifted so the actual line is used

As one can see in this picture from a client's FTP:
<img width="746" alt="screen shot 2016-03-09 at 12 02 00 pm" src="https://cloud.githubusercontent.com/assets/535862/13643645/dd268276-e5ef-11e5-93ca-5382b2f7d694.png">

Otherwise the following error is thrown:
`PHP error:  Undefined offset: 8 in myrepo/vendor/league/flysystem/src/Adapter/AbstractFtpAdapter.php on line 398`

This is related to [#229](https://github.com/thephpleague/flysystem/issues/229)