### PR TITLE
Do not call getters internally

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -51,7 +51,7 @@ class Filesystem implements FilesystemInterface
     {
         $path = Util::normalizePath($path);
 
-        return (bool) $this->getAdapter()->has($path);
+        return (bool) $this->adapter->has($path);
     }
 
     /**
@@ -63,7 +63,7 @@ class Filesystem implements FilesystemInterface
         $this->assertAbsent($path);
         $config = $this->prepareConfig($config);
 
-        return (bool) $this->getAdapter()->write($path, $contents, $config);
+        return (bool) $this->adapter->write($path, $contents, $config);
     }
 
     /**
@@ -81,7 +81,7 @@ class Filesystem implements FilesystemInterface
 
         Util::rewindStream($resource);
 
-        return (bool) $this->getAdapter()->writeStream($path, $resource, $config);
+        return (bool) $this->adapter->writeStream($path, $resource, $config);
     }
 
     /**
@@ -93,10 +93,10 @@ class Filesystem implements FilesystemInterface
         $config = $this->prepareConfig($config);
 
         if ($this->has($path)) {
-            return (bool) $this->getAdapter()->update($path, $contents, $config);
+            return (bool) $this->adapter->update($path, $contents, $config);
         }
 
-        return (bool) $this->getAdapter()->write($path, $contents, $config);
+        return (bool) $this->adapter->write($path, $contents, $config);
     }
 
     /**
@@ -113,10 +113,10 @@ class Filesystem implements FilesystemInterface
         Util::rewindStream($resource);
 
         if ($this->has($path)) {
-            return (bool) $this->getAdapter()->updateStream($path, $resource, $config);
+            return (bool) $this->adapter->updateStream($path, $resource, $config);
         }
 
-        return (bool) $this->getAdapter()->writeStream($path, $resource, $config);
+        return (bool) $this->adapter->writeStream($path, $resource, $config);
     }
 
     /**
@@ -147,7 +147,7 @@ class Filesystem implements FilesystemInterface
 
         $this->assertPresent($path);
 
-        return (bool) $this->getAdapter()->update($path, $contents, $config);
+        return (bool) $this->adapter->update($path, $contents, $config);
     }
 
     /**
@@ -164,7 +164,7 @@ class Filesystem implements FilesystemInterface
         $this->assertPresent($path);
         Util::rewindStream($resource);
 
-        return (bool) $this->getAdapter()->updateStream($path, $resource, $config);
+        return (bool) $this->adapter->updateStream($path, $resource, $config);
     }
 
     /**
@@ -175,7 +175,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if ( ! ($object = $this->getAdapter()->read($path))) {
+        if ( ! ($object = $this->adapter->read($path))) {
             return false;
         }
 
@@ -190,7 +190,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if ( ! $object = $this->getAdapter()->readStream($path)) {
+        if ( ! $object = $this->adapter->readStream($path)) {
             return false;
         }
 
@@ -207,7 +207,7 @@ class Filesystem implements FilesystemInterface
         $this->assertPresent($path);
         $this->assertAbsent($newpath);
 
-        return (bool) $this->getAdapter()->rename($path, $newpath);
+        return (bool) $this->adapter->rename($path, $newpath);
     }
 
     /**
@@ -220,7 +220,7 @@ class Filesystem implements FilesystemInterface
         $this->assertPresent($path);
         $this->assertAbsent($newpath);
 
-        return $this->getAdapter()->copy($path, $newpath);
+        return $this->adapter->copy($path, $newpath);
     }
 
     /**
@@ -231,7 +231,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        return $this->getAdapter()->delete($path);
+        return $this->adapter->delete($path);
     }
 
     /**
@@ -245,7 +245,7 @@ class Filesystem implements FilesystemInterface
             throw new RootViolationException('Root directories can not be deleted.');
         }
 
-        return (bool) $this->getAdapter()->deleteDir($dirname);
+        return (bool) $this->adapter->deleteDir($dirname);
     }
 
     /**
@@ -256,7 +256,7 @@ class Filesystem implements FilesystemInterface
         $dirname = Util::normalizePath($dirname);
         $config = $this->prepareConfig($config);
 
-        return (bool) $this->getAdapter()->createDir($dirname, $config);
+        return (bool) $this->adapter->createDir($dirname, $config);
     }
 
     /**
@@ -265,7 +265,7 @@ class Filesystem implements FilesystemInterface
     public function listContents($directory = '', $recursive = false)
     {
         $directory = Util::normalizePath($directory);
-        $contents = $this->getAdapter()->listContents($directory, $recursive);
+        $contents = $this->adapter->listContents($directory, $recursive);
 
         return (new ContentListingFormatter($directory, $recursive))->formatListing($contents);
     }
@@ -278,7 +278,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if ( ! $object = $this->getAdapter()->getMimetype($path)) {
+        if ( ! $object = $this->adapter->getMimetype($path)) {
             return false;
         }
 
@@ -293,7 +293,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if ( ! $object = $this->getAdapter()->getTimestamp($path)) {
+        if ( ! $object = $this->adapter->getTimestamp($path)) {
             return false;
         }
 
@@ -308,7 +308,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if (($object = $this->getAdapter()->getVisibility($path)) === false) {
+        if (($object = $this->adapter->getVisibility($path)) === false) {
             return false;
         }
 
@@ -322,7 +322,7 @@ class Filesystem implements FilesystemInterface
     {
         $path = Util::normalizePath($path);
 
-        if (($object = $this->getAdapter()->getSize($path)) === false || ! isset($object['size'])) {
+        if (($object = $this->adapter->getSize($path)) === false || ! isset($object['size'])) {
             return false;
         }
 
@@ -336,7 +336,7 @@ class Filesystem implements FilesystemInterface
     {
         $path = Util::normalizePath($path);
 
-        return (bool) $this->getAdapter()->setVisibility($path, $visibility);
+        return (bool) $this->adapter->setVisibility($path, $visibility);
     }
 
     /**
@@ -347,7 +347,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        return $this->getAdapter()->getMetadata($path);
+        return $this->adapter->getMetadata($path);
     }
 
     /**


### PR DESCRIPTION
`FileSystem` internally calls `getAdapter()` in many places, instead of just using the local `$adapter` property. PHP function calls being quite expensive, this is a waste of resources.