### PR TITLE
Recursive Ftp folder remove script

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -318,8 +318,8 @@ class Ftp extends AbstractFtpAdapter
                 if ( ! ftp_delete($connection, $object['path'])) {
                     return false;
                 }
-            } elseif ( ! ftp_rmdir($connection, $object['path'])) {
-                return false;
+            } elseif($object['type'] === 'dir'){
+                $this->deleteDir($object['path'])
             }
         }
 

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -319,7 +319,7 @@ class Ftp extends AbstractFtpAdapter
                     return false;
                 }
             } elseif($object['type'] === 'dir'){
-                $this->deleteDir($object['path'])
+                $this->deleteDir($object['path']);
             }
         }
 


### PR DESCRIPTION
You cannot use ftp_rmdir() if the directory is not empty. So if you want to delete a folder, that contains one or more sub-folder containing some files, the script return false and it cause an error. That way, you can completely remove a folder and all the child at once, which is, I think, a better way.