### PR TITLE
Listing filtered contents mechanism, set of example filters, example …

### DIFF
--- a/spec/FilterFileInfoSpec.php
+++ b/spec/FilterFileInfoSpec.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace spec\League\Flysystem;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use League\Flysystem\UnsupportedFilterException;
+
+class FilterFileInfoSpec extends ObjectBehavior
+{
+    function it_could_create_itself_from_normalized_file_info()
+    {
+        $timestamp = date_timestamp_get(new \DateTime('now'));
+        $normalizedFileInfo = [
+            'type' => 'file',
+            'path' => 'file.txt',
+            'timestamp' => $timestamp,
+            'size' => 21981278127,
+            'extension' => 'txt',
+            'filename' => 'file',
+            'visibility' => 'public'
+        ];
+
+        $this->beConstructedThrough('createFromNormalized', [$normalizedFileInfo]);
+
+        $this->getType()->shouldReturn('file');
+        $this->getPath()->shouldReturn('file.txt');
+        $this->getTimestamp()->shouldReturn($timestamp);
+        $this->getSize()->shouldReturn(21981278127);
+        $this->getExtension()->shouldReturn('txt');
+        $this->getFilename()->shouldReturn('file');
+        $this->getVisibility()->shouldReturn('public');
+    }
+
+    function it_should_inform_about_not_supporting_filter_while_trying_to_retreive_specific_information()
+    {
+        $type = 'file';
+        $path = null;
+        $timestamp = null;
+        $size = null;
+        $extension = 'txt';
+        $filename = 'file';
+        $visibility = 'public';
+
+        $this->beConstructedWith(
+            $type,
+            $path,
+            $timestamp,
+            $size,
+            $extension,
+            $filename,
+            $visibility
+        );
+
+        $this->getType()->shouldReturn('file');
+        $this->shouldThrow(new UnsupportedFilterException('Filtering by path is not supported.'))
+            ->during('getPath');
+        $this->shouldThrow(new UnsupportedFilterException('Filtering by timestamp is not supported.'))
+            ->during('getTimestamp');
+        $this->shouldThrow(new UnsupportedFilterException('Filtering by size is not supported.'))
+            ->during('getSize');
+        $this->getExtension()->shouldReturn('txt');
+        $this->getFilename()->shouldReturn('file');
+        $this->getVisibility()->shouldReturn('public');
+
+    }
+}

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -275,6 +275,28 @@ class Filesystem implements FilesystemInterface
     /**
      * @inheritdoc
      */
+    public function listFilteredContents(FilterCriteriaInterface $filterCriteria, $directory = '', $recursive = false)
+    {
+        $directory = Util::normalizePath($directory);
+
+        $filteredContents = [];
+        if ($this->getAdapter() instanceof FilteringReadInterface) {
+            $filteredContents = $this->getAdapter()->listFilteredContents($filterCriteria, $directory, $recursive);
+        } else {
+            $contents = $this->getAdapter()->listContents($directory, $recursive);
+            foreach ($contents as $content) {
+                if ($filterCriteria->isSatisfiedBy(FilterFileInfo::createFromNormalized($content))) {
+                    $filteredContents[] = $content;
+                }
+            }
+        }
+
+        return (new ContentListingFormatter($directory, $recursive))->formatListing($filteredContents);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getMimetype($path)
     {
         $path = Util::normalizePath($path);

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -46,6 +46,19 @@ interface FilesystemInterface
     public function listContents($directory = '', $recursive = false);
 
     /**
+     * List filtered contents of a directory.
+     *
+     * @param FilterCriteriaInterface $filterCriteria Criteria to filer contents of directory
+     * @param string                  $directory      The directory to list.
+     * @param bool                    $recursive      Whether to list recursively.
+     *
+     * @throws UnsupportedFilterException
+     *
+     * @return array A list of file metadata.
+     */
+    public function listFilteredContents(FilterCriteriaInterface $filterCriteria, $directory = '', $recursive = false);
+
+    /**
      * Get a file's metadata.
      *
      * @param string $path The path to the file.

--- a/src/Filter/AndX.php
+++ b/src/Filter/AndX.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class AndX implements FilterCriteriaInterface
+{
+    /**
+     * @var FilterCriteriaInterface[]
+     */
+    private $filters = [];
+
+    public function __construct()
+    {
+        $args = func_get_args();
+        $this->guardArgs($args);
+
+        $this->filters = $args;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        foreach ($this->filters as $filter) {
+            if ( ! $filter->isSatisfiedBy($filterFileInfo)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Guards if all of arguments passed.
+     *
+     * @param array $args
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function guardArgs(array $args)
+    {
+        foreach ($args as $arg) {
+            if ( ! is_object($arg)) {
+                throw new \InvalidArgumentException(
+                    'All argument should implements FilterCriteriaInterface. Not an object given.'
+                );
+            }
+            if (is_object($arg) && ! in_array('League\Flysystem\FilterCriteriaInterface', class_implements($arg))) {
+                throw new \InvalidArgumentException(
+                    sprintf('All argument should implements FilterCriteriaInterface. %s given.', is_object($arg))
+                );
+            }
+        }
+    }
+}

--- a/src/Filter/ExtensionEquals.php
+++ b/src/Filter/ExtensionEquals.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class ExtensionEquals implements FilterCriteriaInterface
+{
+    /**
+     * @var string
+     */
+    private $extension;
+
+    public function __construct($extension)
+    {
+        if ( ! is_string($extension)) {
+            throw new \InvalidArgumentException('Extenstion have to be a string.');
+        }
+
+        $this->extension = $extension;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getExtension() === $this->extension;
+    }
+}

--- a/src/Filter/FilenameEquals.php
+++ b/src/Filter/FilenameEquals.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class FilenameEquals implements FilterCriteriaInterface
+{
+    /**
+     * @var string
+     */
+    private $fileName;
+
+    /**
+     * FilenameEquals constructor.
+     *
+     * @param string $fileName
+     */
+    public function __construct($fileName)
+    {
+        if ( ! is_string($fileName)) {
+            throw new \InvalidArgumentException('File name have to be a string.');
+        }
+
+        $this->fileName = $fileName;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getFilename() === $this->fileName;
+    }
+}

--- a/src/Filter/FilenameStartsWith.php
+++ b/src/Filter/FilenameStartsWith.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class FilenameStartsWith implements FilterCriteriaInterface
+{
+    /**
+     * @var string
+     */
+    private $fileNameStart;
+
+    /**
+     * FilenameStartsWith constructor.
+     *
+     * @param string $fileNameStart
+     */
+    public function __construct($fileNameStart)
+    {
+        if ( ! is_string($fileNameStart)) {
+            throw new \InvalidArgumentException('File name have to be a string.');
+        }
+
+        $this->fileNameStart = $fileNameStart;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return strpos($filterFileInfo->getFilename(), $this->fileNameStart) === 0;
+    }
+}

--- a/src/Filter/IsDirectory.php
+++ b/src/Filter/IsDirectory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class IsDirectory implements FilterCriteriaInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getType() === FilterFileInfo::TYPE_DIR;
+    }
+}

--- a/src/Filter/IsFile.php
+++ b/src/Filter/IsFile.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class IsFile implements FilterCriteriaInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getType() === FilterFileInfo::TYPE_FILE;
+    }
+}

