### PR TITLE
CaseSensitivity fix for Dropbox

### DIFF
--- a/src/Util/ContentListingFormatter.php
+++ b/src/Util/ContentListingFormatter.php
@@ -97,7 +97,7 @@ class ContentListingFormatter
      */
     private function isDirectChild(array $entry)
     {
-        return Util::dirname($entry['path']) === $this->directory;
+        return strtolower(Util::dirname($entry['path'])) === strtolower($this->directory);
     }
 
     /**


### PR DESCRIPTION
When renaming directories in Dropbox (from and to upper to lower case) it causes path comparision bug to discard existing directories in Listing.
This commit is an easy fix on that bug
