### PR TITLE
provided a set method to change the adapter at runtime

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -47,6 +47,18 @@ class Filesystem implements FilesystemInterface
         return $this->adapter;
     }
 
+
+    /**
+     * Set the Adapter
+     *
+     * @param AdapterInterface $adapter
+     * @return AdapterInterface
+     */
+    public function setAdapter(AdapterInterface $adapter)
+    {
+        return $this->adapter = $adapter;
+    }
+
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
I was attempting to use this amazing library with OneupFlysystemBundle for a symfony app [see this](https://github.com/1up-lab/OneupFlysystemBundle/issues/143).
A setter injection can be very helpful in a context when you want the adapter to be chosen by a final user rather than set by the application. 