### PR TITLE
fix League\Flysystem\Config::has() so that it also checks the fallback config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -50,6 +50,10 @@ class Config
      */
     public function has($key)
     {
+        if ( ! array_key_exists($key, $this->settings) && $this->fallback) {
+            return $this->fallback->has($key);
+        }
+
         return array_key_exists($key, $this->settings);
     }
 


### PR DESCRIPTION
Currently `League\Flysystem\Config::has()` doesn't check if the `$key` exists on the fallback config. 

I was testing the [`Superbalist/flysystem-google-cloud-storage`](https://github.com/Superbalist/flysystem-google-cloud-storage) and it [relies on the previously mentioned method](https://github.com/Superbalist/flysystem-google-cloud-storage/blob/master/src/GoogleStorageAdapter.php#L142) to check if the `visibility` was set but it would never return true, so after some debugging this is my finding and suggested fix.