### PR TITLE
Introduce putRequiresUpdate and putStreamRequiresUpdate

### DIFF
--- a/spec/FilesystemSpec.php
+++ b/spec/FilesystemSpec.php
@@ -115,6 +115,7 @@ class FilesystemSpec extends ObjectBehavior
 
     public function it_should_write_when_putting_a_new_file()
     {
+        $this->adapter->putRequiresUpdate()->willReturn(true);
         $this->adapter->has('file')->willReturn(false);
         $this->adapter->write('file', 'contents', Argument::type('League\Flysystem\Config'))->willReturn($cache = [
             'path' => 'file',
@@ -126,6 +127,7 @@ class FilesystemSpec extends ObjectBehavior
     public function it_should_write_when_putting_a_new_file_using_stream()
     {
         $stream = tmpfile();
+        $this->adapter->putStreamRequiresUpdate()->willReturn(true);
         $this->adapter->has('file')->willReturn(false);
         $this->adapter->writeStream('file', $stream, Argument::type('League\Flysystem\Config'))->willReturn($cache = [
             'path' => 'file',
@@ -136,6 +138,7 @@ class FilesystemSpec extends ObjectBehavior
 
     public function it_should_update_when_putting_a_new_file()
     {
+        $this->adapter->putRequiresUpdate()->willReturn(true);
         $this->adapter->has('file')->willReturn(true);
         $this->adapter->update('file', 'contents', Argument::type('League\Flysystem\Config'))->willReturn($cache = [
             'path' => 'file',
@@ -147,6 +150,7 @@ class FilesystemSpec extends ObjectBehavior
     public function it_should_update_when_putting_a_new_file_using_stream()
     {
         $stream = tmpfile();
+        $this->adapter->putStreamRequiresUpdate()->willReturn(true);
         $this->adapter->has('file')->willReturn(true);
         $this->adapter->updateStream('file', $stream, Argument::type('League\Flysystem\Config'))->willReturn($cache = [
             'path' => 'file',

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -17,6 +17,16 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $pathSeparator = '/';
 
     /**
+     * @var bool
+     */
+    protected $putRequiresUpdate = true;
+
+    /**
+     * @var bool
+     */
+    protected $putStreamRequiresUpdate = true;
+
+    /**
      * Set the path prefix.
      *
      * @param string $prefix
@@ -82,5 +92,25 @@ abstract class AbstractAdapter implements AdapterInterface
         }
 
         return substr($path, strlen($pathPrefix));
+    }
+
+    /**
+     * Returns whether the adapter requires update to be called if path exists
+     *
+     * @return bool
+     */
+    public function putRequiresUpdate()
+    {
+        return $this->putRequiresUpdate;
+    }
+
+    /**
+     * Returns whether the adapter requires update to be called if path exists for a stream
+     *
+     * @return bool
+     */
+    public function putStreamRequiresUpdate()
+    {
+        return $this->putStreamRequiresUpdate;
     }
 }

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -115,4 +115,18 @@ interface AdapterInterface extends ReadInterface
      * @return array|false file meta data
      */
     public function setVisibility($path, $visibility);
+
+    /**
+     * Returns whether the adapter requires update to be called if path exists
+     *
+     * @return bool
+     */
+    public function putRequiresUpdate();
+
+    /**
+     * Returns whether the adapter requires update to be called if path exists for a stream
+     *
+     * @return bool
+     */
+    public function putStreamRequiresUpdate();
 }

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -94,7 +94,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $config = $this->prepareConfig($config);
 
-        if ($this->has($path)) {
+        if ($this->getAdapter()->putRequiresUpdate() && $this->has($path)) {
             return (bool) $this->getAdapter()->update($path, $contents, $config);
         }
 
@@ -114,7 +114,7 @@ class Filesystem implements FilesystemInterface
         $config = $this->prepareConfig($config);
         Util::rewindStream($resource);
 
-        if ($this->has($path)) {
+        if ($this->getAdapter()->putStreamRequiresUpdate() && $this->has($path)) {
             return (bool) $this->getAdapter()->updateStream($path, $resource, $config);
         }
 

--- a/tests/FilesystemTests.php
+++ b/tests/FilesystemTests.php
@@ -113,6 +113,7 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
     {
         $path = 'path.txt';
         $contents = 'contents';
+        $this->prophecy->putRequiresUpdate()->willReturn(true);
         $this->prophecy->has($path)->willReturn(false);
         $this->prophecy->write($path, $contents, $this->config)->willReturn(compact('path', 'contents'));
         $this->assertTrue($this->filesystem->put($path, $contents));
@@ -122,6 +123,7 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
     {
         $path = 'path.txt';
         $stream = tmpfile();
+        $this->prophecy->putStreamRequiresUpdate()->willReturn(true);
         $this->prophecy->has($path)->willReturn(false);
         $this->prophecy->writeStream($path, $stream, $this->config)->willReturn(compact('path'));
         $this->assertTrue($this->filesystem->putStream($path, $stream));
@@ -132,6 +134,7 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
     {
         $path = 'path.txt';
         $contents = 'contents';
+        $this->prophecy->putRequiresUpdate()->willReturn(true);
         $this->prophecy->has($path)->willReturn(true);
         $this->prophecy->update($path, $contents, $this->config)->willReturn(compact('path', 'contents'));
         $this->assertTrue($this->filesystem->put($path, $contents));
@@ -141,8 +144,47 @@ class FilesystemTests extends \PHPUnit_Framework_TestCase
     {
         $path = 'path.txt';
         $stream = tmpfile();
+        $this->prophecy->putStreamRequiresUpdate()->willReturn(true);
         $this->prophecy->has($path)->willReturn(true);
         $this->prophecy->updateStream($path, $stream, $this->config)->willReturn(compact('path'));
+        $this->assertTrue($this->filesystem->putStream($path, $stream));
+        fclose($stream);
+    }
+
+    public function testPutNewNoUpdate()
+    {
+        $path = 'path.txt';
+        $contents = 'contents';
+        $this->prophecy->putRequiresUpdate()->willReturn(false);
+        $this->prophecy->write($path, $contents, $this->config)->willReturn(compact('path', 'contents'));
+        $this->assertTrue($this->filesystem->put($path, $contents));
+    }
+
+    public function testPutNewStreamNoUpdate()
+    {
+        $path = 'path.txt';
+        $stream = tmpfile();
+        $this->prophecy->putStreamRequiresUpdate()->willReturn(false);
+        $this->prophecy->writeStream($path, $stream, $this->config)->willReturn(compact('path'));
+        $this->assertTrue($this->filesystem->putStream($path, $stream));
+        fclose($stream);
+    }
+
+    public function testPutUpdateNoUpdate()
+    {
+        $path = 'path.txt';
+        $contents = 'contents';
+        $this->prophecy->putRequiresUpdate()->willReturn(false);
+        $this->prophecy->write($path, $contents, $this->config)->willReturn(compact('path', 'contents'));
+        $this->assertTrue($this->filesystem->put($path, $contents));
+    }
+
+    public function testPutUpdateStreamNoUpdate()
+    {
+        $path = 'path.txt';
+        $stream = tmpfile();
+        $this->prophecy->putStreamRequiresUpdate()->willReturn(false);
+        $this->prophecy->writeStream($path, $stream, $this->config)->willReturn(compact('path'));
         $this->assertTrue($this->filesystem->putStream($path, $stream));
         fclose($stream);
     }


### PR DESCRIPTION
# What does this PR do?

Add `putRequiresUpdate` and `putStreamRequiresUpdate` so that `Adapters` which do not differentiate between a `write` and a `update` can skip the `has` call, which has detrimental effect on some filesystem performance for initial write.
# Why?

We have observed poor performance calling `put` when using the [`flysystem-aws-s3-v3`](https://github.com/thephpleague/flysystem-aws-s3-v3) adapter on initial upload of an object.
# What is the cause

[`Filesystem->put()` calls a `has`](https://github.com/thephpleague/flysystem/blob/master/src/Filesystem.php#L97-L99) to determine if the object should be created or updated. This triggers up to two requests to s3.
1. First, `has` calls [`S3Client->doesObjectExist`](https://github.com/aws/aws-sdk-php/blob/master/src/S3/S3ClientTrait.php#L197) which causes a `HEAD` to be triggered
2. If the HEAD returns with no object found, it runs [`doesDirectoryExist`](https://github.com/thephpleague/flysystem-aws-s3-v3/blob/master/src/AwsS3Adapter.php#L655) which checks if the "directory" exists by calling `listObjects` with a prefix up to the final `/` of the path in question.

As an s3 bucket gets busier, performance sometimes suffers. The trace below shows a request where the entire `has` function has taken 635ms to run, while the actual `write` to s3, once started, takes only 69ms. Ideally we should avoid making this request, since there is no actual need. 
#### Column Headers: Duration (ms), Duration (%), Segment, Drilldown, Timestamp

![image](https://cloud.githubusercontent.com/assets/618130/19402134/5555e36a-922d-11e6-8f16-46b4fb92cdaa.png)

Update: I've added a second trace where the second part of `has`, the call to `doesDirectoryExist`, has taken 1960ms to run.
![image](https://cloud.githubusercontent.com/assets/618130/19404615/77a75c54-923d-11e6-9b57-ed5bf0e2a337.png)

The s3 adapter in particular does not make any distinction between a [`write()` and `update()`](https://github.com/thephpleague/flysystem-aws-s3-v3/blob/master/src/AwsS3Adapter.php#L115-L132) or [`writeStream()` and `updateStream()`](https://github.com/thephpleague/flysystem-aws-s3-v3/blob/master/src/AwsS3Adapter.php#L362-L379) so for this adapter there is no reason to call `has`. Just call `write()` or `writeStream()`.
# Other impacts

Removing the un-needed `HEAD` call on new object uploads will prevent the following issue from being needlessly introduced.

> Amazon S3 provides read-after-write consistency for PUTS of new objects in your S3 bucket in all regions with one caveat. The caveat is that if you make a HEAD or GET request to the key name (to find if the object exists) before creating the object, Amazon S3 provides eventual consistency for read-after-write.
> (from http://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel)
# Finally

I'm happy to work on the implementation here if changes are requested.
