### PR TITLE
Added missing config parameter to move and copy, to allow passing through of options.

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -182,10 +182,11 @@ class MountManager
     /**
      * @param $from
      * @param $to
+     * @param array $config
      *
      * @return bool
      */
-    public function copy($from, $to)
+    public function copy($from, $to, array $config = [])
     {
         list($prefixFrom, $arguments) = $this->filterPrefix([$from]);
 
@@ -199,7 +200,7 @@ class MountManager
         list($prefixTo, $arguments) = $this->filterPrefix([$to]);
 
         $fsTo = $this->getFilesystem($prefixTo);
-        $result =  call_user_func_array([$fsTo, 'writeStream'], array_merge($arguments, [$buffer]));
+        $result =  call_user_func_array([$fsTo, 'writeStream'], array_merge($arguments, [$buffer, $config]));
 
         if (is_resource($buffer)) {
             fclose($buffer);
@@ -229,12 +230,13 @@ class MountManager
      *
      * @param $from
      * @param $to
+     * @param array $config
      *
      * @return bool
      */
-    public function move($from, $to)
+    public function move($from, $to, array $config = [])
     {
-        $copied = $this->copy($from, $to);
+        $copied = $this->copy($from, $to, $config);
 
         if ($copied) {
             return $this->delete($from);

--- a/tests/MountManagerTests.php
+++ b/tests/MountManagerTests.php
@@ -76,7 +76,7 @@ class MountManagerTests extends PHPUnit_Framework_TestCase
         $filename = 'test.txt';
         $buffer = tmpfile();
         $fs1->shouldReceive('readStream')->once()->with($filename)->andReturn($buffer);
-        $fs2->shouldReceive('writeStream')->once()->with($filename, $buffer)->andReturn(true);
+        $fs2->shouldReceive('writeStream')->once()->with($filename, $buffer, [])->andReturn(true);
         $response = $manager->copy("fs1://{$filename}", "fs2://{$filename}");
         $this->assertTrue($response);
 
@@ -87,13 +87,13 @@ class MountManagerTests extends PHPUnit_Framework_TestCase
 
         $buffer = tmpfile();
         $fs1->shouldReceive('readStream')->once()->with($filename)->andReturn($buffer);
-        $fs2->shouldReceive('writeStream')->once()->with($filename, $buffer)->andReturn(false);
+        $fs2->shouldReceive('writeStream')->once()->with($filename, $buffer, [])->andReturn(false);
         $status = $manager->copy("fs1://{$filename}", "fs2://{$filename}");
         $this->assertFalse($status);
 
         $buffer = tmpfile();
         $fs1->shouldReceive('readStream')->once()->with($filename)->andReturn($buffer);
-        $fs2->shouldReceive('writeStream')->once()->with($filename, $buffer)->andReturn(true);
+        $fs2->shouldReceive('writeStream')->once()->with($filename, $buffer, [])->andReturn(true);
         $status = $manager->copy("fs1://{$filename}", "fs2://{$filename}");
         $this->assertTrue($status);
     }
@@ -109,11 +109,11 @@ class MountManagerTests extends PHPUnit_Framework_TestCase
         $filename = 'test.txt';
         $buffer = tmpfile();
         $fs1->shouldReceive('readStream')->with($filename)->andReturn($buffer);
-        $fs2->shouldReceive('writeStream')->with($filename, $buffer)->andReturn(false);
+        $fs2->shouldReceive('writeStream')->with($filename, $buffer, [])->andReturn(false);
         $code = $manager->move("fs1://{$filename}", "fs2://{$filename}");
         $this->assertFalse($code);
 
-        $manager->shouldReceive('copy')->with("fs1://{$filename}", "fs2://{$filename}")->andReturn(true);
+        $manager->shouldReceive('copy')->with("fs1://{$filename}", "fs2://{$filename}", [])->andReturn(true);
         $manager->shouldReceive('delete')->with("fs1://{$filename}")->andReturn(true);
         $code = $manager->move("fs1://{$filename}", "fs2://{$filename}");
 


### PR DESCRIPTION
Allows options such as AWS visibility or mimetype, to be used with MountManager move and copy.