### PR TITLE
[Plugin] PassiveWrite: Write a file or pass if it exists without overwriting or failing

### DIFF
--- a/src/Plugin/PassiveWrite.php
+++ b/src/Plugin/PassiveWrite.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace League\Flysystem\Plugin;
+
+use League\Flysystem\FileExistsException;
+
+class PassiveWrite extends AbstractPlugin
+{
+    /**
+     * @inheritdoc
+     */
+    public function getMethod()
+    {
+        return 'passiveWrite';
+    }
+
+    /**
+     * Writes a file, passing if it already existing.
+     *
+     * @param string $path     Path to the file to write.
+     * @param string $contents Contents to write.
+     * @param array  $config   Config options for the adapter.
+     *
+     * @return bool True on success, false on failure.
+     */
+    public function handle($path, $contents, $config=[])
+    {
+        try {
+            $written = $this->filesystem->write($path, $contents, $config);
+        } catch (FileExistsException $e) {
+            // The destination path exists. Don't write.
+            $written = true;
+        }
+
+        return $written;
+    }
+}

--- a/tests/PassiveWritePluginTests.php
+++ b/tests/PassiveWritePluginTests.php
@@ -9,7 +9,9 @@ class PassiveWritePluginTests extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->filesystem = Mockery::mock('League\Flysystem\FilesystemInterface');
+        $this->filesystem = Mockery::mock(
+            'League\Flysystem\FilesystemInterface'
+        );
         $this->plugin = new PassiveWrite();
         $this->plugin->setFilesystem($this->filesystem);
     }
@@ -17,21 +19,25 @@ class PassiveWritePluginTests extends PHPUnit_Framework_TestCase
     public function testPluginSuccess()
     {
         $this->assertSame('passiveWrite', $this->plugin->getMethod());
-        $this->filesystem->shouldReceive('write')->with('path', 'contents')->andReturn(true);
+        $this->filesystem->shouldReceive('write')
+            ->with('path', 'contents', [])
+            ->andReturn(true);
         $this->assertTrue($this->plugin->handle('path', 'contents'));
     }
 
     public function testPluginFileExists()
     {
         $this->filesystem->shouldReceive('write')
-            ->with('path', 'contents')
+            ->with('path', 'contents', [])
             ->andThrow('League\Flysystem\FileExistsException', 'path');
         $this->assertTrue($this->plugin->handle('path', 'newpath'));
     }
 
     public function testPluginFail()
     {
-        $this->filesystem->shouldReceive('write')->with('path', 'contents')->andReturn(false);
+        $this->filesystem->shouldReceive('write')
+            ->with('path', 'contents', [])
+            ->andReturn(false);
         $this->assertFalse($this->plugin->handle('path', 'contents'));
     }
 }

--- a/tests/PassiveWritePluginTests.php
+++ b/tests/PassiveWritePluginTests.php
@@ -30,7 +30,7 @@ class PassiveWritePluginTests extends PHPUnit_Framework_TestCase
         $this->filesystem->shouldReceive('write')
             ->with('path', 'contents', [])
             ->andThrow('League\Flysystem\FileExistsException', 'path');
-        $this->assertTrue($this->plugin->handle('path', 'newpath'));
+        $this->assertTrue($this->plugin->handle('path', 'contents'));
     }
 
     public function testPluginFail()

--- a/tests/PassiveWritePluginTests.php
+++ b/tests/PassiveWritePluginTests.php
@@ -1,0 +1,37 @@
+<?php
+
+use League\Flysystem\Plugin\PassiveWrite;
+
+class PassiveWritePluginTests extends PHPUnit_Framework_TestCase
+{
+    protected $filesystem;
+    protected $plugin;
+
+    public function setUp()
+    {
+        $this->filesystem = Mockery::mock('League\Flysystem\FilesystemInterface');
+        $this->plugin = new PassiveWrite();
+        $this->plugin->setFilesystem($this->filesystem);
+    }
+
+    public function testPluginSuccess()
+    {
+        $this->assertSame('passiveWrite', $this->plugin->getMethod());
+        $this->filesystem->shouldReceive('write')->with('path', 'contents')->andReturn(true);
+        $this->assertTrue($this->plugin->handle('path', 'contents'));
+    }
+
+    public function testPluginFileExists()
+    {
+        $this->filesystem->shouldReceive('write')
+            ->with('path', 'contents)
+            ->andThrow('League\Flysystem\FileExistsException', 'path');
+        $this->assertTrue($this->plugin->handle('path', 'newpath'));
+    }
+
+    public function testPluginFail()
+    {
+        $this->filesystem->shouldReceive('write')->with('path', 'contents')->andReturn(false);
+        $this->assertFalse($this->plugin->handle('path', 'contents'));
+    }
+}

--- a/tests/PassiveWritePluginTests.php
+++ b/tests/PassiveWritePluginTests.php
@@ -24,7 +24,7 @@ class PassiveWritePluginTests extends PHPUnit_Framework_TestCase
     public function testPluginFileExists()
     {
         $this->filesystem->shouldReceive('write')
-            ->with('path', 'contents)
+            ->with('path', 'contents')
             ->andThrow('League\Flysystem\FileExistsException', 'path');
         $this->assertTrue($this->plugin->handle('path', 'newpath'));
     }


### PR DESCRIPTION
This adds a new plugin, PassiveWrite, which attempts to write a file, but still returns a success message, even if the target path already exists.

It is a drop-in replacement for the standard `write` method.