--- a/src/Filter/IsPrivate.php
+++ b/src/Filter/IsPrivate.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class IsPrivate implements FilterCriteriaInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getVisibility() === FilterFileInfo::VISIBILITY_PRIVATE;
+    }
+}

--- a/src/Filter/IsPublic.php
+++ b/src/Filter/IsPublic.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class IsPublic implements FilterCriteriaInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getVisibility() === FilterFileInfo::VISIBILITY_PUBLIC;
+    }
+}

--- a/src/Filter/ModifiedAfter.php
+++ b/src/Filter/ModifiedAfter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class ModifiedAfter implements FilterCriteriaInterface
+{
+    /**
+     * @var \DateTime
+     */
+    private $dateTime;
+
+    /**
+     * ModifiedAfter constructor.
+     *
+     * @param \DateTime $dateTime
+     */
+    public function __construct(\DateTime $dateTime)
+    {
+        $this->dateTime = $dateTime;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getTimestamp() > date_timestamp_get($this->dateTime);
+    }
+}

--- a/src/Filter/ModifiedAt.php
+++ b/src/Filter/ModifiedAt.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class ModifiedAt implements FilterCriteriaInterface
+{
+    /**
+     * @var \DateTime
+     */
+    private $dateTime;
+
+    /**
+     * ModifiedAt constructor.
+     *
+     * @param \DateTime $dateTime
+     */
+    public function __construct(\DateTime $dateTime)
+    {
+        $this->dateTime = $dateTime;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getTimestamp() === date_timestamp_get($this->dateTime);
+    }
+}

--- a/src/Filter/ModifiedBefore.php
+++ b/src/Filter/ModifiedBefore.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class ModifiedBefore implements FilterCriteriaInterface
+{
+    /**
+     * @var \DateTime
+     */
+    private $dateTime;
+
+    /**
+     * ModifiedBefore constructor.
+     *
+     * @param \DateTime $dateTime
+     */
+    public function __construct(\DateTime $dateTime)
+    {
+        $this->dateTime = $dateTime;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getTimestamp() < date_timestamp_get($this->dateTime);
+    }
+}

--- a/src/Filter/NotX.php
+++ b/src/Filter/NotX.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class NotX implements FilterCriteriaInterface
+{
+    /**
+     * @var FilterCriteriaInterface[]
+     */
+    private $baseFilter;
+
+    /**
+     * NotX constructor.
+     *
+     * @param FilterCriteriaInterface $baseFilterCriteria
+     */
+    public function __construct(FilterCriteriaInterface $baseFilterCriteria)
+    {
+        $this->baseFilter = $baseFilterCriteria;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return ! $this->baseFilter->isSatisfiedBy($filterFileInfo);
+    }
+}

