### PR TITLE
Fix: escape space characters for ftp adapter

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -512,7 +512,11 @@ class Ftp extends AbstractFtpAdapter
 
     protected function detectFtpServerName()
     {
-        $response = ftp_raw($this->getConnection(), 'HELP');
+        if (!$this->connection) {
+            return null;
+        }
+        
+        $response = ftp_raw($this->connection, 'HELP');
         if (!$response) {
             return null;
         }

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -353,7 +353,7 @@ class Ftp extends AbstractFtpAdapter
             return ['type' => 'dir', 'path' => $path];
         }
 
-        $listing = ftp_rawlist($connection, '-A ' . str_replace('*', '\\*', $path));
+        $listing = $this->ftp_rawlist('-A ', str_replace('*', '\\*', $path));
 
         if (empty($listing)) {
             return false;
@@ -456,7 +456,7 @@ class Ftp extends AbstractFtpAdapter
         }
 
         $options = $recursive ? '-alnR' : '-aln';
-        $listing = ftp_rawlist($this->getConnection(), $options . ' ' . $directory);
+        $listing = $this->ftp_rawlist($options, $directory);
 
         return $listing ? $this->normalizeListing($listing, $directory) : [];
     }
@@ -468,7 +468,7 @@ class Ftp extends AbstractFtpAdapter
      */
     protected function listDirectoryContentsRecursive($directory)
     {
-        $listing = $this->normalizeListing(ftp_rawlist($this->getConnection(), '-aln' . ' ' . $directory) ?: []);
+        $listing = $this->normalizeListing($this->ftp_rawlist('-aln', $directory) ?: []);
         $output = [];
 
         foreach ($listing as $directory) {
@@ -501,5 +501,11 @@ class Ftp extends AbstractFtpAdapter
 
             return false;
         }
+    }
+
+    protected function ftp_rawlist($options, $path)
+    {
+        $path = str_replace(' ', '\ ', $path);
+        return ftp_rawlist($this->getConnection(), $options . ' ' . $path);
     }
 }

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -360,7 +360,7 @@ class Ftp extends AbstractFtpAdapter
             return ['type' => 'dir', 'path' => $path];
         }
 
-        $listing = $this->ftp_rawlist('-A', str_replace('*', '\\*', $path));
+        $listing = $this->ftpRawlist('-A', str_replace('*', '\\*', $path));
 
         if (empty($listing)) {
             return false;
@@ -463,7 +463,7 @@ class Ftp extends AbstractFtpAdapter
         }
 
         $options = $recursive ? '-alnR' : '-aln';
-        $listing = $this->ftp_rawlist($options, $directory);
+        $listing = $this->ftpRawlist($options, $directory);
 
         return $listing ? $this->normalizeListing($listing, $directory) : [];
     }
@@ -475,7 +475,7 @@ class Ftp extends AbstractFtpAdapter
      */
     protected function listDirectoryContentsRecursive($directory)
     {
-        $listing = $this->normalizeListing($this->ftp_rawlist('-aln', $directory) ?: []);
+        $listing = $this->normalizeListing($this->ftpRawlist('-aln', $directory) ?: []);
         $output = [];
 
         foreach ($listing as $directory) {
@@ -529,7 +529,7 @@ class Ftp extends AbstractFtpAdapter
         return null;
     }
 
-    protected function ftp_rawlist($options, $path)
+    protected function ftpRawlist($options, $path)
     {
         if ($this->ftpServerName == 'Pure-FTPd') {
             $path = str_replace(' ', '\ ', $path);


### PR DESCRIPTION
Bug example:

```
$filesystem->has('that path/have/the space character.txt');
// Return false every time if in path have space character.
```

Because before call ftp_rawlist we need add a slash in front of each space character in path.

```
$options = '-A';
$path = str_replace(' ', '\ ', $path);
$result = ftp_rawlist($connection, $options . ' ' . $path);
```
