### PR TITLE
Fix Windows path handling and simplify path normalization.

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -81,26 +81,7 @@ class Util
      */
     public static function normalizePath($path)
     {
-        $isWindowsPath = strpos($path, '\\') !== false;
-        $normalized = str_replace('\\', '/', $path);
-        // Remove any kind of funky unicode whitespace
-        $normalized = preg_replace('#\p{C}+|^\./#u', '', $normalized);
-        $normalized = static::normalizeRelativePath($normalized);
-
-        if (preg_match('#(^|/)\.{2}(/|$)#', $normalized)) {
-            throw new LogicException(
-                'Path is outside of the defined root, path: [' . $path . '], resolved: [' . $normalized . ']'
-            );
-        }
-
-        $normalized = preg_replace('#\\\{2,}#', '\\', trim($normalized, '\\'));
-        $normalized = preg_replace('#/{2,}#', '/', trim($normalized, '/'));
-
-        if ($isWindowsPath) {
-            return str_replace('/', '\\', $normalized);
-        }
-
-        return $normalized;
+        return static::normalizeRelativePath($path);
     }
 
     /**
@@ -108,18 +89,53 @@ class Util
      *
      * @param string $path
      *
+     * @throws LogicException
+     *
      * @return string
      */
     public static function normalizeRelativePath($path)
     {
-        // Path remove self referring paths ("/./").
-        $path = preg_replace('#/\.(?=/)|^\./|(/|^)\./?$#', '', $path);
+        $path = str_replace('\\', '/', $path);
+        $path = static::removeFunkyWhiteSpace($path);
 
-        // Regex for resolving relative paths
-        $regex = '#/*[^/\.]+/\.\.(?=/|$)#Uu';
+        $parts = [];
 
-        while (preg_match($regex, $path)) {
-            $path = preg_replace($regex, '', $path);
+        foreach (explode('/', $path) as $part) {
+            switch ($part) {
+                case '':
+                case '.':
+                break;
+
+            case '..':
+                if (empty($parts)) {
+                    throw new LogicException(
+                        'Path is outside of the defined root, path: [' . $path . ']'
+                    );
+                }
+                array_pop($parts);
+                break;
+
+            default:
+                $parts[] = $part;
+                break;
+            }
+        }
+
+        return implode('/', $parts);
+    }
+
+    /**
+     * Removes unprintable characters and invalid unicode characters.
+     *
+     * @param string $path
+     *
+     * @return string $path
+     */
+    protected static function removeFunkyWhiteSpace($path) {
+        // We do this check in a loop, since removing invalid unicode characters
+        // can lead to new characters being created.
+        while (preg_match('#\p{C}+|^\./#u', $path)) {
+            $path = preg_replace('#\p{C}+|^\./#u', '', $path);
         }
 
         return $path;

--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -106,13 +106,14 @@ class UtilTests extends \PHPUnit_Framework_TestCase
             ['/something/deep/../../dirname', 'dirname'],
             ['00004869/files/other/10-75..stl', '00004869/files/other/10-75..stl'],
             ['/dirname//subdir///subsubdir', 'dirname/subdir/subsubdir'],
-            ['\dirname\\\\subdir\\\\\\subsubdir', 'dirname\subdir\subsubdir'],
-            ['\\\\some\shared\\\\drive', 'some\shared\drive'],
-            ['C:\dirname\\\\subdir\\\\\\subsubdir', 'C:\dirname\subdir\subsubdir'],
-            ['C:\\\\dirname\subdir\\\\subsubdir', 'C:\dirname\subdir\subsubdir'],
+            ['\dirname\\\\subdir\\\\\\subsubdir', 'dirname/subdir/subsubdir'],
+            ['\\\\some\shared\\\\drive', 'some/shared/drive'],
+            ['C:\dirname\\\\subdir\\\\\\subsubdir', 'C:/dirname/subdir/subsubdir'],
+            ['C:\\\\dirname\subdir\\\\subsubdir', 'C:/dirname/subdir/subsubdir'],
             ['example/path/..txt', 'example/path/..txt'],
-            ['\\example\\path.txt', 'example\\path.txt'],
+            ['\\example\\path.txt', 'example/path.txt'],
             ['\\example\\..\\path.txt', 'path.txt'],
+            ["some\0/path.txt", 'some/path.txt'],
         ];
     }
 


### PR DESCRIPTION
Issues:
1. Just because a path contains a backslash, doesn't mean it's a Windows path. Backslashes are valid in file/directory names on Linux.
2. Windows is fine using forward slashes for paths.
3. The regex was hard to figure out. This, to me at least, is a lot simpler to follow.
4. Added a test to check about removing null bytes.

Even though Linux supports backslashes, I haven't checked all the other adapters to see what they support. And, since backslashes are directory separators on Windows, we could wind up with different file structures if we allowed them. This seems like the lowest common denominator.

Also, I've merged `normalizePath()` and `normalizeRelativePath()` since I don't see a safe subset for `normalizeRelativePath()` to do, or how they are really different.