### PR TITLE
Fixed ensureDirectory method in Local adapter - Dir seems to be not readable although it is

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -73,13 +73,13 @@ class Local extends AbstractAdapter
     {
         $root = is_link($root) ? realpath($root) : $root;
         $this->permissionMap = array_replace_recursive(static::$permissions, $permissions);
-        $realRoot = $this->ensureDirectory($root);
+        $this->ensureDirectory($root);
 
-        if ( ! is_dir($realRoot) || ! is_readable($realRoot)) {
+        if ( ! is_dir($root) || ! is_readable($root)) {
             throw new LogicException('The root path ' . $root . ' is not readable.');
         }
 
-        $this->setPathPrefix($realRoot);
+        $this->setPathPrefix($root);
         $this->writeFlags = $writeFlags;
         $this->linkHandling = $linkHandling;
     }
@@ -89,7 +89,7 @@ class Local extends AbstractAdapter
      *
      * @param string $root root directory path
      *
-     * @return string real path to root
+     * @return void
      *
      * @throws Exception in case the root directory can not be created
      */
@@ -104,8 +104,6 @@ class Local extends AbstractAdapter
                 throw new Exception(sprintf('Impossible to create the root directory "%s".', $root));
             }
         }
-
-        return $root;
     }
 
     /**

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -105,7 +105,7 @@ class Local extends AbstractAdapter
             }
         }
 
-        return realpath($root);
+        return $root;
     }
 
     /**

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -173,7 +173,7 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
 
     public function testGetPathPrefix()
     {
-        $this->assertEquals(realpath($this->root) . DIRECTORY_SEPARATOR, $this->adapter->getPathPrefix());
+        $this->assertEquals(realpath($this->root), realpath($this->adapter->getPathPrefix()));
     }
 
     public function testRenameToNonExistsingDirectory()


### PR DESCRIPTION
FIX: no need to use realpath($root) in Local adapter for ensureDirectory method - directory already ensured by is_dir($root) (realpath function causes issues when running script without executable permissions on all directories in the hierarchy)