### PR TITLE
Suggest extensions needed for standard FTP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,8 @@
         "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
         "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications",
         "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+        "ext-ftp": "Allows you to use FTP server storage",
+        "ext-openssl": "Allows you to use FTPS server storage",
         "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
         "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter"
     },


### PR DESCRIPTION
If PHP has been built without these extensions then the FtpAdapter won't work