### PR TITLE
Read stream in binary mode

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -415,7 +415,7 @@ class Ftp extends AbstractFtpAdapter
      */
     public function readStream($path)
     {
-        $stream = fopen('php://temp', 'w+');
+        $stream = fopen('php://temp', 'w+b');
         $result = ftp_fget($this->getConnection(), $stream, $path, $this->transferMode);
         rewind($stream);
 

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -148,7 +148,7 @@ class Local extends AbstractAdapter
     {
         $location = $this->applyPathPrefix($path);
         $this->ensureDirectory(dirname($location));
-        $stream = fopen($location, 'w+');
+        $stream = fopen($location, 'w+b');
 
         if ( ! $stream) {
             return false;
@@ -173,7 +173,7 @@ class Local extends AbstractAdapter
     public function readStream($path)
     {
         $location = $this->applyPathPrefix($path);
-        $stream = fopen($location, 'r');
+        $stream = fopen($location, 'rb');
 
         return compact('stream', 'path');
     }


### PR DESCRIPTION
See http://php.net/manual/en/function.fopen.php and https://github.com/thephpleague/flysystem/issues/72#issuecomment-233303480
> For portability, it is strongly recommended that you always use the 'b' flag when opening files with fopen().