### PR TITLE
remove check for empty path value to preserve proceeding slash

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -108,7 +108,6 @@ class Util
 
         foreach (explode('/', $path) as $part) {
             switch ($part) {
-                case '':
                 case '.':
                 break;
 


### PR DESCRIPTION
the function `normalizeRelativePath` removes the proceeding slash from absolute paths. 
By removing the check for empty `$part` you can preserve the beginning slash. 