### PR TITLE
Implement serialize prevention.

### DIFF
--- a/src/SafeStorage.php
+++ b/src/SafeStorage.php
@@ -2,38 +2,75 @@
 
 namespace League\Flysystem;
 
+/**
+ * Prevents data from being leaked via exceptions and serialization.
+ */
 final class SafeStorage
 {
     /**
      * @var string
      */
-    private $hash;
-
-    /**
-     * @var array
-     */
-    protected static $safeStorage = [];
+    protected $hash;
 
     public function __construct()
     {
         $this->hash = spl_object_hash($this);
-        static::$safeStorage[$this->hash] = [];
     }
 
+    /**
+     * Stores a value in safe storage.
+     *
+     * @param string $key
+     * @param mixed  $value
+     */
     public function storeSafely($key, $value)
     {
-        static::$safeStorage[$this->hash][$key] = $value;
+        $storage = &$this->getStorage();
+        $storage[$key] = $value;
     }
 
+    /**
+     * Returns a value from safe storage.
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
     public function retrieveSafely($key)
     {
-        if (array_key_exists($key, static::$safeStorage[$this->hash])) {
-            return static::$safeStorage[$this->hash][$key];
-        }
+        $storage = &$this->getStorage();
+
+        return isset($storage[$key]) ? $storage[$key] : null;
     }
 
+    /**
+     * Deletes this objects storage when the object is destroyed.
+     */
     public function __destruct()
     {
-        unset(static::$safeStorage[$this->hash]);
+        $storage = &$this->getStorage();
+        unset($storage[$this->hash]);
+    }
+
+    /**
+     * @return array
+     */
+    protected function &getStorage()
+    {
+        static $storage = [];
+
+        if ( ! isset($storage[$this->hash])) {
+            $storage[$this->hash] = [];
+        }
+
+        return $storage[$this->hash];
+    }
+
+    /**
+     * Prevents SafeStorage from being serialized.
+     */
+    public function __sleep()
+    {
+        throw new \LogicException('SafeStorage cannot be serialized.');
     }
 }

--- a/tests/SafeStorageTest.php
+++ b/tests/SafeStorageTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace League\Flysystem;
+
+use League\Flysystem\SafeStorage;
+
+class SafeStorageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetAndSet()
+    {
+        $a = new SafeStorage();
+        $a->storeSafely('a_key', 'a_value');
+        $this->assertSame('a_value', $a->retrieveSafely('a_key'));
+
+        $b = new SafeStorage();
+        $b->storeSafely('b_key', 'b_value');
+        $this->assertSame('b_value', $b->retrieveSafely('b_key'));
+
+        // Check that storage does not leak between instances.
+        $this->assertNull($b->retrieveSafely('a_key'));
+        $this->assertNull($a->retrieveSafely('b_key'));
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testSerialize()
+    {
+        serialize(new SafeStorage());
+    }
+}


### PR DESCRIPTION
Coming from https://github.com/thephpleague/flysystem-sftp/issues/36.

I've moved the actual data storage into a function static, that should help to ensure that it doesn't get serialized. I'm also not sure if class statics leak.

Edit: Added some tests to ensure behavior.