### PR TITLE
WIP Add PathPrefixAdapter, moved prefixing behavior to a trait.

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -2,70 +2,10 @@
 
 namespace League\Flysystem\Adapter;
 
+use League\Flysystem\Adapter\Polyfill\PathPrefixTrait;
 use League\Flysystem\AdapterInterface;
 
 abstract class AbstractAdapter implements AdapterInterface
 {
-    /**
-     * @var string path prefix
-     */
-    protected $pathPrefix;
-
-    /**
-     * @var string
-     */
-    protected $pathSeparator = '/';
-
-    /**
-     * Set the path prefix.
-     *
-     * @param string $prefix
-     *
-     * @return void
-     */
-    public function setPathPrefix($prefix)
-    {
-        $prefix = (string) $prefix;
-
-        if ($prefix === '') {
-            $this->pathPrefix = null;
-            return;
-        }
-
-        $this->pathPrefix = rtrim($prefix, '\\/') . $this->pathSeparator;
-    }
-
-    /**
-     * Get the path prefix.
-     *
-     * @return string path prefix
-     */
-    public function getPathPrefix()
-    {
-        return $this->pathPrefix;
-    }
-
-    /**
-     * Prefix a path.
-     *
-     * @param string $path
-     *
-     * @return string prefixed path
-     */
-    public function applyPathPrefix($path)
-    {
-        return $this->getPathPrefix() . ltrim($path, '\\/');
-    }
-
-    /**
-     * Remove a path prefix.
-     *
-     * @param string $path
-     *
-     * @return string path without the prefix
-     */
-    public function removePathPrefix($path)
-    {
-        return substr($path, strlen($this->getPathPrefix()));
-    }
+    use PathPrefixTrait;
 }

--- a/src/Adapter/PathPrefixAdapter.php
+++ b/src/Adapter/PathPrefixAdapter.php
@@ -91,7 +91,7 @@ class PathPrefixAdapter implements AdapterInterface
      */
     public function deleteDir($dirname)
     {
-        return $this->adapter->delete($this->applyPathPrefix($dirname));
+        return $this->adapter->deleteDir($this->applyPathPrefix($dirname));
     }
 
     /**
@@ -139,7 +139,10 @@ class PathPrefixAdapter implements AdapterInterface
      */
     public function listContents($directory = '', $recursive = false)
     {
-        return $this->adapter->listContents($this->applyPathPrefix($directory));
+        $list = $this->adapter->listContents($this->applyPathPrefix($directory));
+
+
+        return is_array($list) ? array_map([$this, 'removePrefixPathFromMetadata'], $list) : $list;
     }
 
     /**
@@ -147,7 +150,7 @@ class PathPrefixAdapter implements AdapterInterface
      */
     public function getMetadata($path)
     {
-        return $this->adapter->getMetadata($this->applyPathPrefix($path));
+        return $this->removePrefixPathFromMetadata($this->adapter->getMetadata($this->applyPathPrefix($path)));
     }
 
     /**
@@ -155,7 +158,7 @@ class PathPrefixAdapter implements AdapterInterface
      */
     public function getSize($path)
     {
-        return $this->adapter->getSize($this->applyPathPrefix($path));
+        return $this->removePrefixPathFromMetadata($this->adapter->getSize($this->applyPathPrefix($path)));
     }
 
     /**
@@ -163,7 +166,7 @@ class PathPrefixAdapter implements AdapterInterface
      */
     public function getMimetype($path)
     {
-        return $this->adapter->getMimetype($this->applyPathPrefix($path));
+        return $this->removePrefixPathFromMetadata($this->adapter->getMimetype($this->applyPathPrefix($path)));
     }
 
     /**
@@ -171,7 +174,7 @@ class PathPrefixAdapter implements AdapterInterface
      */
     public function getTimestamp($path)
     {
-        return $this->adapter->getTimestamp($this->applyPathPrefix($path));
+        return $this->removePrefixPathFromMetadata($this->adapter->getTimestamp($this->applyPathPrefix($path)));
     }
 
     /**
@@ -179,6 +182,8 @@ class PathPrefixAdapter implements AdapterInterface
      */
     public function getVisibility($path)
     {
-        return $this->adapter->getVisibility($this->applyPathPrefix($path));
+        return $this->removePrefixPathFromMetadata($this->adapter->getVisibility($this->applyPathPrefix($path)));
     }
+
+
 }

