### PR TITLE
Implement copy and rename plugins that overwrite destination.

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -8,6 +8,8 @@ use League\Flysystem\Util\ContentListingFormatter;
 
 /**
  * @method array getWithMetadata(string $path, array $metadata)
+ * @method bool  forceCopy(string $path, string $newpath)
+ * @method bool  forceRename(string $path, string $newpath)
  * @method array listFiles(string $path = '', boolean $recursive = false)
  * @method array listPaths(string $path = '', boolean $recursive = false)
  * @method array listWith(array $keys = [], $directory = '', $recursive = false)

--- a/src/Plugin/ForcedCopy.php
+++ b/src/Plugin/ForcedCopy.php
@@ -27,11 +27,16 @@ class ForcedCopy extends AbstractPlugin
     public function handle($path, $newpath)
     {
         try {
-            $this->filesystem->delete($newpath);
+            $deleted = $this->filesystem->delete($newpath);
         } catch (FileNotFoundException $e) {
             // The destination path does not exist. That's ok.
+            $deleted = true;
         }
 
-        return $this->filesystem->copy($path, $newpath);
+        if ($deleted) {
+            return $this->filesystem->copy($path, $newpath);
+        }
+
+        return false;
     }
 }

--- a/src/Plugin/ForcedCopy.php
+++ b/src/Plugin/ForcedCopy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace League\Flysystem\Plugin;
+
+use League\Flysystem\FileNotFoundException;
+
+class ForcedCopy extends AbstractPlugin
+{
+    /**
+     * @inheritdoc
+     */
+    public function getMethod()
+    {
+        return 'forceCopy';
+    }
+
+    /**
+     * Copies a file, overwriting any existing files.
+     *
+     * @param string $path    Path to the existing file.
+     * @param string $newpath The new path of the file.
+     *
+     * @throws FileNotFoundException Thrown if $path does not exist.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function handle($path, $newpath)
+    {
+        try {
+            $this->filesystem->delete($newpath);
+        } catch (FileNotFoundException $e) {
+            // The destination path does not exist. That's ok.
+        }
+
+        return $this->filesystem->copy($path, $newpath);
+    }
+}

--- a/src/Plugin/ForcedRename.php
+++ b/src/Plugin/ForcedRename.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace League\Flysystem\Plugin;
+
+use League\Flysystem\FileNotFoundException;
+
+class ForcedRename extends AbstractPlugin
+{
+    /**
+     * @inheritdoc
+     */
+    public function getMethod()
+    {
+        return 'forceRename';
+    }
+
+    /**
+     * Renames a file, overwriting the destination if it exists.
+     *
+     * @param string $path    Path to the existing file.
+     * @param string $newpath The new path of the file.
+     *
+     * @throws FileNotFoundException Thrown if $path does not exist.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function handle($path, $newpath)
+    {
+        try {
+            $this->filesystem->delete($newpath);
+        } catch (FileNotFoundException $e) {
+            // The destination path does not exist. That's ok.
+        }
+
+        return $this->filesystem->rename($path, $newpath);
+    }
+}

--- a/src/Plugin/ForcedRename.php
+++ b/src/Plugin/ForcedRename.php
@@ -27,11 +27,16 @@ class ForcedRename extends AbstractPlugin
     public function handle($path, $newpath)
     {
         try {
-            $this->filesystem->delete($newpath);
+            $deleted = $this->filesystem->delete($newpath);
         } catch (FileNotFoundException $e) {
             // The destination path does not exist. That's ok.
+            $deleted = true;
         }
 
-        return $this->filesystem->rename($path, $newpath);
+        if ($deleted) {
+            return $this->filesystem->rename($path, $newpath);
+        }
+
+        return false;
     }
 }

--- a/tests/ForcedCopyPluginTests.php
+++ b/tests/ForcedCopyPluginTests.php
@@ -1,0 +1,44 @@
+<?php
+
+
+use League\Flysystem\Plugin\ForcedCopy;
+
+class ForcedCopyPluginTests extends PHPUnit_Framework_TestCase
+{
+    protected $filesystem;
+    protected $plugin;
+
+    public function setUp()
+    {
+        $this->filesystem = Mockery::mock('League\Flysystem\FilesystemInterface');
+        $this->plugin = new ForcedCopy();
+        $this->plugin->setFilesystem($this->filesystem);
+    }
+
+    public function testPluginSuccess()
+    {
+        $this->assertSame('forceCopy', $this->plugin->getMethod());
+
+        $this->filesystem->shouldReceive('delete')->with('newpath')->andReturn(true);
+        $this->filesystem->shouldReceive('copy')->with('path', 'newpath')->andReturn(true);
+
+        $this->assertTrue($this->plugin->handle('path', 'newpath'));
+    }
+
+    public function testPluginDeleteNotExists()
+    {
+        $this->filesystem->shouldReceive('delete')
+            ->with('newpath')
+            ->andThrow('League\Flysystem\FileNotFoundException', 'newpath');
+
+        $this->filesystem->shouldReceive('copy')->with('path', 'newpath')->andReturn(true);
+
+        $this->assertTrue($this->plugin->handle('path', 'newpath'));
+    }
+
+    public function testPluginDeleteFail()
+    {
+        $this->filesystem->shouldReceive('delete')->with('newpath')->andReturn(false);
+        $this->assertFalse($this->plugin->handle('path', 'newpath'));
+    }
+}

--- a/tests/ForcedRenamePluginTests.php
+++ b/tests/ForcedRenamePluginTests.php
@@ -1,0 +1,44 @@
+<?php
+
+
+use League\Flysystem\Plugin\ForcedRename;
+
+class ForcedRenamePluginTests extends PHPUnit_Framework_TestCase
+{
+    protected $filesystem;
+    protected $plugin;
+
+    public function setUp()
+    {
+        $this->filesystem = Mockery::mock('League\Flysystem\FilesystemInterface');
+        $this->plugin = new ForcedRename();
+        $this->plugin->setFilesystem($this->filesystem);
+    }
+
+    public function testPluginSuccess()
+    {
+        $this->assertSame('forceRename', $this->plugin->getMethod());
+
+        $this->filesystem->shouldReceive('delete')->with('newpath')->andReturn(true);
+        $this->filesystem->shouldReceive('rename')->with('path', 'newpath')->andReturn(true);
+
+        $this->assertTrue($this->plugin->handle('path', 'newpath'));
+    }
+
+    public function testPluginDeleteNotExists()
+    {
+        $this->filesystem->shouldReceive('delete')
+            ->with('newpath')
+            ->andThrow('League\Flysystem\FileNotFoundException', 'newpath');
+
+        $this->filesystem->shouldReceive('rename')->with('path', 'newpath')->andReturn(true);
+
+        $this->assertTrue($this->plugin->handle('path', 'newpath'));
+    }
+
+    public function testPluginDeleteFail()
+    {
+        $this->filesystem->shouldReceive('delete')->with('newpath')->andReturn(false);
+        $this->assertFalse($this->plugin->handle('path', 'newpath'));
+    }
+}


### PR DESCRIPTION
RE: #292 

Trying to extend the interface, or default implementation, leads to problems.

Here's an implementation via plugins.