### PR TITLE
Allow more than 2 date formats as the file timestamp

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -442,16 +442,16 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
         list($date, $time, $size, $name) = explode(' ', $item, 4);
         $path = empty($base) ? $name : $base . $this->separator . $name;
 
-        if ($dt = DateTime::createFromFormat('m-d-YH:iA', $date . $time)) { // dd-mm-yyyy
-            $timestamp = $dt->getTimestamp();
-        } else if ($dt = DateTime::createFromFormat('m-d-yH:iA', $date . $time)) { // dd-mm-yy
-            $timestamp = $dt->getTimestamp();
-        } else if ($dt = DateTime::createFromFormat('Y-m-dH:i', $date . $time)) { // yyyy-mm-dd
-            $timestamp = $dt->getTimestamp();
-        } else {
-            // Try to parse the given date and time to a timestamp
-            $timestamp = strtotime($date . " " . $time);
-        }
+		// Check for the correct date/time format
+        $format = strlen($date) === 8 ? 'm-d-yH:iA' : 'Y-m-dH:i';
+        $dt = DateTime::createFromFormat($format, $date . $time);
+
+		// Check if $dt is not false before fetching to timestamp to avoid an exception
+		if (!$dt) {
+			$timestamp = 0;
+		} else {
+			$timestamp = $dt->getTimestamp();
+		}
 
         if ($size === '<DIR>') {
             $type = 'dir';

--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -446,12 +446,12 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
         $format = strlen($date) === 8 ? 'm-d-yH:iA' : 'Y-m-dH:i';
         $dt = DateTime::createFromFormat($format, $date . $time);
 
-		// Check if $dt is not false before fetching to timestamp to avoid an exception
+		// Check if $dt is not false before fetching the timestamp to avoid an exception
 		if (!$dt) {
-			$timestamp = 0;
-		} else {
-			$timestamp = $dt->getTimestamp();
+            $dt = new DateTime("$date $time");
 		}
+		
+        $timestamp = $dt->getTimestamp();
 
         if ($size === '<DIR>') {
             $type = 'dir';

--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -416,8 +416,6 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
      * @param string $item
      * @param string $base
      *
-     * @throws Exception
-     *
      * @return array normalized file array
      */
     protected function normalizeWindowsObject($item, $base)
@@ -433,7 +431,8 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
         } else if ($dt = DateTime::createFromFormat('Y-m-dH:i', $date . $time)) { // yyyy-mm-dd
             $timestamp = $dt->getTimestamp();
         } else {
-            throw new Exception("Invalid datetime format: {$date}{$time}");
+            // Try to parse the given date and time to a timestamp
+            $timestamp = strtotime($date . " " . $time);
         }
 
         if ($size === '<DIR>') {

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -106,7 +106,7 @@ function ftp_chdir($connection, $directory)
         return false;
     }
 
-    if (in_array($directory, ['file1.txt', 'file2.txt', 'dir1'])) {
+    if (in_array($directory, ['file1.txt', 'file2.txt', 'file3.txt', 'dir1'])) {
         return false;
     }
 
@@ -174,6 +174,12 @@ function ftp_rawlist($connection, $directory)
     if (strpos($directory, 'file2.txt') !== false) {
         return [
             '05-23-15  12:09PM                  684 file2.txt',
+        ];
+    }
+
+    if (strpos($directory, 'file3.txt') !== false) {
+        return [
+            '16-03-2016  12:28PM                1337 file3.txt',
         ];
     }
 
@@ -425,6 +431,15 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1432382940, $metadata['timestamp']);
         $this->assertEquals('public', $metadata['visibility']);
         $this->assertEquals(684, $metadata['size']);
+
+        // Test file with m-d-Y H:iA time format
+        $metadata = $adapter->getMetadata('file3.txt');
+        $this->assertInternalType('array', $metadata);
+        $this->assertEquals('file', $metadata['type']);
+        $this->assertEquals('file3.txt', $metadata['path']);
+        $this->assertEquals(1491222480, $metadata['timestamp']);
+        $this->assertEquals('public', $metadata['visibility']);
+        $this->assertEquals(1337, $metadata['size']);
 
         $metadata = $adapter->getMetadata('dir1');
         $this->assertEquals('dir', $metadata['type']);

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -526,7 +526,7 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $metadata);
         $this->assertEquals('file', $metadata['type']);
         $this->assertEquals('file3.txt', $metadata['path']);
-        $this->assertEquals(1491222480, $metadata['timestamp']);
+        $this->assertEquals(0, $metadata['timestamp']);
         $this->assertEquals('public', $metadata['visibility']);
         $this->assertEquals(1337, $metadata['size']);
 

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -526,7 +526,7 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $metadata);
         $this->assertEquals('file', $metadata['type']);
         $this->assertEquals('file3.txt', $metadata['path']);
-        $this->assertEquals(0, $metadata['timestamp']);
+        $this->assertEquals(1458131280, $metadata['timestamp']);
         $this->assertEquals('public', $metadata['visibility']);
         $this->assertEquals(1337, $metadata['size']);
 


### PR DESCRIPTION
This will fix issue https://github.com/thephpleague/flysystem/issues/618

The check will be extended to also recognise mm-dd-yyyy as a correct date format.
If none of the checks match, `strtotime` will be used to try and get a timestamp as a last resort.