### PR TITLE
Fixed #650 - MountManager::filterPrefix only fixes the first path

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -128,6 +128,7 @@ class MountManager
             throw new LogicException('At least one argument needed');
         }
 
+        // The prefix depends on the first argument.
         $path = array_shift($arguments);
 
         if ( ! is_string($path)) {
@@ -139,6 +140,15 @@ class MountManager
         }
 
         list($prefix, $path) = explode('://', $path, 2);
+
+        // If there are more paths in the arguments, we'll fix them as well.
+        foreach ($arguments as $key => $argument) {
+            $parts = explode('://', $argument, 2);
+            if (count($parts) == 2) {
+                $arguments[$key] = $parts[1];
+            }
+        }
+
         array_unshift($arguments, $path);
 
         return [$prefix, $arguments];

--- a/tests/MountManagerTests.php
+++ b/tests/MountManagerTests.php
@@ -1,5 +1,6 @@
 <?php
 
+use League\Flysystem\AdapterInterface;
 use League\Flysystem\Filesystem;
 use League\Flysystem\MountManager;
 
@@ -54,6 +55,41 @@ class MountManagerTests extends PHPUnit_Framework_TestCase
         $this->setExpectedException($exception);
         $manager = new MountManager();
         $manager->filterPrefix($arguments);
+    }
+
+    public function testFilterPrefixProvider()
+    {
+        return [
+            [["tmp://some-dir/foo.jpg"], "tmp", ["some-dir/foo.jpg"]],
+            // Signature for a method call with two paths in it.
+            [
+                ["tmp://some-dir/foo.jpg", "tmp://some-dir/bar.jpg"],
+                "tmp",
+                ["some-dir/foo.jpg", "some-dir/bar.jpg"]
+            ],
+            // Signature for a call with only one path.
+            [
+                ["assets://some-file.png", AdapterInterface::VISIBILITY_PUBLIC],
+                "assets",
+                ["some-file.png", AdapterInterface::VISIBILITY_PUBLIC],
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider testFilterPrefixProvider
+     */
+    public function testFilterPrefix($values, $expectedPrefix, $expectedValues)
+    {
+        $manager = new MountManager();
+        $prefix = $manager->filterPrefix($values)[0];
+        $this->assertEquals($expectedPrefix, $prefix);
+
+        list ($prefix, $arguments) = $manager->filterPrefix($values);
+
+        foreach ($arguments as $key => $argument) {
+            $this->assertEquals($argument, $expectedValues[$key]);
+        }
     }
 
     public function testCallForwarder()


### PR DESCRIPTION
See https://github.com/thephpleague/flysystem/issues/650