### PR TITLE
Fix root directory creation problem

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -7,6 +7,7 @@ use FilesystemIterator;
 use finfo as Finfo;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
+use League\Flysystem\Exception;
 use League\Flysystem\NotSupportedException;
 use League\Flysystem\UnreadableFileException;
 use League\Flysystem\Util;
@@ -88,12 +89,16 @@ class Local extends AbstractAdapter
      * @param string $root root directory path
      *
      * @return string real path to root
+     *
+     * @throws Exception in case the root directory can not be created
      */
     protected function ensureDirectory($root)
     {
         if ( ! is_dir($root)) {
             $umask = umask(0);
-            mkdir($root, $this->permissionMap['dir']['public'], true);
+            if ( ! mkdir($root, $this->permissionMap['dir']['public'], true)) {
+                throw new Exception(sprintf('Impossible to create the root directory "%s".', $root));
+            }
             umask($umask);
         }
 

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -348,7 +348,7 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException League\Flysystem\NotSupportedException
+     * @expectedException \League\Flysystem\NotSupportedException
      */
     public function testLinkCausedUnsupportedException()
     {
@@ -401,5 +401,14 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $fileInfo->getRealPath()->willReturn('somewhere');
         $fileInfo->isReadable()->willReturn(false);
         $method->invoke($adapter, $fileInfo->reveal());
+    }
+
+    /**
+     * @expectedException \League\Flysystem\Exception
+     */
+    public function testRootDirectoryCreationProblemCausesAnError()
+    {
+        $root = __DIR__ . '/files/fail.plz';
+        new Local($root);
     }
 }


### PR DESCRIPTION
To fix a weird use case. Imagine the root directory is `/foo/bar/baz`

At the creation of the Local adapter, everything's OK. The root directory `/foo/bar/baz` is created.
Then the directory `/foo/bar` is deleted and the permissions on `/foo` are changed. No possibility to read/write anymore in this directory.

Then every call to the read/write methods of the adapter will "fail" silently.