### PR TITLE
Adding OpenStack Swift adapter to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Want to get started quickly? Check out some of these integrations:
 * Google Cloud Storage: https://github.com/Superbalist/flysystem-google-storage
 * SinaAppEngine Storage: https://github.com/litp/flysystem-sae-storage
 * Gaufrette: https://github.com/jenkoian/flysystem-gaufrette
+* OpenStack Swift: https://github.com/nimbusoftltd/flysystem-openstack-swift
 
 ## Caching
 


### PR DESCRIPTION
Hey,

I've written an adapter for OpenStack Swift. It uses php-opencloud/openstack as a base as rackspace/php-opencloud is going to enter end-of-life soon.

Hope this is useful for some people.