### PR TITLE
Use strict comparison because folder "01" is not equal "1" for example.

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -329,7 +329,7 @@ class Ftp extends AbstractFtpAdapter
             }
         }
 
-        if (in_array($directory, $listing)) {
+        if (in_array($directory, $listing, true)) {
             return true;
         }
 


### PR DESCRIPTION
Right now, you cannot create a folder named "01" if already a folder named "1" exists because the check for existing directories is not strict enough.