### PR TITLE
Allow finding MIME types by extension only

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -148,14 +148,18 @@ class Util
     /**
      * Guess MIME Type based on the path of the file and it's content.
      *
-     * @param string $path
-     * @param string $content
+     * @param string      $path    The path of the file.
+     * @param string|NULL $content The content of the file, or NULl to only use
+     *                             the file name.
      *
      * @return string|null MIME Type or NULL if no extension detected
      */
-    public static function guessMimeType($path, $content)
+    public static function guessMimeType($path, $content = NULL)
     {
-        $mimeType = MimeType::detectByContent($content);
+        $mimeType = NULL;
+        if ($content) {
+            $mimeType = MimeType::detectByContent($content);
+        }
 
         if (empty($mimeType) || in_array($mimeType, ['application/x-empty', 'text/plain', 'text/x-asm'])) {
             $extension = pathinfo($path, PATHINFO_EXTENSION);


### PR DESCRIPTION
When using the S3 adapter, images are uploaded without a MIME type, causing S3 to serve them with the default application/octet MIME type. This breaks browsers as they force downloads of direct image URLs.

The S3 adapter is doing an is_string() check on the request body (which it fails, because it's a stream) to comply with the method signature of guessMimeType(). By making $content optional, we can detect image types based on the extension only.

I didn't see a phpcs config or CONTRIBUTING.md file, so let me know if there's style or other changes to make on this.