### PR TITLE
Fix Util::normalizeRelativePath

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -85,7 +85,7 @@ class Util
         $normalized = preg_replace('#\p{C}+|^\./#u', '', $path);
         $normalized = static::normalizeRelativePath($normalized);
 
-        if (preg_match('#/\.{2}|^\.{2}/|^\.{2}$#', $normalized)) {
+        if (preg_match('#(^|/)\.{2}(/|$)#', $normalized)) {
             throw new LogicException(
                 'Path is outside of the defined root, path: [' . $path . '], resolved: [' . $normalized . ']'
             );

--- a/src/Util.php
+++ b/src/Util.php
@@ -110,7 +110,7 @@ class Util
         $path = preg_replace('#/\.(?=/)|^\./|(/|^)\./?$#', '', $path);
 
         // Regex for resolving relative paths
-        $regex = '#/*[^/\.]+/\.\.#Uu';
+        $regex = '#/*[^/\.]+/\.\.(/|$)#Uu';
 
         while (preg_match($regex, $path)) {
             $path = preg_replace($regex, '', $path);

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -107,6 +107,7 @@ class UtilTests extends \PHPUnit_Framework_TestCase
             ['\\\\some\shared\\\\drive', 'some\shared\drive'],
             ['C:\dirname\\\\subdir\\\\\\subsubdir', 'C:\dirname\subdir\subsubdir'],
             ['C:\\\\dirname\subdir\\\\subsubdir', 'C:\dirname\subdir\subsubdir'],
+            ['example/path/..txt', 'example/path/..txt'],
         ];
     }
 


### PR DESCRIPTION
Bug example:
echo Utils::normalizeRelativePath('example/path/..txt'); 
//Output: example/txt
//Expected: example/path/..txt

Because after .. must be / or end of string.