### PR TITLE
Make the windows date/time normalizer not cause an exception if the date could not be parsed

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -444,7 +444,16 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
 
         // Check for the correct date/time format
         $format = strlen($date) === 8 ? 'm-d-yH:iA' : 'Y-m-dH:i';
-        $timestamp = DateTime::createFromFormat($format, $date . $time)->getTimestamp();
+        $dt = DateTime::createFromFormat($format, $date . $time);
+
+        // Check $dt before getting the timestamp
+        if ($dt) {
+            $timestamp = $dt->getTimestamp();
+        } else {
+            // As a last resort, try to guess the timestamp.
+            // Cast the outcome to an int, if it returns false, it will be 0 instead
+            $timestamp = (int) strtotime("$date $time");
+        }
 
         if ($size === '<DIR>') {
             $type = 'dir';

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -107,7 +107,7 @@ function ftp_chdir($connection, $directory)
         return false;
     }
 
-    if (in_array($directory, ['file1.txt', 'file2.txt', 'dir1', 'file1.with-total-line.txt', 'file1.with-invalid-line.txt'])) {
+    if (in_array($directory, ['file1.txt', 'file2.txt', 'file3.txt', 'file4.txt', 'dir1', 'file1.with-total-line.txt', 'file1.with-invalid-line.txt'])) {
         return false;
     }
 
@@ -200,6 +200,18 @@ function ftp_rawlist($connection, $directory)
         ];
     }
 
+    if (strpos($directory, 'file3.txt') !== false) {
+        return [
+            '06-09-2016  12:09PM                  684 file3.txt',
+        ];
+    }
+    
+    if (strpos($directory, 'file4.txt') !== false) {
+        return [
+            '2016-05-23  12:09PM                  684 file4.txt',
+        ];
+    }
+    
     if (strpos($directory, 'dir1') !== false) {
         return [
             '2015-05-23  12:09       <DIR>          dir1',
@@ -515,6 +527,22 @@ class FtpTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('public', $metadata['visibility']);
         $this->assertEquals(684, $metadata['size']);
 
+        $metadata = $adapter->getMetadata('file3.txt');
+        $this->assertInternalType('array', $metadata);
+        $this->assertEquals('file', $metadata['type']);
+        $this->assertEquals('file3.txt', $metadata['path']);
+        $this->assertEquals(1473163740, $metadata['timestamp']);
+        $this->assertEquals('public', $metadata['visibility']);
+        $this->assertEquals(684, $metadata['size']);
+        
+        $metadata = $adapter->getMetadata('file4.txt');
+        $this->assertInternalType('array', $metadata);
+        $this->assertEquals('file', $metadata['type']);
+        $this->assertEquals('file4.txt', $metadata['path']);
+        $this->assertEquals(1464005340, $metadata['timestamp']);
+        $this->assertEquals('public', $metadata['visibility']);
+        $this->assertEquals(684, $metadata['size']);
+        
         $metadata = $adapter->getMetadata('dir1');
         $this->assertEquals('dir', $metadata['type']);
         $this->assertEquals('dir1', $metadata['path']);


### PR DESCRIPTION
Currently, if the date/time doesn't match either of the 2 formats. DateTime will return false and ->getTimestamp() causes an exception `Call ->getTimestamp() on boolean`.
I order to prevent this exception. I've made a check that will first check if DateTime is not false and if it is, it will try to create a timestamp using `strtotime`.
The value from `strtotime` is cast to an int so if that also returns false, it will return 0 (which is a valid timestamp).