### PR TITLE
Implement custom pathinfo() functions.

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -16,9 +16,15 @@ class Util
      */
     public static function pathinfo($path)
     {
-        $pathinfo = pathinfo($path) + compact('path');
-        $pathinfo['dirname'] = array_key_exists('dirname', $pathinfo)
-            ? static::normalizeDirname($pathinfo['dirname']) : '';
+        $pathinfo = compact('path');
+
+        if ('' !== $dirname = dirname($path)) {
+            $pathinfo['dirname'] = static::normalizeDirname($dirname);
+        }
+
+        $pathinfo['basename'] = static::basename($path);
+
+        $pathinfo += pathinfo($pathinfo['basename']);
 
         return $pathinfo;
     }
@@ -284,5 +290,41 @@ class Util
         }
 
         return [$directories, $listedDirectories];
+    }
+
+    /**
+     * Returns the trailing name component of the path.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private static function basename($path)
+    {
+        $separators = DIRECTORY_SEPARATOR === '/' ? '/' : '\/';
+
+        $path = rtrim($path, $separators);
+
+        $basename = preg_replace('#.*?([^' . preg_quote($separators, '#') . ']+$)#', '$1', $path);
+
+        if (DIRECTORY_SEPARATOR === '/') {
+            return $basename;
+        }
+        // @codeCoverageIgnoreStart
+        // Extra Windows path munging. This is tested via AppVeyor, but code
+        // coverage is not reported.
+
+        // Handle relative paths with drive letters. c:file.txt.
+        while (preg_match('#^[a-zA-Z]{1}:[^\\\/]#', $basename)) {
+            $basename = substr($basename, 2);
+        }
+
+        // Remove colon for standalone drive letter names.
+        if (preg_match('#^[a-zA-Z]{1}:$#', $basename)) {
+            $basename = rtrim($basename, ':');
+        }
+
+        return $basename;
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -164,4 +164,120 @@ class UtilTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test/', Util::normalizePrefix('test', '/'));
         $this->assertEquals('test/', Util::normalizePrefix('test/', '/'));
     }
+
+    public function pathinfoPathProvider()
+    {
+        return [
+            [''],
+            ['.'],
+            ['..'],
+            ['...'],
+            ['/.'],
+            ['//.'],
+            ['///.'],
+
+            ['foo'],
+            ['/foo'],
+            ['/foo/bar'],
+            ['/foo/bar/'],
+
+            ['file.txt'],
+            ['foo/file.txt'],
+            ['/foo/file.jpeg'],
+
+            ['.txt'],
+            ['dir/.txt'],
+            ['/dir/.txt'],
+
+            ['foo/bar.'],
+            ['foo/bar..'],
+            ['foo/bar/.'],
+
+            ['c:'],
+            ['c:\\'],
+            ['c:/'],
+            ['c:file'],
+            ['c:f:ile'],
+            ['c:f:'],
+            ['c:d:e:'],
+            ['AB:file'],
+            ['AB:'],
+            ['d:\foo\bar'],
+            ['E:\foo\bar\\'],
+            ['f:\foo\bar:baz'],
+            ['G:\foo\bar:'],
+            ['c:/foo/bar'],
+            ['c:/foo/bar/'],
+            ['Y:\foo\bar.txt'],
+            ['z:\foo\bar.'],
+            ['foo\bar'],
+        ];
+    }
+
+    /**
+     * @dataProvider  pathinfoPathProvider
+     */
+    public function testPathinfo($path)
+    {
+        $expected = compact('path') + pathinfo($path);
+
+        if (isset($expected['dirname'])) {
+            $expected['dirname'] = Util::normalizeDirname($expected['dirname']);
+        }
+
+        $this->assertSame($expected, Util::pathinfo($path));
+    }
+
+    public function testPathinfoHandlesUtf8()
+    {
+        $path = 'files/繁體中文字/test.txt';
+        $expected = [
+            'path' => 'files/繁體中文字/test.txt',
+            'dirname' => 'files/繁體中文字',
+            'basename' => 'test.txt',
+            'extension' => 'txt',
+            'filename' => 'test',
+        ];
+        $this->assertSame($expected, Util::pathinfo($path));
+
+        $path = 'files/繁體中文字.txt';
+        $expected = [
+            'path' => 'files/繁體中文字.txt',
+            'dirname' => 'files',
+            'basename' => '繁體中文字.txt',
+            'extension' => 'txt',
+            'filename' => '繁體中文字',
+        ];
+        $this->assertSame($expected, Util::pathinfo($path));
+
+        $path = '👨‍👩‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧/繁體中文字.txt';
+        $expected = [
+            'path' => '👨‍👩‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧/繁體中文字.txt',
+            'dirname' => '👨‍👩‍👧‍👦👨‍👩‍👦‍👦👨‍👩‍👧‍👧',
+            'basename' => '繁體中文字.txt',
+            'extension' => 'txt',
+            'filename' => '繁體中文字',
+        ];
+        $this->assertSame($expected, Util::pathinfo($path));
+
+        $path = 'foo/bar.baz.😀😬😁';
+        $expected = [
+            'path' => 'foo/bar.baz.😀😬😁',
+            'dirname' => 'foo',
+            'basename' => 'bar.baz.😀😬😁',
+            'extension' => '😀😬😁',
+            'filename' => 'bar.baz',
+        ];
+        $this->assertSame($expected, Util::pathinfo($path));
+
+        $path = '繁體中文字/👨‍👩‍👧‍👦.😺😸😹😻.😀😬😁';
+        $expected = [
+            'path' => '繁體中文字/👨‍👩‍👧‍👦.😺😸😹😻.😀😬😁',
+            'dirname' => '繁體中文字',
+            'basename' => '👨‍👩‍👧‍👦.😺😸😹😻.😀😬😁',
+            'extension' => '😀😬😁',
+            'filename' => '👨‍👩‍👧‍👦.😺😸😹😻',
+        ];
+        $this->assertSame($expected, Util::pathinfo($path));
+    }
 }


### PR DESCRIPTION
As mentioned in #235, `pathinfo()` has inconsistent handling of UTF-8 file paths.

This has been a known problem for quite some time, and I'm surprised it's taken this long to get reported.

I know that Drupal implements their own version of `basename()` for this reason.

See http://bugs.php.net/bug.php?id=37738

This is a clean-room implementation of the required methods.
