### PR TITLE
Use League\Flysystem\Exception in Adapters, users can catch single exception

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -8,6 +8,7 @@ use finfo as Finfo;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
 use League\Flysystem\Exception;
+use League\Flysystem\LogicException;
 use League\Flysystem\NotSupportedException;
 use League\Flysystem\UnreadableFileException;
 use League\Flysystem\Util;
@@ -68,7 +69,7 @@ class Local extends AbstractAdapter
      * @param int    $linkHandling
      * @param array  $permissions
      *
-     * @throws Exception
+     * @throws LogicException
      */
     public function __construct($root, $writeFlags = LOCK_EX, $linkHandling = self::DISALLOW_LINKS, array $permissions = [])
     {
@@ -77,7 +78,7 @@ class Local extends AbstractAdapter
         $this->ensureDirectory($root);
 
         if ( ! is_dir($root) || ! is_readable($root)) {
-            throw new Exception('The root path ' . $root . ' is not readable.');
+            throw new LogicException('The root path ' . $root . ' is not readable.');
         }
 
         $this->setPathPrefix($root);

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -11,7 +11,6 @@ use League\Flysystem\Exception;
 use League\Flysystem\NotSupportedException;
 use League\Flysystem\UnreadableFileException;
 use League\Flysystem\Util;
-use LogicException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -69,7 +68,7 @@ class Local extends AbstractAdapter
      * @param int    $linkHandling
      * @param array  $permissions
      *
-     * @throws LogicException
+     * @throws Exception
      */
     public function __construct($root, $writeFlags = LOCK_EX, $linkHandling = self::DISALLOW_LINKS, array $permissions = [])
     {
@@ -78,7 +77,7 @@ class Local extends AbstractAdapter
         $this->ensureDirectory($root);
 
         if ( ! is_dir($root) || ! is_readable($root)) {
-            throw new LogicException('The root path ' . $root . ' is not readable.');
+            throw new Exception('The root path ' . $root . ' is not readable.');
         }
 
         $this->setPathPrefix($root);

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -77,6 +77,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $path
      * @param string $newpath
      *
+     * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
      *                   (disk full, permission denied, network error, ...)
      *
@@ -90,6 +91,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $path
      * @param string $newpath
      *
+     * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
      *                   (disk full, permission denied, network error, ...)
      *
@@ -102,8 +104,9 @@ interface AdapterInterface extends ReadInterface
      *
      * @param string $path
      *
+     * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return bool
      */
@@ -115,7 +118,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $dirname
      *
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return bool
      */
@@ -140,8 +143,9 @@ interface AdapterInterface extends ReadInterface
      * @param string $path
      * @param string $visibility
      *
+     * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return array|false file meta data
      */

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -21,6 +21,9 @@ interface AdapterInterface extends ReadInterface
      * @param string $contents
      * @param Config $config   Config object
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
+     *
      * @return array|false false on failure file meta data on success
      */
     public function write($path, $contents, Config $config);
@@ -31,6 +34,9 @@ interface AdapterInterface extends ReadInterface
      * @param string   $path
      * @param resource $resource
      * @param Config   $config   Config object
+     *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return array|false false on failure file meta data on success
      */
@@ -43,7 +49,11 @@ interface AdapterInterface extends ReadInterface
      * @param string $contents
      * @param Config $config   Config object
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
+     *
      * @return array|false false on failure file meta data on success
+     *
      */
     public function update($path, $contents, Config $config);
 
@@ -53,6 +63,9 @@ interface AdapterInterface extends ReadInterface
      * @param string   $path
      * @param resource $resource
      * @param Config   $config   Config object
+     *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return array|false false on failure file meta data on success
      */
@@ -64,6 +77,9 @@ interface AdapterInterface extends ReadInterface
      * @param string $path
      * @param string $newpath
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
+     *
      * @return bool
      */
     public function rename($path, $newpath);
@@ -74,6 +90,9 @@ interface AdapterInterface extends ReadInterface
      * @param string $path
      * @param string $newpath
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
+     *
      * @return bool
      */
     public function copy($path, $newpath);
@@ -83,6 +102,9 @@ interface AdapterInterface extends ReadInterface
      *
      * @param string $path
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
+     *
      * @return bool
      */
     public function delete($path);
@@ -91,6 +113,9 @@ interface AdapterInterface extends ReadInterface
      * Delete a directory.
      *
      * @param string $dirname
+     *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool
      */
@@ -102,6 +127,9 @@ interface AdapterInterface extends ReadInterface
      * @param string $dirname directory name
      * @param Config $config
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
+     *
      * @return array|false
      */
     public function createDir($dirname, Config $config);
@@ -111,6 +139,9 @@ interface AdapterInterface extends ReadInterface
      *
      * @param string $path
      * @param string $visibility
+     *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return array|false file meta data
      */

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -21,8 +21,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $contents
      * @param Config $config   Config object
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return array|false false on failure file meta data on success
      */
@@ -35,8 +34,7 @@ interface AdapterInterface extends ReadInterface
      * @param resource $resource
      * @param Config   $config   Config object
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return array|false false on failure file meta data on success
      */
@@ -49,8 +47,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $contents
      * @param Config $config   Config object
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return array|false false on failure file meta data on success
      *
@@ -64,8 +61,7 @@ interface AdapterInterface extends ReadInterface
      * @param resource $resource
      * @param Config   $config   Config object
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return array|false false on failure file meta data on success
      */
@@ -78,8 +74,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $newpath
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool
      */
@@ -92,8 +87,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $newpath
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool
      */
@@ -105,8 +99,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $path
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return bool
      */
@@ -117,8 +110,7 @@ interface AdapterInterface extends ReadInterface
      *
      * @param string $dirname
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return bool
      */
@@ -130,8 +122,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $dirname directory name
      * @param Config $config
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -144,8 +135,7 @@ interface AdapterInterface extends ReadInterface
      * @param string $visibility
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false file meta data
      */

--- a/src/ErrorException.php
+++ b/src/ErrorException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Flysystem;
+
+class ErrorException extends Exception
+{
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,5 +4,15 @@ namespace League\Flysystem;
 
 class Exception extends \Exception
 {
-    //
+    /**
+     * Wraps exception, used to wrap 3rd party client exceptions inside Flysystem exception
+     *
+     * @param \Exception $exception Exception thrown from adapter
+     *
+     * @return Exception
+     */
+    public static function wrap(\Exception $exception)
+    {
+        return new self($exception->getMessage(), $exception->getCode(), $exception);
+    }
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -13,6 +13,6 @@ class Exception extends \Exception
      */
     public static function wrap(\Exception $exception)
     {
-        return new self($exception->getMessage(), $exception->getCode(), $exception);
+        return new static($exception->getMessage(), $exception->getCode(), $exception);
     }
 }

--- a/src/FileExistsException.php
+++ b/src/FileExistsException.php
@@ -2,8 +2,6 @@
 
 namespace League\Flysystem;
 
-use Exception as BaseException;
-
 class FileExistsException extends Exception
 {
     /**
@@ -14,11 +12,11 @@ class FileExistsException extends Exception
     /**
      * Constructor.
      *
-     * @param string        $path
-     * @param int           $code
-     * @param BaseException $previous
+     * @param string    $path
+     * @param int       $code
+     * @param Exception $previous
      */
-    public function __construct($path, $code = 0, BaseException $previous = null)
+    public function __construct($path, $code = 0, Exception $previous = null)
     {
         $this->path = $path;
 

--- a/src/FileNotFoundException.php
+++ b/src/FileNotFoundException.php
@@ -2,8 +2,6 @@
 
 namespace League\Flysystem;
 
-use Exception as BaseException;
-
 class FileNotFoundException extends Exception
 {
     /**
@@ -18,7 +16,7 @@ class FileNotFoundException extends Exception
      * @param int        $code
      * @param \Exception $previous
      */
-    public function __construct($path, $code = 0, BaseException $previous = null)
+    public function __construct($path, $code = 0, Exception $previous = null)
     {
         $this->path = $path;
 

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -22,7 +22,7 @@ interface FilesystemInterface
      *
      * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return string|false The file contents or false on failure.
      */
@@ -34,8 +34,8 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception if Adapter fails to read from remote service
+     *                   (connection error, mount not available, ...)
      *
      * @return resource|false The path resource or false on failure.
      */
@@ -47,8 +47,9 @@ interface FilesystemInterface
      * @param string $directory The directory to list.
      * @param bool   $recursive Whether to list recursively.
      *
-     *@throws Exception If a low-level, adapter-specific error occurs
-     *                  (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If directory doesn't exist
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (permission denied, network error, ...)
      *
      * @return array A list of file metadata.
      */
@@ -61,7 +62,7 @@ interface FilesystemInterface
      *
      * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return array|false The file metadata or false on failure.
      */
@@ -72,8 +73,9 @@ interface FilesystemInterface
      *
      * @param string $path The path to the file.
      *
+     * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return int|false The file size or false on failure.
      *
@@ -86,9 +88,8 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     *
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return string|false The file mime-type or false on failure.
      */
@@ -101,7 +102,7 @@ interface FilesystemInterface
      *
      * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return string|false The timestamp or false on failure.
      */
@@ -114,7 +115,7 @@ interface FilesystemInterface
      *
      * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return string|false The visibility (public|private) or false on failure.
      */
@@ -219,7 +220,7 @@ interface FilesystemInterface
      *
      * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -258,7 +259,7 @@ interface FilesystemInterface
      * @param string $visibility One of 'public' or 'private'.
      *
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -300,7 +301,7 @@ interface FilesystemInterface
      *
      * @throws FileNotFoundException
      * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     *                   (permission denied, network error, ...)
      *
      * @return string|false The file contents, or false on failure.
      */

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -9,8 +9,7 @@ interface FilesystemInterface
      *
      * @param string $path
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      * @return bool
      */
     public function has($path);
@@ -21,8 +20,7 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return string|false The file contents or false on failure.
      */
@@ -34,8 +32,7 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception if Adapter fails to read from remote service
-     *                   (connection error, mount not available, ...)
+     * @throws Exception if Adapter fails to read from remote service (connection error, mount not available, ...)
      *
      * @return resource|false The path resource or false on failure.
      */
@@ -48,8 +45,7 @@ interface FilesystemInterface
      * @param bool   $recursive Whether to list recursively.
      *
      * @throws FileNotFoundException If directory doesn't exist
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array A list of file metadata.
      */
@@ -61,8 +57,7 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false The file metadata or false on failure.
      */
@@ -74,8 +69,7 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return int|false The file size or false on failure.
      *
@@ -88,8 +82,7 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return string|false The file mime-type or false on failure.
      */
@@ -101,8 +94,7 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return string|false The timestamp or false on failure.
      */
@@ -114,8 +106,7 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return string|false The visibility (public|private) or false on failure.
      */
@@ -129,8 +120,7 @@ interface FilesystemInterface
      * @param array  $config   An optional configuration array.
      *
      * @throws FileExistsException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -145,8 +135,7 @@ interface FilesystemInterface
      *
      * @throws \InvalidArgumentException If $resource is not a file handle.
      * @throws FileExistsException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -160,8 +149,7 @@ interface FilesystemInterface
      * @param array  $config   An optional configuration array.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -176,8 +164,7 @@ interface FilesystemInterface
      *
      * @throws \InvalidArgumentException If $resource is not a file handle.
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -191,8 +178,7 @@ interface FilesystemInterface
      *
      * @throws FileExistsException   Thrown if $newpath exists.
      * @throws FileNotFoundException Thrown if $path does not exist.
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -206,8 +192,7 @@ interface FilesystemInterface
      *
      * @throws FileExistsException   Thrown if $newpath exists.
      * @throws FileNotFoundException Thrown if $path does not exist.
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -219,8 +204,7 @@ interface FilesystemInterface
      * @param string $path
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -232,8 +216,7 @@ interface FilesystemInterface
      * @param string $dirname
      *
      * @throws RootViolationException Thrown if $dirname is empty.
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -245,8 +228,7 @@ interface FilesystemInterface
      * @param string $dirname The name of the new directory.
      * @param array  $config  An optional configuration array.
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -258,8 +240,7 @@ interface FilesystemInterface
      * @param string $path       The path to the file.
      * @param string $visibility One of 'public' or 'private'.
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -272,8 +253,7 @@ interface FilesystemInterface
      * @param string $contents The file contents.
      * @param array  $config   An optional configuration array.
      *
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -287,8 +267,7 @@ interface FilesystemInterface
      * @param array    $config   An optional configuration array.
      *
      * @throws \InvalidArgumentException Thrown if $resource is not a resource.
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -300,8 +279,7 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
-     * @throws Exception If a low-level, adapter-specific error occurs
-     *                   (permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return string|false The file contents, or false on failure.
      */

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -9,6 +9,8 @@ interface FilesystemInterface
      *
      * @param string $path
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      * @return bool
      */
     public function has($path);
@@ -19,6 +21,8 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return string|false The file contents or false on failure.
      */
@@ -30,6 +34,8 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return resource|false The path resource or false on failure.
      */
@@ -41,6 +47,9 @@ interface FilesystemInterface
      * @param string $directory The directory to list.
      * @param bool   $recursive Whether to list recursively.
      *
+     *@throws Exception If a low-level, adapter-specific error occurs
+     *                  (disk full, permission denied, network error, ...)
+     *
      * @return array A list of file metadata.
      */
     public function listContents($directory = '', $recursive = false);
@@ -51,6 +60,8 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return array|false The file metadata or false on failure.
      */
@@ -61,7 +72,11 @@ interface FilesystemInterface
      *
      * @param string $path The path to the file.
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
+     *
      * @return int|false The file size or false on failure.
+     *
      */
     public function getSize($path);
 
@@ -71,6 +86,9 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
+     *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return string|false The file mime-type or false on failure.
      */
@@ -82,6 +100,8 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return string|false The timestamp or false on failure.
      */
@@ -93,6 +113,8 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return string|false The visibility (public|private) or false on failure.
      */
@@ -106,6 +128,8 @@ interface FilesystemInterface
      * @param array  $config   An optional configuration array.
      *
      * @throws FileExistsException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -120,6 +144,8 @@ interface FilesystemInterface
      *
      * @throws \InvalidArgumentException If $resource is not a file handle.
      * @throws FileExistsException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -133,6 +159,8 @@ interface FilesystemInterface
      * @param array  $config   An optional configuration array.
      *
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -147,6 +175,8 @@ interface FilesystemInterface
      *
      * @throws \InvalidArgumentException If $resource is not a file handle.
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -160,6 +190,8 @@ interface FilesystemInterface
      *
      * @throws FileExistsException   Thrown if $newpath exists.
      * @throws FileNotFoundException Thrown if $path does not exist.
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -173,6 +205,8 @@ interface FilesystemInterface
      *
      * @throws FileExistsException   Thrown if $newpath exists.
      * @throws FileNotFoundException Thrown if $path does not exist.
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -184,6 +218,8 @@ interface FilesystemInterface
      * @param string $path
      *
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -195,6 +231,8 @@ interface FilesystemInterface
      * @param string $dirname
      *
      * @throws RootViolationException Thrown if $dirname is empty.
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -206,6 +244,9 @@ interface FilesystemInterface
      * @param string $dirname The name of the new directory.
      * @param array  $config  An optional configuration array.
      *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
+     *
      * @return bool True on success, false on failure.
      */
     public function createDir($dirname, array $config = []);
@@ -215,6 +256,9 @@ interface FilesystemInterface
      *
      * @param string $path       The path to the file.
      * @param string $visibility One of 'public' or 'private'.
+     *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -226,6 +270,9 @@ interface FilesystemInterface
      * @param string $path     The path to the file.
      * @param string $contents The file contents.
      * @param array  $config   An optional configuration array.
+     *
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -239,6 +286,8 @@ interface FilesystemInterface
      * @param array    $config   An optional configuration array.
      *
      * @throws \InvalidArgumentException Thrown if $resource is not a resource.
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return bool True on success, false on failure.
      */
@@ -250,6 +299,8 @@ interface FilesystemInterface
      * @param string $path The path to the file.
      *
      * @throws FileNotFoundException
+     * @throws Exception If a low-level, adapter-specific error occurs
+     *                   (disk full, permission denied, network error, ...)
      *
      * @return string|false The file contents, or false on failure.
      */

--- a/src/FilesystemNotFoundException.php
+++ b/src/FilesystemNotFoundException.php
@@ -2,8 +2,6 @@
 
 namespace League\Flysystem;
 
-use LogicException;
-
 /**
  * Thrown when the MountManager cannot find a filesystem.
  */

--- a/src/LogicException.php
+++ b/src/LogicException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Flysystem;
+
+class LogicException extends Exception
+{
+}

--- a/src/NotSupportedException.php
+++ b/src/NotSupportedException.php
@@ -2,7 +2,6 @@
 
 namespace League\Flysystem;
 
-use RuntimeException;
 use SplFileInfo;
 
 class NotSupportedException extends RuntimeException

--- a/src/ReadInterface.php
+++ b/src/ReadInterface.php
@@ -9,6 +9,9 @@ interface ReadInterface
      *
      * @param string $path
      *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
+     *
      * @return array|bool|null
      */
     public function has($path);
@@ -18,6 +21,9 @@ interface ReadInterface
      *
      * @param string $path
      *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
+     *
      * @return array|false
      */
     public function read($path);
@@ -26,6 +32,9 @@ interface ReadInterface
      * Read a file as a stream.
      *
      * @param string $path
+     *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -37,6 +46,9 @@ interface ReadInterface
      * @param string $directory
      * @param bool   $recursive
      *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
+     *
      * @return array
      */
     public function listContents($directory = '', $recursive = false);
@@ -45,6 +57,9 @@ interface ReadInterface
      * Get all the meta data of a file or directory.
      *
      * @param string $path
+     *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -55,6 +70,9 @@ interface ReadInterface
      *
      * @param string $path
      *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
+     *
      * @return array|false
      */
     public function getSize($path);
@@ -63,6 +81,9 @@ interface ReadInterface
      * Get the mimetype of a file.
      *
      * @param string $path
+     *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -73,6 +94,9 @@ interface ReadInterface
      *
      * @param string $path
      *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
+     *
      * @return array|false
      */
     public function getTimestamp($path);
@@ -81,6 +105,9 @@ interface ReadInterface
      * Get the visibility of a file.
      *
      * @param string $path
+     *
+     * @throws Exception    If a low-level, adapter-specific error occurs
+     *                      (disk full, permission denied, network error, ...)
      *
      * @return array|false
      */

--- a/src/ReadInterface.php
+++ b/src/ReadInterface.php
@@ -9,8 +9,7 @@ interface ReadInterface
      *
      * @param string $path
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|bool|null
      */
@@ -21,8 +20,8 @@ interface ReadInterface
      *
      * @param string $path
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If file doesn't exist
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -33,8 +32,8 @@ interface ReadInterface
      *
      * @param string $path
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If file doesn't exist
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -46,8 +45,8 @@ interface ReadInterface
      * @param string $directory
      * @param bool   $recursive
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If directory doesn't exist
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array
      */
@@ -58,8 +57,8 @@ interface ReadInterface
      *
      * @param string $path
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If file doesn't exists
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -70,8 +69,8 @@ interface ReadInterface
      *
      * @param string $path
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If file doesn't exists
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -82,8 +81,8 @@ interface ReadInterface
      *
      * @param string $path
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If file doesn't exists
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -94,8 +93,8 @@ interface ReadInterface
      *
      * @param string $path
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If file doesn't exists
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false
      */
@@ -106,8 +105,8 @@ interface ReadInterface
      *
      * @param string $path
      *
-     * @throws Exception    If a low-level, adapter-specific error occurs
-     *                      (disk full, permission denied, network error, ...)
+     * @throws FileNotFoundException If file doesn't exists
+     * @throws Exception If a low-level, adapter-specific error occurs (permission denied, network error, ...)
      *
      * @return array|false
      */

--- a/src/RootViolationException.php
+++ b/src/RootViolationException.php
@@ -2,8 +2,6 @@
 
 namespace League\Flysystem;
 
-use LogicException;
-
 class RootViolationException extends LogicException
 {
     //

--- a/src/RuntimeException.php
+++ b/src/RuntimeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Flysystem;
+
+class RuntimeException extends Exception
+{
+}

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -2,8 +2,8 @@
 
 namespace League\Flysystem\Adapter;
 
-use ErrorException;
 use League\Flysystem\Config;
+use League\Flysystem\ErrorException;
 use PHPUnit\Framework\TestCase;
 
 function ftp_systype($connection)
@@ -155,11 +155,11 @@ function ftp_rawlist($connection, $directory)
 
     if ($directory === '/') {
         if (getenv('FTP_CLOSE_THROW') === 'DISCONNECT_CATCH') {
-            throw new ErrorException('ftp_rawlist');
+            throw new \ErrorException('ftp_rawlist');
         }
 
         if (getenv('FTP_CLOSE_THROW') === 'DISCONNECT_RETHROW') {
-            throw new ErrorException('does not contain the correct message');
+            throw new \ErrorException('does not contain the correct message');
         }
     }
 
@@ -446,7 +446,7 @@ class FtpTests extends TestCase
     {
         putenv('FTP_CLOSE_THROW=DISCONNECT_RETHROW');
 
-        $this->setExpectedException('ErrorException');
+        $this->setExpectedException(ErrorException::class);
         $adapter = new Ftp(array_merge($this->options, ['host' => 'disconnect.check']));
         $adapter->connect();
         $adapter->isConnected();
@@ -649,7 +649,7 @@ class FtpTests extends TestCase
 
     /**
      * @depends testInstantiable
-     * @expectedException RuntimeException
+     * @expectedException \League\Flysystem\RuntimeException
      */
     public function testConnectFail()
     {
@@ -669,7 +669,7 @@ class FtpTests extends TestCase
 
     /**
      * @depends testInstantiable
-     * @expectedException RuntimeException
+     * @expectedException \League\Flysystem\RuntimeException
      */
     public function testConnectFailSsl()
     {
@@ -679,7 +679,7 @@ class FtpTests extends TestCase
 
     /**
      * @depends testInstantiable
-     * @expectedException RuntimeException
+     * @expectedException \League\Flysystem\RuntimeException
      */
     public function testLoginFailSsl()
     {
@@ -689,7 +689,7 @@ class FtpTests extends TestCase
 
     /**
      * @depends testInstantiable
-     * @expectedException RuntimeException
+     * @expectedException \League\Flysystem\RuntimeException
      */
     public function testRootFailSsl()
     {
@@ -699,7 +699,7 @@ class FtpTests extends TestCase
 
     /**
      * @depends testInstantiable
-     * @expectedException RuntimeException
+     * @expectedException \League\Flysystem\RuntimeException
      */
     public function testPassiveFailSsl()
     {
@@ -740,7 +740,7 @@ class FtpTests extends TestCase
 
     /**
      * @depends testInstantiable
-     * @expectedException \RuntimeException
+     * @expectedException \League\Flysystem\RuntimeException
      */
     public function testItThrowsAnExceptionWhenAnInvalidUnixListingIsFound()
     {
@@ -760,7 +760,7 @@ class FtpTests extends TestCase
 
     /**
      * @depends testInstantiable
-     * @expectedException \RuntimeException
+     * @expectedException \League\Flysystem\RuntimeException
      */
     public function testItThrowsAnExceptionWhenAnInvalidWindowsListingIsFound()
     {

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -3,6 +3,7 @@
 namespace League\Flysystem\Adapter;
 
 use League\Flysystem\Config;
+use League\Flysystem\LogicException;
 use PHPUnit\Framework\TestCase;
 
 function fopen($result, $mode)
@@ -231,7 +232,7 @@ class LocalAdapterTests extends TestCase
         try {
             $root = __DIR__ . '/files/not-writable';
             mkdir($root, 0000, true);
-            $this->setExpectedException('LogicException');
+            $this->setExpectedException(LogicException::class);
             new Local($root);
         } catch (\Exception $e) {
             rmdir($root);

--- a/tests/MountManagerTests.php
+++ b/tests/MountManagerTests.php
@@ -29,7 +29,7 @@ class MountManagerTests extends TestCase
     }
 
     /**
-     * @expectedException  LogicException
+     * @expectedException  \League\Flysystem\LogicException
      */
     public function testUndefinedFilesystem()
     {


### PR DESCRIPTION
First of all, excellent work on the library, thanks everyone who is contributing.

The goal of this PR is to suggest using `League\Flysystem\Exception` for all errors coming from adapters. The change is related to issue #620 and #611 

**Why?**
I need to differentiate between false and exception. Also when I call `Filesystem->has()` or different method I want to put the logic inside try/catch block and act on it.

Right now different exceptions might be returned and there is no rule that custom adapters should extend or wrap exceptions inside `League\Flysystem\Exception`. This means that if I use `Filesystem` and I want to catch Google Cloud Storage exception I have to check Google SDK exceptions.

The fix for adapter can be implemented without BC break, I can extend or wrap exceptions in already existing `League\Flysystem\Exception`. So here I suggest changing the phpdocs to include `@throws Exception`.

**Possible BC break**
I would love to keep BC breaks minimal or none if possible, otherwise this will end up in 2.0 branch, but I changed Local and FTP adapters to throw `League\Flysystem\Exception`. I am happy to remove these changes from this PR if it's too much.

**Discussion**
Let's discuss what's the best approach to deal with this. Right now I think it's should be the Adapter's job to deal with specific exceptions and throwing something Filesystem user expects, but maybe there is better solution to this.