### PR TITLE
Simplify prefix handling.

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -25,13 +25,14 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function setPathPrefix($prefix)
     {
-        $is_empty = empty($prefix);
+        $prefix = (string) $prefix;
 
-        if ( ! $is_empty) {
-            $prefix = rtrim($prefix, '\\/') . $this->pathSeparator;
+        if ($prefix === '') {
+            $this->pathPrefix = null;
+            return;
         }
 
-        $this->pathPrefix = $is_empty ? null : $prefix;
+        $this->pathPrefix = rtrim($prefix, '\\/') . $this->pathSeparator;
     }
 
     /**
@@ -53,17 +54,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function applyPathPrefix($path)
     {
-        $path = ltrim($path, '\\/');
-
-        if (strlen($path) === 0) {
-            return $this->getPathPrefix() ?: '';
-        }
-
-        if ($prefix = $this->getPathPrefix()) {
-            $path = $prefix . $path;
-        }
-
-        return $path;
+        return $this->getPathPrefix() . ltrim($path, '\\/');
     }
 
     /**
@@ -75,12 +66,6 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function removePathPrefix($path)
     {
-        $pathPrefix = $this->getPathPrefix();
-
-        if ($pathPrefix === null) {
-            return $path;
-        }
-
-        return substr($path, strlen($pathPrefix));
+        return substr($path, strlen($this->getPathPrefix()));
     }
 }

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -493,16 +493,6 @@ class Local extends AbstractAdapter
     }
 
     /**
-     * @inheritdoc
-     */
-    public function applyPathPrefix($path)
-    {
-        $prefixedPath = parent::applyPathPrefix($path);
-
-        return str_replace('/', DIRECTORY_SEPARATOR, $prefixedPath);
-    }
-
-    /**
      * @param SplFileInfo $file
      *
      * @throws UnreadableFileException

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -195,6 +195,23 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals($path, $this->adapter->removePathPrefix($path));
     }
 
+    public function testWindowsPrefix()
+    {
+        $path = 'some' . DIRECTORY_SEPARATOR . 'path.ext';
+        $expected = 'c:' . DIRECTORY_SEPARATOR . $path;
+
+        $this->adapter->setPathPrefix('c:/');
+        $prefixed = $this->adapter->applyPathPrefix($path);
+        $this->assertEquals($expected, $prefixed);
+        $this->assertEquals($path, $this->adapter->removePathPrefix($prefixed));
+
+        $expected = 'c:\\\\some\\dir' . DIRECTORY_SEPARATOR . $path;
+        $this->adapter->setPathPrefix('c:\\\\some\\dir\\');
+        $prefixed = $this->adapter->applyPathPrefix($path);
+        $this->assertEquals($expected, $prefixed);
+        $this->assertEquals($path, $this->adapter->removePathPrefix($prefixed));
+    }
+
     public function testGetPathPrefix()
     {
         $this->assertEquals(realpath($this->root), realpath($this->adapter->getPathPrefix()));


### PR DESCRIPTION
Relating to #739 and #740.

I was doing some investigating, and I couldn't find a problem.

I wonder @ArminVieweg, are you using the  Local adapter directly?

Anyway, while I was digging in, I added some tests, and found some ways to simplify the logic surrounding path prefixes.