### PR TITLE
add UTF-8 mode for the FTP adapter

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -30,6 +30,11 @@ class Ftp extends AbstractFtpAdapter
     protected $recurseManually = false;
 
     /**
+     * @var bool
+     */
+    protected $utf8 = true;
+
+    /**
      * @var array
      */
     protected $configurable = [
@@ -47,6 +52,7 @@ class Ftp extends AbstractFtpAdapter
         'systemType',
         'ignorePassiveAddress',
         'recurseManually',
+        'utf8',
     ];
 
     /**
@@ -109,6 +115,14 @@ class Ftp extends AbstractFtpAdapter
     }
 
     /**
+     * @param bool $utf8
+     */
+    public function setUtf8($utf8) 
+    {
+        $this->utf8 = (bool) $utf8;
+    }
+
+    /**
      * Connect to the FTP server.
      */
     public function connect()
@@ -124,9 +138,25 @@ class Ftp extends AbstractFtpAdapter
         }
 
         $this->login();
+        $this->setUtf8Mode();
         $this->setConnectionPassiveMode();
         $this->setConnectionRoot();
         $this->isPureFtpd = $this->isPureFtpdServer();
+    }
+
+    /**
+     * Set the connection to UTF-8 mode.
+     */
+    protected function setUtf8Mode()
+    {
+        if ($this->utf8) {
+            $response = ftp_raw($this->connection, "OPTS UTF8 ON");
+            if (substr($response[0], 0, 3) !== '200') {
+                throw new RuntimeException(
+                    'Could not set UTF-8 mode for connection: ' . $this->getHost() . '::' . $this->getPort()
+                );
+            }
+        }
     }
 
     /**

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -32,7 +32,7 @@ class Ftp extends AbstractFtpAdapter
     /**
      * @var bool
      */
-    protected $utf8 = true;
+    protected $utf8 = false;
 
     /**
      * @var array

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -125,6 +125,10 @@ function ftp_pwd($connection)
 
 function ftp_raw($connection, $command)
 {
+	if ($command === 'OPTS UTF8 ON') {
+        return [0 => '200 UTF8 set to on'];
+    }
+    
     if ($command === 'STAT syno.not.found') {
         return [0 => '211- status of syno.not.found:', 1 => 'ftpd: assd: No such file or directory.' ,2 => '211 End of status'];
     }


### PR DESCRIPTION
Now the FTP adapter can work with UTF-8 file paths. The UTF-8 mode is disabled by default. 
Example:
```
use League\Flysystem\Filesystem;
use League\Flysystem\Adapter\Ftp as Adapter;

$filesystem = new Filesystem(new Adapter([
    'host' => $host,
    'username' => $user,
    'password' => $password,
    'utf8' => true,         // enable the UTF-8 mode
]));

$filesystem->read('テスト'); // without the UTF-8 mode will throw FileNotFoundException
```

Another way to enable the UTF-8 mode:
```
// before connect to server (any CRUD operations)
// or you must manually reconnect after that
$filesystem->getAdapater()->setUtf8(true); 
```