### PR TITLE
Add missing return type declarations

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -376,6 +376,8 @@ class Filesystem implements FilesystemInterface
      * @param string $path path to file
      *
      * @throws FileNotFoundException
+     * 
+     * @return void
      */
     public function assertPresent($path)
     {
@@ -390,6 +392,8 @@ class Filesystem implements FilesystemInterface
      * @param string $path path to file
      *
      * @throws FileExistsException
+     * 
+     * @return void
      */
     public function assertAbsent($path)
     {

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -39,8 +39,8 @@ use LogicException;
  * @method array|false getMetadata($path)
  * @method Handler get($path, Handler $handler = null)
  * @method Filesystem flushCache()
- * @method assertPresent($path)
- * @method assertAbsent($path)
+ * @method void assertPresent($path)
+ * @method void assertAbsent($path)
  * @method Filesystem addPlugin(PluginInterface $plugin)
  */
 class MountManager


### PR DESCRIPTION
`MountManager` and `Filesystem` classes had missing return type declarations for `assert*` methods. This prevents using these classes when you're doing `phpspec`. An exception is thrown stating these methods are not existing.
In short, `phpspec/prophecy` relies on `phpdocumentor`, where an empty type declaration causes an exception to be thrown (`'Attempted to resolve "' . $type . '" but it appears to be empty'`) during parsing the class docblock. This will prevent phpspec to get a list of any of the supported magic methods.