### PR TITLE
Fix the ftpRawList path escape

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -533,9 +533,11 @@ class Ftp extends AbstractFtpAdapter
      */
     protected function ftpRawlist($options, $path)
     {
+        $connection = $this->getConnection();
+        
         if ($this->isPureFtpd) {
             $path = str_replace(' ', '\ ', $path);
         }
-        return ftp_rawlist($this->getConnection(), $options . ' ' . $path);
+        return ftp_rawlist($connection, $options . ' ' . $path);
     }
 }


### PR DESCRIPTION
The first call of the ftpRawList was not escaped, because getConnection() must be called before checking on the Pure-Ftpd Server.