--- a/src/Adapter/PathPrefixAdapter.php
+++ b/src/Adapter/PathPrefixAdapter.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace League\Flysystem\Adapter;
+
+use League\Flysystem\Adapter\Polyfill\PathPrefixTrait;
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Config;
+
+/**
+ * Class PrefixAdapter
+ * Decorator to add support for path prefixes to any adapter.
+ */
+class PathPrefixAdapter implements AdapterInterface
+{
+    use PathPrefixTrait;
+
+    /**
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    /**
+     * PathPrefixAdapter constructor.
+     * @param AdapterInterface $adapter The adapter to decorate
+     * @param string $prefix The path prefix to use
+     */
+    public function __construct(AdapterInterface $adapter, $prefix)
+    {
+        $this->adapter = $adapter;
+        $this->setPathPrefix($prefix);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function write($path, $contents, Config $config)
+    {
+        return $this->adapter->write($this->applyPathPrefix($path), $contents, $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function writeStream($path, $resource, Config $config)
+    {
+        return $this->adapter->writeStream($this->applyPathPrefix($path), $resource, $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function update($path, $contents, Config $config)
+    {
+        $this->adapter->update($this->applyPathPrefix($path), $contents, $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function updateStream($path, $resource, Config $config)
+    {
+        return $this->adapter->updateStream($this->applyPathPrefix($path), $resource, $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function rename($path, $newpath)
+    {
+        return $this->adapter->rename($this->applyPathPrefix($path), $this->applyPathPrefix($newpath));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function copy($path, $newpath)
+    {
+        return $this->adapter->copy($this->applyPathPrefix($path), $this->applyPathPrefix($newpath));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function delete($path)
+    {
+        return $this->adapter->delete($this->applyPathPrefix($path));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function deleteDir($dirname)
+    {
+        return $this->adapter->delete($this->applyPathPrefix($dirname));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createDir($dirname, Config $config)
+    {
+        return $this->adapter->createDir($this->applyPathPrefix($dirname), $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setVisibility($path, $visibility)
+    {
+        return $this->adapter->setVisibility($this->applyPathPrefix($path), $visibility);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function has($path)
+    {
+        return $this->adapter->has($this->applyPathPrefix($path));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function read($path)
+    {
+        return $this->adapter->read($this->applyPathPrefix($path));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function readStream($path)
+    {
+        return $this->adapter->readStream($this->applyPathPrefix($path));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function listContents($directory = '', $recursive = false)
+    {
+        return $this->adapter->listContents($this->applyPathPrefix($directory));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMetadata($path)
+    {
+        return $this->adapter->getMetadata($this->applyPathPrefix($path));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSize($path)
+    {
+        return $this->adapter->getSize($this->applyPathPrefix($path));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMimetype($path)
+    {
+        return $this->adapter->getMimetype($this->applyPathPrefix($path));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTimestamp($path)
+    {
+        return $this->adapter->getTimestamp($this->applyPathPrefix($path));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getVisibility($path)
+    {
+        return $this->adapter->getVisibility($this->applyPathPrefix($path));
+    }
+}

--- a/src/Adapter/Polyfill/PathPrefixTrait.php
+++ b/src/Adapter/Polyfill/PathPrefixTrait.php
@@ -69,4 +69,16 @@ trait PathPrefixTrait
         return substr($path, strlen($this->getPathPrefix()));
     }
 
+    /**
+     * Removes the path prefix from a metadata array.
+     * @param array|false $metaData
+     * @return array|false
+     */
+    protected function removePrefixPathFromMetadata($metaData)
+    {
+        if (isset($metaData['path'])) {
+            $metaData['path'] = $this->removePathPrefix($metaData['path']);
+        }
+        return $metaData;
+    }
 }

--- a/src/Adapter/Polyfill/PathPrefixTrait.php
+++ b/src/Adapter/Polyfill/PathPrefixTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+
+namespace League\Flysystem\Adapter\Polyfill;
+
+
+trait PathPrefixTrait
+{
+    /**
+     * @var string path prefix
+     */
+    protected $pathPrefix;
+
+    /**
+     * @var string
+     */
+    protected $pathSeparator = '/';
+
+    /**
+     * Set the path prefix.
+     *
+     * @param string $prefix
+     *
+     * @return void
+     */
+    public function setPathPrefix($prefix)
+    {
+        $prefix = (string) $prefix;
+
+        if ($prefix === '') {
+            $this->pathPrefix = null;
+            return;
+        }
+
+        $this->pathPrefix = rtrim($prefix, '\\/') . $this->pathSeparator;
+    }
+
+    /**
+     * Get the path prefix.
+     *
+     * @return string path prefix
+     */
+    public function getPathPrefix()
+    {
+        return $this->pathPrefix;
+    }
+
+    /**
+     * Prefix a path.
+     *
+     * @param string $path
+     *
+     * @return string prefixed path
+     */
+    public function applyPathPrefix($path)
+    {
+        return $this->getPathPrefix() . ltrim($path, '\\/');
+    }
+
+    /**
+     * Remove a path prefix.
+     *
+     * @param string $path
+     *
+     * @return string path without the prefix
+     */
+    public function removePathPrefix($path)
+    {
+        return substr($path, strlen($this->getPathPrefix()));
+    }
+
+}

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -462,4 +462,11 @@ class LocalAdapterTests extends \PHPUnit_Framework_TestCase
         $root = __DIR__ . '/files/fail.plz';
         new Local($root);
     }
+
+    public function testRelativePathRootEscape()
+    {
+        // This should fail ?
+        $adapter = new Local(__DIR__ . '/files/');
+        $this->assertFalse($adapter->has('../' . __FILE__));
+    }
 }

--- a/tests/PathPrefixAdapterTests.php
+++ b/tests/PathPrefixAdapterTests.php
@@ -15,9 +15,7 @@ class PathPrefixAdapterTests extends \PHPUnit_Framework_TestCase
 
     public function setup()
     {
-        $this->adapter = $this->getMock(AdapterInterface::class);
         $this->adapter = $this->getMockBuilder(AdapterInterface::class)
-            ->disableProxyingToOriginalMethods()
             ->getMock();
 
 
@@ -156,45 +154,70 @@ class PathPrefixAdapterTests extends \PHPUnit_Framework_TestCase
     {
         $this->adapter->expects($this->once())
             ->method('listContents')
-            ->with('prefix/test');
+            ->with('prefix/test')
+            ->willReturn([
+                [
+                    'type' => 'file',
+                    'path' => 'prefix/test/coolstuff'
+                ]
+            ]);
 
-        $this->prefixAdapter->listContents('test');
+        $result = $this->prefixAdapter->listContents('test');
+        $this->assertCount(1, $result);
+        $this->assertArrayHasKey('path', $result[0]);
+        $this->assertEquals('test/coolstuff', $result[0]['path']);
     }
 
     public function testGetMetadata()
     {
         $this->adapter->expects($this->once())
             ->method('getMetadata')
-            ->with('prefix/test');
+            ->with('prefix/test')
+            ->willReturn([
+                'path' => 'prefix/test'
+            ]);
 
-        $this->prefixAdapter->getMetadata('test');
+
+        $this->assertEquals(['path' => 'test'], $this->prefixAdapter->getMetadata('test'));
     }
 
     public function testGetMimetype()
     {
         $this->adapter->expects($this->once())
             ->method('getMimetype')
-            ->with('prefix/test');
+            ->with('prefix/test')
+            ->willReturn([
+                'path' => 'prefix/test'
+            ]);
 
-        $this->prefixAdapter->getMimetype('test');
+
+        $this->assertEquals(['path' => 'test'], $this->prefixAdapter->getMimetype('test'));
     }
 
     public function testGetTimestamp()
     {
         $this->adapter->expects($this->once())
             ->method('getTimestamp')
-            ->with('prefix/test');
+            ->with('prefix/test')
+            ->willReturn([
+                'path' => 'prefix/test'
+            ]);
 
-        $this->prefixAdapter->getTimestamp('test');
+
+        $this->assertEquals(['path' => 'test'], $this->prefixAdapter->getTimestamp('test'));
     }
 
     public function testGetVisibility()
     {
         $this->adapter->expects($this->once())
             ->method('getVisibility')
-            ->with('prefix/test');
+            ->with('prefix/test')
+            ->willReturn([
+                'path' => 'prefix/test'
+            ]);
 
-        $this->prefixAdapter->getVisibility('test');
+
+        $this->assertEquals(['path' => 'test'], $this->prefixAdapter->getVisibility('test'));
     }
 
 }

--- a/tests/PathPrefixAdapterTests.php
+++ b/tests/PathPrefixAdapterTests.php
@@ -15,7 +15,12 @@ class PathPrefixAdapterTests extends \PHPUnit_Framework_TestCase
 
     public function setup()
     {
-        $this->adapter = $this->getMock('League\Flysystem\AdapterInterface');
+        $this->adapter = $this->getMock(AdapterInterface::class);
+        $this->adapter = $this->getMockBuilder(AdapterInterface::class)
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+
+
         $this->prefixAdapter = new PathPrefixAdapter($this->adapter, 'prefix');
     }
 
@@ -58,13 +63,138 @@ class PathPrefixAdapterTests extends \PHPUnit_Framework_TestCase
     public function testUpdateStream()
     {
         $config = new Config;
-
         $this->adapter->expects($this->once())
             ->method('updateStream')
             ->with('prefix/test', 'contents', $config);
 
-
         $this->prefixAdapter->updateStream('test', 'contents', $config);
+    }
+
+    public function testRename()
+    {
+        $this->adapter->expects($this->once())
+            ->method('rename')
+            ->with('prefix/test', 'prefix/newtest');
+
+        $this->prefixAdapter->rename('test', 'newtest');
+    }
+
+    public function testCopy()
+    {
+        $this->adapter->expects($this->once())
+            ->method('copy')
+            ->with('prefix/test', 'prefix/newtest');
+
+        $this->prefixAdapter->copy('test', 'newtest');
+    }
+
+    public function testDelete()
+    {
+        $this->adapter->expects($this->once())
+            ->method('delete')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->delete('test');
+    }
+
+    public function testDeleteDir()
+    {
+        $this->adapter->expects($this->once())
+            ->method('deleteDir')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->deleteDir('test');
+    }
+
+    public function testCreateDir()
+    {
+        $config = new Config;
+        $this->adapter->expects($this->once())
+            ->method('createDir')
+            ->with('prefix/test', $config);
+
+        $this->prefixAdapter->createDir('test', $config);
+    }
+
+    public function testSetVisibility()
+    {
+        $this->adapter->expects($this->once())
+            ->method('setVisibility')
+            ->with('prefix/test', 'hidden');
+
+        $this->prefixAdapter->setVisibility('test', 'hidden');
+    }
+
+    public function testHas()
+    {
+        $this->adapter->expects($this->once())
+            ->method('has')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->has('test');
+    }
+
+    public function testRead()
+    {
+        $this->adapter->expects($this->once())
+            ->method('read')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->read('test');
+    }
+
+    public function testReadStream()
+    {
+        $this->adapter->expects($this->once())
+            ->method('readStream')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->readStream('test');
+    }
+
+    public function testListContents()
+    {
+        $this->adapter->expects($this->once())
+            ->method('listContents')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->listContents('test');
+    }
+
+    public function testGetMetadata()
+    {
+        $this->adapter->expects($this->once())
+            ->method('getMetadata')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->getMetadata('test');
+    }
+
+    public function testGetMimetype()
+    {
+        $this->adapter->expects($this->once())
+            ->method('getMimetype')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->getMimetype('test');
+    }
+
+    public function testGetTimestamp()
+    {
+        $this->adapter->expects($this->once())
+            ->method('getTimestamp')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->getTimestamp('test');
+    }
+
+    public function testGetVisibility()
+    {
+        $this->adapter->expects($this->once())
+            ->method('getVisibility')
+            ->with('prefix/test');
+
+        $this->prefixAdapter->getVisibility('test');
     }
 
 }

--- a/tests/PathPrefixAdapterTests.php
+++ b/tests/PathPrefixAdapterTests.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace League\Flysystem\Adapter;
+
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Config;
+
+class PathPrefixAdapterTests extends \PHPUnit_Framework_TestCase
+{
+    protected $adapter;
+    /**
+     * @var AdapterInterface
+     */
+    protected $prefixAdapter;
+
+    public function setup()
+    {
+        $this->adapter = $this->getMock('League\Flysystem\AdapterInterface');
+        $this->prefixAdapter = new PathPrefixAdapter($this->adapter, 'prefix');
+    }
+
+
+
+    public function teardown()
+    {
+    }
+
+    public function testWrite()
+    {
+        $config = new Config;
+        $this->adapter->expects($this->once())
+            ->method('write')
+            ->with('prefix/test', 'contents', $config);
+
+        $this->prefixAdapter->write('test', 'contents', $config);
+    }
+
+    public function testWriteStream()
+    {
+        $config = new Config;
+        $this->adapter->expects($this->once())
+            ->method('writeStream')
+            ->with('prefix/test', 'contents', $config);
+
+        $this->prefixAdapter->writeStream('test', 'contents', $config);
+    }
+
+    public function testUpdate()
+    {
+        $config = new Config;
+        $this->adapter->expects($this->once())
+            ->method('update')
+            ->with('prefix/test', 'contents', $config);
+
+        $this->prefixAdapter->update('test', 'contents', $config);
+    }
+
+    public function testUpdateStream()
+    {
+        $config = new Config;
+
+        $this->adapter->expects($this->once())
+            ->method('updateStream')
+            ->with('prefix/test', 'contents', $config);
+
+
+        $this->prefixAdapter->updateStream('test', 'contents', $config);
+    }
+
+}


### PR DESCRIPTION
The test is not done yet.

I'd appreciate some assistance since I'm not familiar with mocking.

I can check that a specific method gets called exactly once, but I'm unsure how to specify that all other functions should not be called.

For example:
````
PathPrefixAdapter::read($a, $b, $c) {
    $this->adapter->write('....');
    return $this->adapter->read($a, $b, $c);
}
````

Would not be detected in my tests, while it is obviously not good :|