--- a/src/Filter/OrX.php
+++ b/src/Filter/OrX.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class OrX implements FilterCriteriaInterface
+{
+    /**
+     * @var FilterCriteriaInterface[]
+     */
+    private $filters = [];
+
+    /**
+     * OrX constructor.
+     */
+    public function __construct()
+    {
+        $args = func_get_args();
+        $this->guardArgs($args);
+
+        $this->filters = $args;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        foreach ($this->filters as $filter) {
+            if ($filter->isSatisfiedBy($filterFileInfo)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Guards if all of arguments passed.
+     *
+     * @param array $args
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function guardArgs(array $args)
+    {
+        foreach ($args as $arg) {
+            if ( ! is_object($arg)) {
+                throw new \InvalidArgumentException(
+                    'All argument should implements FilterCriteriaInterface. Not an object given.'
+                );
+            }
+            if (is_object($arg) && ! in_array('League\Flysystem\FilterCriteriaInterface', class_implements($arg))) {
+                throw new \InvalidArgumentException(
+                    sprintf('All argument should implements FilterCriteriaInterface. %s given.', is_object($arg))
+                );
+            }
+        }
+    }
+}

--- a/src/Filter/PathContains.php
+++ b/src/Filter/PathContains.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class PathContains implements FilterCriteriaInterface
+{
+    /**
+     * @var string
+     */
+    private $pathFragment;
+
+    /**
+     * PathContains constructor.
+     *
+     * @param string $pathFragment
+     */
+    public function __construct($pathFragment)
+    {
+        if ( ! is_string($pathFragment)) {
+            throw new \InvalidArgumentException('Path fragment have to be a string.');
+        }
+
+        $this->pathFragment = $pathFragment;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return ! (strpos($filterFileInfo->getPath(), $this->pathFragment) === false);
+    }
+}

--- a/src/Filter/SizeBiggerThan.php
+++ b/src/Filter/SizeBiggerThan.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class SizeBiggerThan implements FilterCriteriaInterface
+{
+    /**
+     * @var string
+     */
+    private $size;
+
+    /**
+     * SizeBiggerThan constructor.
+     *
+     * @param integer $size
+     */
+    public function __construct($size)
+    {
+        if ( ! is_integer($size)) {
+            throw new \InvalidArgumentException('Size have to be an integer.');
+        }
+
+        $this->size = $size;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getSize() > $this->size;
+    }
+}

--- a/src/Filter/SizeEquals.php
+++ b/src/Filter/SizeEquals.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class SizeEquals implements FilterCriteriaInterface
+{
+    /**
+     * @var string
+     */
+    private $size;
+
+    /**
+     * SizeEquals constructor.
+     *
+     * @param integer $size
+     */
+    public function __construct($size)
+    {
+        if ( ! is_integer($size)) {
+            throw new \InvalidArgumentException('Size have to be an integer.');
+        }
+
+        $this->size = $size;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getSize() === $this->size;
+    }
+}

--- a/src/Filter/SizeSmallerThan.php
+++ b/src/Filter/SizeSmallerThan.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\FilterCriteriaInterface;
+use League\Flysystem\FilterFileInfo;
+
+class SizeSmallerThan implements FilterCriteriaInterface
+{
+    /**
+     * @var string
+     */
+    private $size;
+
+    /**
+     * SizeSmallerThan constructor.
+     *
+     * @param integer $size
+     */
+    public function __construct($size)
+    {
+        if ( ! is_integer($size)) {
+            throw new \InvalidArgumentException('Size have to be an integer.');
+        }
+
+        $this->size = $size;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
+    {
+        return $filterFileInfo->getSize() < $this->size;
+    }
+}

--- a/src/FilterCriteriaInterface.php
+++ b/src/FilterCriteriaInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace League\Flysystem;
+
+interface FilterCriteriaInterface
+{
+    /**
+     * Detrrmines that file info satisfying criteria or not.
+     *
+     * @param FilterFileInfo $filterFileInfo
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy(FilterFileInfo $filterFileInfo);
+}

--- a/src/FilterFileInfo.php
+++ b/src/FilterFileInfo.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace League\Flysystem;
+
+class FilterFileInfo
+{
+    const TYPE_FILE = 'file';
+    const TYPE_DIR = 'dir';
+    const VISIBILITY_PUBLIC = 'public';
+    const VISIBILITY_PRIVATE = 'private';
+
+    /**
+     * @var array
+     */
+    private $elements = [];
+
+    /**
+     * FilterFileInfo constructor.
+     * @param string|null  $type
+     * @param string|null  $path
+     * @param integer|null $timestamp
+     * @param integer|null $size
+     * @param string|null  $extension
+     * @param string|null  $filename
+     * @param string|null  $visibility
+     */
+    public function __construct(
+        $type,
+        $path,
+        $timestamp,
+        $size,
+        $extension,
+        $filename,
+        $visibility
+    ) {
+        if ( ! empty($type)) {
+            $this->elements['type'] = $type;
+        }
+        if ( ! empty($path)) {
+            $this->elements['path'] = $path;
+        }
+        if ( ! empty($timestamp)) {
+            $this->elements['timestamp'] = $timestamp;
+        }
+        if ( ! empty($size)) {
+            $this->elements['size'] = $size;
+        }
+        if ( ! empty($extension)) {
+            $this->elements['extension'] = $extension;
+        }
+        if ( ! empty($filename)) {
+            $this->elements['filename'] = $filename;
+        }
+        if ( ! empty($visibility)) {
+            $this->elements['visibility'] = $visibility;
+        }
+    }
+
+    /**
+     * @param array $normalizedFileInfo
+     *
+     * @return FilterFileInfo
+     */
+    public static function createFromNormalized(array $normalizedFileInfo)
+    {
+        return (new FilterFileInfo(
+            array_key_exists('type', $normalizedFileInfo) ? $normalizedFileInfo['type'] : null,
+            array_key_exists('path', $normalizedFileInfo) ? $normalizedFileInfo['path'] : null,
+            array_key_exists('timestamp', $normalizedFileInfo) ? $normalizedFileInfo['timestamp'] : null,
+            array_key_exists('size', $normalizedFileInfo) ? $normalizedFileInfo['size'] : null,
+            array_key_exists('extension', $normalizedFileInfo) ? $normalizedFileInfo['extension'] : null,
+            array_key_exists('filename', $normalizedFileInfo) ? $normalizedFileInfo['filename'] : null,
+            array_key_exists('visibility', $normalizedFileInfo) ? $normalizedFileInfo['visibility'] : null
+        ));
+    }
+
+    /**
+     * @return string
+     *
+     * @throws UnsupportedFilterException
+     */
+    public function getType()
+    {
+        if ( ! array_key_exists('type', $this->elements)) {
+            throw new UnsupportedFilterException('Filtering by type is not supported.');
+        }
+
+        return $this->elements['type'];
+    }
+
+    /**
+     * @return string
+     *
+     * @throws UnsupportedFilterException
+     */
+    public function getPath()
+    {
+        if ( ! array_key_exists('path', $this->elements)) {
+            throw new UnsupportedFilterException('Filtering by path is not supported.');
+        }
+
+        return $this->elements['path'];
+    }
+
+    /**
+     * @return int
+     *
+     * @throws UnsupportedFilterException
+     */
+    public function getTimestamp()
+    {
+        if ( ! array_key_exists('timestamp', $this->elements)) {
+            throw new UnsupportedFilterException('Filtering by timestamp is not supported.');
+        }
+
+        return $this->elements['timestamp'];
+    }
+
+    /**
+     * @return int
+     *
+     * @throws UnsupportedFilterException
+     */
+    public function getSize()
+    {
+        if ( ! array_key_exists('size', $this->elements)) {
+            throw new UnsupportedFilterException('Filtering by size is not supported.');
+        }
+
+        return $this->elements['size'];
+    }
+
+    /**
+     * @return string
+     *
+     * @throws UnsupportedFilterException
+     */
+    public function getExtension()
+    {
+        if ( ! array_key_exists('extension', $this->elements)) {
+            throw new UnsupportedFilterException('Filtering by extension is not supported.');
+        }
+
+        return $this->elements['extension'];
+    }
+
+    /**
+     * @return string
+     *
+     * @throws UnsupportedFilterException
+     */
+    public function getFilename()
+    {
+        if ( ! array_key_exists('filename', $this->elements)) {
+            throw new UnsupportedFilterException('Filtering by filename is not supported.');
+        }
+
+        return $this->elements['filename'];
+    }
+
+    /**
+     * @return string
+     *
+     * @throws UnsupportedFilterException
+     */
+    public function getVisibility()
+    {
+        if ( ! array_key_exists('visibility', $this->elements)) {
+            throw new UnsupportedFilterException('Filtering by visibility is not supported.');
+        }
+
+        return $this->elements['visibility'];
+    }
+}

--- a/src/FilteringReadInterface.php
+++ b/src/FilteringReadInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace League\Flysystem;
+
+interface FilteringReadInterface extends ReadInterface
+{
+    /**
+     * List filtered contents of a directory.
+     *
+     * @param FilterCriteriaInterface $filterCriteria Criteria to filer contents of directory
+     * @param string                  $directory      The directory to list.
+     * @param bool                    $recursive      Whether to list recursively.
+     *
+     * @throws UnsupportedFilterException
+     *
+     * @return array A list of file metadata.
+     */
+    public function listFilteredContents(FilterCriteriaInterface $filterCriteria, $directory = '', $recursive = false);
+}

--- a/src/UnsupportedFilterException.php
+++ b/src/UnsupportedFilterException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Flysystem;
+
+class UnsupportedFilterException extends Exception
+{
+}

--- a/tests/Filter/AndXTests.php
+++ b/tests/Filter/AndXTests.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+class AndXTests extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructionWithDifferentNumberOfArguments()
+    {
+        $filterCriteriaOne = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterCriteriaTwo = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterCriteriaThree = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+
+        new AndX($filterCriteriaOne->reveal());
+        new AndX($filterCriteriaOne->reveal(), $filterCriteriaTwo->reveal());
+        new AndX($filterCriteriaOne->reveal(), $filterCriteriaThree->reveal(), $filterCriteriaTwo->reveal());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCanBeConstructedOnlyWithFilterCriterias()
+    {
+        $filterCriteria = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $string = 'string';
+
+        new AndX($filterCriteria->reveal(), $string);
+    }
+
+    public function testWorksAsLogicAndOfCriteriasConstructedWith()
+    {
+        $filterCriteriaOne = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterCriteriaTwo = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterFileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $filterCriteriaOne->isSatisfiedBy($filterFileInfo)->willReturn(true);
+        $filterCriteriaTwo->isSatisfiedBy($filterFileInfo)->willReturn(false);
+
+        $this->assertTrue((new AndX($filterCriteriaOne->reveal(), $filterCriteriaOne->reveal()))
+            ->isSatisfiedBy($filterFileInfo->reveal()));
+        $this->assertFalse((new AndX($filterCriteriaOne->reveal(), $filterCriteriaTwo->reveal()))
+            ->isSatisfiedBy($filterFileInfo->reveal()));
+        $this->assertFalse((new AndX($filterCriteriaTwo->reveal(), $filterCriteriaTwo->reveal()))
+            ->isSatisfiedBy($filterFileInfo->reveal()));
+    }
+}

--- a/tests/Filter/ExtensionEqualsTest.php
+++ b/tests/Filter/ExtensionEqualsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class ExtensionEqualsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAllowCreationWithStringOnly()
+    {
+        new ExtensionEquals(2323);
+    }
+
+    public function testRecognizeExtensionOfFile()
+    {
+        $fileInfoTxt = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoBmp = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoTxt->getExtension()->willReturn('txt');
+        $fileInfoBmp->getExtension()->willReturn('bmp');
+
+        $this->assertFalse(
+            (new ExtensionEquals('bmp'))->isSatisfiedBy($fileInfoTxt->reveal())
+        );
+        $this->assertTrue(
+            (new ExtensionEquals('bmp'))->isSatisfiedBy($fileInfoBmp->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenExtensionIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getExtension()->willThrow(new UnsupportedFilterException());
+
+        (new ExtensionEquals('bmp'))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/FilenameEqualsTest.php
+++ b/tests/Filter/FilenameEqualsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class FilenameEqualsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAllowCreationWithStringOnly()
+    {
+        new FilenameEquals(2323);
+    }
+
+    public function testPickFilesWithEqualFilename()
+    {
+        $fileInfoSameName = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoOtherName = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoSameName->getFilename()->willReturn('file');
+        $fileInfoOtherName->getFilename()->willReturn('other_file');
+
+        $this->assertTrue(
+            (new FilenameEquals('file'))->isSatisfiedBy($fileInfoSameName->reveal())
+        );
+        $this->assertFalse(
+            (new FilenameEquals('file'))->isSatisfiedBy($fileInfoOtherName->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenFilenameIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getFilename()->willThrow(new UnsupportedFilterException());
+
+        (new FilenameEquals('file'))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/FilenameStartsWithTest.php
+++ b/tests/Filter/FilenameStartsWithTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class FilenameStartsWithTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAllowCreationWithStringOnly()
+    {
+        new FilenameStartsWith(2323);
+    }
+
+    public function testPickFilesWithEqualFilename()
+    {
+        $fileInfoSameName = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoOtherName = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoSameName->getFilename()->willReturn('file');
+        $fileInfoOtherName->getFilename()->willReturn('other_file');
+
+        $this->assertTrue(
+            (new FilenameStartsWith('fil'))->isSatisfiedBy($fileInfoSameName->reveal())
+        );
+        $this->assertFalse(
+            (new FilenameStartsWith('fil'))->isSatisfiedBy($fileInfoOtherName->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenFilenameIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getFilename()->willThrow(new UnsupportedFilterException());
+
+        (new FilenameStartsWith('fil'))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/IsDirectoryTest.php
+++ b/tests/Filter/IsDirectoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class IsDirectoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testChecksIfIsFile()
+    {
+        $fileInfoFile = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoDirectory = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoFile->getType()->willReturn('file');
+        $fileInfoDirectory->getType()->willReturn('dir');
+
+        $this->assertFalse(
+            (new IsDirectory())->isSatisfiedBy($fileInfoFile->reveal())
+        );
+        $this->assertTrue(
+            (new IsDirectory())->isSatisfiedBy($fileInfoDirectory->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenTypeIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getType()->willThrow(new UnsupportedFilterException());
+
+        (new IsDirectory())->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/IsFileTest.php
+++ b/tests/Filter/IsFileTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class IsFileTest extends \PHPUnit_Framework_TestCase
+{
+    public function testChecksIfIsFile()
+    {
+        $fileInfoFile = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoDirectory = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoFile->getType()->willReturn('file');
+        $fileInfoDirectory->getType()->willReturn('directory');
+
+        $this->assertTrue(
+            (new IsFile())->isSatisfiedBy($fileInfoFile->reveal())
+        );
+        $this->assertFalse(
+            (new IsFile())->isSatisfiedBy($fileInfoDirectory->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenTypeIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getType()->willThrow(new UnsupportedFilterException());
+
+        (new IsFile())->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/IsPrivateTest.php
+++ b/tests/Filter/IsPrivateTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class IsPrivateTest extends \PHPUnit_Framework_TestCase
+{
+    public function testChecksPrivateVisibilityOfFile()
+    {
+        $fileInfoPublic = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoPrivate = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoPublic->getVisibility()->willReturn('public');
+        $fileInfoPrivate->getVisibility()->willReturn('private');
+
+        $this->assertFalse(
+            (new IsPrivate())->isSatisfiedBy($fileInfoPublic->reveal())
+        );
+        $this->assertTrue(
+            (new IsPrivate())->isSatisfiedBy($fileInfoPrivate->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenVislibilityIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getVisibility()->willThrow(new UnsupportedFilterException());
+
+        (new IsPublic())->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/IsPublicTest.php
+++ b/tests/Filter/IsPublicTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class IsPublicTest extends \PHPUnit_Framework_TestCase
+{
+    public function testChecksPublicVisibilityOfFile()
+    {
+        $fileInfoPublic = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoPrivate = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoPublic->getVisibility()->willReturn('public');
+        $fileInfoPrivate->getVisibility()->willReturn('private');
+
+        $this->assertTrue(
+            (new IsPublic())->isSatisfiedBy($fileInfoPublic->reveal())
+        );
+        $this->assertFalse(
+            (new IsPublic())->isSatisfiedBy($fileInfoPrivate->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenVislibilityIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getVisibility()->willThrow(new UnsupportedFilterException());
+
+        (new IsPublic())->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/ModifiedAfterTest.php
+++ b/tests/Filter/ModifiedAfterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class ModifiedAfterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \DateTime
+     */
+    private $now;
+    /**
+     * @var \DateTime
+     */
+    private $future;
+    /**
+     * @var \DateTime
+     */
+    private $past;
+
+    public function setUp()
+    {
+        $this->future = new \DateTime('first day of next month');
+        $this->now = new \DateTime('now');
+        $this->past = new \DateTime('first day of previous month');
+    }
+
+    public function testPickFileModifiedAfterDate()
+    {
+        $fileInfoActual = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoPast = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoFuture = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoActual->getTimestamp()->willReturn(date_timestamp_get($this->now));
+        $fileInfoPast->getTimestamp()->willReturn(date_timestamp_get($this->past));
+        $fileInfoFuture->getTimestamp()->willReturn(date_timestamp_get($this->future));
+
+        $this->assertFalse(
+            (new ModifiedAfter($this->now))->isSatisfiedBy($fileInfoPast->reveal())
+        );
+        $this->assertFalse(
+            (new ModifiedAfter($this->now))->isSatisfiedBy($fileInfoActual->reveal())
+        );
+        $this->assertTrue(
+            (new ModifiedAfter($this->now))->isSatisfiedBy($fileInfoFuture->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenTimestampIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getTimestamp()->willThrow(new UnsupportedFilterException());
+
+        (new ModifiedAfter($this->now))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/ModifiedAtTest.php
+++ b/tests/Filter/ModifiedAtTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class ModifiedAtTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \DateTime
+     */
+    private $now;
+    /**
+     * @var \DateTime
+     */
+    private $future;
+    /**
+     * @var \DateTime
+     */
+    private $past;
+
+    public function setUp()
+    {
+        $this->future = new \DateTime('first day of next month');
+        $this->now = new \DateTime('now');
+        $this->past = new \DateTime('first day of previous month');
+    }
+
+    public function testPickFileModifiedAtDate()
+    {
+        $fileInfoActual = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoPast = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoFuture = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoActual->getTimestamp()->willReturn(date_timestamp_get($this->now));
+        $fileInfoPast->getTimestamp()->willReturn(date_timestamp_get($this->past));
+        $fileInfoFuture->getTimestamp()->willReturn(date_timestamp_get($this->future));
+
+        $this->assertFalse(
+            (new ModifiedAt($this->now))->isSatisfiedBy($fileInfoPast->reveal())
+        );
+        $this->assertTrue(
+            (new ModifiedAt($this->now))->isSatisfiedBy($fileInfoActual->reveal())
+        );
+        $this->assertFalse(
+            (new ModifiedAt($this->now))->isSatisfiedBy($fileInfoFuture->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenTimestampIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getTimestamp()->willThrow(new UnsupportedFilterException());
+
+        (new ModifiedAt($this->now))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/ModifiedBeforeTest.php
+++ b/tests/Filter/ModifiedBeforeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class ModifiedBeforeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \DateTime
+     */
+    private $now;
+    /**
+     * @var \DateTime
+     */
+    private $future;
+    /**
+     * @var \DateTime
+     */
+    private $past;
+
+    public function setUp()
+    {
+        $this->future = new \DateTime('first day of next month');
+        $this->now = new \DateTime('now');
+        $this->past = new \DateTime('first day of previous month');
+    }
+
+    public function testPickFileModifiedBeforeDate()
+    {
+        $fileInfoActual = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoPast = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoFuture = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoActual->getTimestamp()->willReturn(date_timestamp_get($this->now));
+        $fileInfoPast->getTimestamp()->willReturn(date_timestamp_get($this->past));
+        $fileInfoFuture->getTimestamp()->willReturn(date_timestamp_get($this->future));
+
+        $this->assertTrue(
+            (new ModifiedBefore($this->now))->isSatisfiedBy($fileInfoPast->reveal())
+        );
+        $this->assertFalse(
+            (new ModifiedBefore($this->now))->isSatisfiedBy($fileInfoActual->reveal())
+        );
+        $this->assertFalse(
+            (new ModifiedBefore($this->now))->isSatisfiedBy($fileInfoFuture->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenTimestampIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getTimestamp()->willThrow(new UnsupportedFilterException());
+
+        (new ModifiedBefore($this->now))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/NotXTests.php
+++ b/tests/Filter/NotXTests.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+class NotXTests extends \PHPUnit_Framework_TestCase
+{
+    public function testWorksAsLogicNotOfCriteriaConstructedWith()
+    {
+        $filterCriteriaOne = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterCriteriaTwo = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterFileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $filterCriteriaOne->isSatisfiedBy($filterFileInfo)->willReturn(true);
+        $filterCriteriaTwo->isSatisfiedBy($filterFileInfo)->willReturn(false);
+
+        $this->assertFalse((new NotX($filterCriteriaOne->reveal()))
+            ->isSatisfiedBy($filterFileInfo->reveal()));
+        $this->assertTrue((new NotX($filterCriteriaTwo->reveal()))
+            ->isSatisfiedBy($filterFileInfo->reveal()));
+    }
+}

--- a/tests/Filter/OrXTests.php
+++ b/tests/Filter/OrXTests.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+class OrXTests extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructionWithDifferentNumberOfArguments()
+    {
+        $filterCriteriaOne = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterCriteriaTwo = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterCriteriaThree = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+
+        new OrX($filterCriteriaOne->reveal());
+        new OrX($filterCriteriaOne->reveal(), $filterCriteriaTwo->reveal());
+        new OrX($filterCriteriaOne->reveal(), $filterCriteriaThree->reveal(), $filterCriteriaTwo->reveal());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCanBeConstructedOnlyWithFilterCriterias()
+    {
+        $filterCriteria = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $string = 'string';
+
+        new OrX($filterCriteria->reveal(), $string);
+    }
+
+    public function testWorksAsLogicOrOfCriteriasConstructedWith()
+    {
+        $filterCriteriaOne = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterCriteriaTwo = $this->prophesize('League\Flysystem\FilterCriteriaInterface');
+        $filterFileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $filterCriteriaOne->isSatisfiedBy($filterFileInfo)->willReturn(true);
+        $filterCriteriaTwo->isSatisfiedBy($filterFileInfo)->willReturn(false);
+
+        $this->assertTrue((new OrX($filterCriteriaOne->reveal(), $filterCriteriaOne->reveal()))
+            ->isSatisfiedBy($filterFileInfo->reveal()));
+        $this->assertTrue((new OrX($filterCriteriaOne->reveal(), $filterCriteriaTwo->reveal()))
+            ->isSatisfiedBy($filterFileInfo->reveal()));
+        $this->assertFalse((new OrX($filterCriteriaTwo->reveal(), $filterCriteriaTwo->reveal()))
+            ->isSatisfiedBy($filterFileInfo->reveal()));
+    }
+}

--- a/tests/Filter/PathContainsTest.php
+++ b/tests/Filter/PathContainsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class PathContainsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAllowCreationWithStringOnly()
+    {
+        new PathContains(2323);
+    }
+
+    public function testPickFilesWithEqualFilename()
+    {
+        $fileInfoSameName = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoSameWithDirName = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoOtherName = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoSameName->getPath()->willReturn('file.txt');
+        $fileInfoSameWithDirName->getPath()->willReturn('dir/file.txt');
+        $fileInfoOtherName->getPath()->willReturn('dir1/dir2/other.txt');
+
+        $this->assertTrue(
+            (new PathContains('fil'))->isSatisfiedBy($fileInfoSameName->reveal())
+        );
+        $this->assertTrue(
+            (new PathContains('fil'))->isSatisfiedBy($fileInfoSameWithDirName->reveal())
+        );
+        $this->assertFalse(
+            (new PathContains('fil'))->isSatisfiedBy($fileInfoOtherName->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenPathIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getPath()->willThrow(new UnsupportedFilterException());
+
+        (new PathContains('fil'))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/SizeBiggerThanTest.php
+++ b/tests/Filter/SizeBiggerThanTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class SizeBiggerThanTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPickBiggerFiles()
+    {
+        $fileInfoSmall = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoMedium = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoBig = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoSmall->getSize()->willReturn(256);
+        $fileInfoMedium->getSize()->willReturn(512);
+        $fileInfoBig->getSize()->willReturn(1024);
+
+        $this->assertFalse(
+            (new SizeBiggerThan(512))->isSatisfiedBy($fileInfoSmall->reveal())
+        );
+        $this->assertFalse(
+            (new SizeBiggerThan(512))->isSatisfiedBy($fileInfoMedium->reveal())
+        );
+        $this->assertTrue(
+            (new SizeBiggerThan(512))->isSatisfiedBy($fileInfoBig->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenSizeIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getSize()->willThrow(new UnsupportedFilterException());
+
+        (new SizeBiggerThan(512))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/SizeEqualsTest.php
+++ b/tests/Filter/SizeEqualsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class SizeEqualsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPickFilesWithSameSize()
+    {
+        $fileInfoSmall = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoMedium = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoBig = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoSmall->getSize()->willReturn(256);
+        $fileInfoMedium->getSize()->willReturn(512);
+        $fileInfoBig->getSize()->willReturn(1024);
+
+        $this->assertFalse(
+            (new SizeEquals(512))->isSatisfiedBy($fileInfoSmall->reveal())
+        );
+        $this->assertTrue(
+            (new SizeEquals(512))->isSatisfiedBy($fileInfoMedium->reveal())
+        );
+        $this->assertFalse(
+            (new SizeEquals(512))->isSatisfiedBy($fileInfoBig->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenSizeIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getSize()->willThrow(new UnsupportedFilterException());
+
+        (new SizeEquals(512))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/Filter/SizeSmallerThanTest.php
+++ b/tests/Filter/SizeSmallerThanTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace League\Flysystem\Filter;
+
+use League\Flysystem\UnsupportedFilterException;
+
+class SizeSmallerThanTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPickFilesWithSameSize()
+    {
+        $fileInfoSmall = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoMedium = $this->prophesize('League\Flysystem\FilterFileInfo');
+        $fileInfoBig = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfoSmall->getSize()->willReturn(256);
+        $fileInfoMedium->getSize()->willReturn(512);
+        $fileInfoBig->getSize()->willReturn(1024);
+
+        $this->assertTrue(
+            (new SizeSmallerThan(512))->isSatisfiedBy($fileInfoSmall->reveal())
+        );
+        $this->assertFalse(
+            (new SizeSmallerThan(512))->isSatisfiedBy($fileInfoMedium->reveal())
+        );
+        $this->assertFalse(
+            (new SizeSmallerThan(512))->isSatisfiedBy($fileInfoBig->reveal())
+        );
+    }
+
+    /**
+     * @expectedException League\Flysystem\UnsupportedFilterException
+     */
+    public function testWillNotFilterWhenSizeIsNotSupportedByFileInfo()
+    {
+        $fileInfo = $this->prophesize('League\Flysystem\FilterFileInfo');
+
+        $fileInfo->getSize()->willThrow(new UnsupportedFilterException());
+
+        (new SizeSmallerThan(512))->isSatisfiedBy($fileInfo->reveal());
+    }
+}

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -3,6 +3,13 @@
 namespace League\Flysystem\Adapter;
 
 use League\Flysystem\Config;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Filter\AndX;
+use League\Flysystem\Filter\ExtensionEquals;
+use League\Flysystem\Filter\FilenameStartsWith;
+use League\Flysystem\Filter\IsFile;
+use League\Flysystem\Filter\OrX;
+use League\Flysystem\Filter\PathContains;
 
 function fopen($result, $mode)
 {
@@ -215,6 +222,33 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->adapter->write('dirname/other.txt', 'contents', new Config());
         $contents = $this->adapter->listContents('', true);
         $this->assertCount(3, $contents);
+    }
+
+    public function testListFilteredContents()
+    {
+        $this->adapter->write('file.txt', 'contents', new Config());
+        $this->adapter->write('file2.jpg', 'contents', new Config());
+        $this->adapter->write('music.mp3', 'contents', new Config());
+
+        $contentsOne = $this->adapter->listFilteredContents(
+            new AndX(
+                new IsFile(),
+                new PathContains('fil')
+            )
+        );
+
+        $contentsTwo = $this->adapter->listFilteredContents(
+            new AndX(
+                new IsFile,
+                new OrX(
+                    new PathContains('jpg'),
+                    new PathContains('mp3')
+                )
+            )
+        );
+
+        $this->assertCount(2, $contentsOne);
+        $this->assertCount(2, $contentsTwo);
     }
 
     public function testGetSize()


### PR DESCRIPTION
…usage with Local adapter

| Q | A |
| --: | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations | no |
| Tests pass? | yes |
| Issue | #503 |

It's proposition for #503. 

There is new interface to implement to avoid BC breaks and allow filtering. Mechanism prefer filtering inside adapter but when adapter doesn't support filtering it is done by the filesystem. There is implemented filtering inside Local adapter as an example.

Filtering is made by Specification patter and that allows to easily adding new type of filters without need to build or modify huge tree of if's an else's.

There are implemented set of example filter criteria which operates on file path, name, size, timestamp, visibility, type, extension. Also logical operation on filters are implemented to make possible easy combining of criteria.

If some of operation are unsupported because of lack of file information given by adapter then exception is thrown.

Examples of usage

Filtering by filename

```
$filesystem->listFilteredContents(
    new FilenameEquals('sample_file')
);
```

JPG files modified before now

```
$filesystem->listFilteredContents(
    new AndX(
        new ExtensionEquals('jpg'),
        new ModifiedBefore(new \DateTime('now'))
    )
);
```

PNG or JPG files bigger than 1024 bytes

```
$filesystem->listFilteredContents(
    new AndX(
        new SizeBiggerThan(1024),
        new OrX(
            new ExtensionEquals('jpg')
            new ExtensionEquals('png')
        )
    )
);
```

Creation of new filters
It's simple as creation of new class that implements `FilterCriteriaInterface`

```
<?php

namespace League\Flysystem;

interface FilterCriteriaInterface
{
    /**
     * Determines that file info satisfying criteria or not.
     *
     * @param FilterFileInfo $filterFileInfo
     *
     * @return bool
     */
    public function isSatisfiedBy(FilterFileInfo $filterFileInfo);
}
```

Example of creating new criteria as combination of existing ones

```
<?php

namespace League\Flysystem\Filter;

use League\Flysystem\FilterCriteriaInterface;
use League\Flysystem\FilterFileInfo;

class IsImage implements FilterCriteriaInterface
{
    /**
     * @inheritdoc
     */
    public function isSatisfiedBy(FilterFileInfo $filterFileInfo)
    {
        return (new AndX(
            new IsFile(),
            new OrX(
                new ExtensionEquals('jpg'),
                new ExtensionEquals('png'),
                new ExtensionEquals('gif'),
            )
        ))->isSatisfiedBy($filterFileInfo);
    }
}
```
