### PR TITLE
getTimestamp() in Filesystem

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -296,7 +296,7 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $this->assertPresent($path);
 
-        if (( ! $object = $this->getAdapter()->getTimestamp($path)) || ! array_key_exists('mimetype', $object)) {
+        if (( ! $object = $this->getAdapter()->getTimestamp($path)) || ! array_key_exists('timestamp', $object)) {
             return false;
         }
 


### PR DESCRIPTION
Hello,

I am proposing to check for existence of the `timestamp` key in the returned file info array instead of the key `mimetype`, which apparently was a result of copy-pasting the implementation for `getMimetype()`.

If this was intentional -- sorry!

Thanks