### PR TITLE
Rename when moving file within the same file system

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -255,7 +255,7 @@ class MountManager
     {
         list($prefixFrom, $pathFrom) = $this->getPrefixAndPath($from);
         list($prefixTo, $pathTo) = $this->getPrefixAndPath($to);
-        
+
         if ($prefixFrom === $prefixTo) {
             $filesystem = $this->getFilesystem($prefixFrom);
             $renamed = $filesystem->rename($pathFrom, $pathTo);
@@ -263,14 +263,14 @@ class MountManager
             if ($renamed && isset($config['visibility'])) {
                 return $filesystem->setVisibility($pathTo, $config['visibility']);
             }
-            
-            return $renamed;
-        } else {
-            $copied = $this->copy($from, $to, $config);
 
-            if ($copied) {
-                return $this->delete($from);
-            }
+            return $renamed;
+        }
+
+        $copied = $this->copy($from, $to, $config);
+
+        if ($copied) {
+            return $this->delete($from);
         }
 
         return false;

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -253,10 +253,24 @@ class MountManager
      */
     public function move($from, $to, array $config = [])
     {
-        $copied = $this->copy($from, $to, $config);
+        list($prefixFrom, $pathFrom) = $this->getPrefixAndPath($from);
+        list($prefixTo, $pathTo) = $this->getPrefixAndPath($to);
+        
+        if ($prefixFrom === $prefixTo) {
+            $filesystem = $this->getFilesystem($prefixFrom);
+            $renamed = $filesystem->rename($pathFrom, $pathTo);
 
-        if ($copied) {
-            return $this->delete($from);
+            if ($renamed && isset($config['visibility'])) {
+                return $filesystem->setVisibility($pathTo, $config['visibility']);
+            }
+            
+            return $renamed;
+        } else {
+            $copied = $this->copy($from, $to, $config);
+
+            if ($copied) {
+                return $this->delete($from);
+            }
         }
 
         return false;


### PR DESCRIPTION
When moving a file using the MountManager, if from and to are in the same file system, perform a rename instead of copying and deleting the file.