### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can also use Flysystem without using Composer by registering an autoloader f
 spl_autoload_register(function($class) {
     $prefix = 'League\\Flysystem\\';
 
-    if ( ! substr($class, 0, 17) === $prefix) {
+    if (substr($class, 0, 17) !== $prefix) {
         return;
     }
 


### PR DESCRIPTION
PHP logical negation operator has higher precedence then comparison so old expression was equivalent to `(! substr($class, 0, 17)) === $prefix`.