### PR TITLE
fixed the normalizePermissions

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -507,8 +507,8 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
             return array_sum(str_split($part));
         };
 
-        // get the sum of the groups
-        return array_sum(array_map($mapper, $parts));
+        // converts to decimal number
+        return octdec(implode('', array_map($mapper, $parts)));
     }
 
     /**


### PR DESCRIPTION
**Example issue**
```
$permissions = normailzePermissions('-rwxr--r--');
printf("%o\n", $permissions);  // 17, but expected 744
```
And because of this, the `getMetadata` will always return an array with a public visibility.
That PR fix it.