### PR TITLE
Updated ServicesBuilder class name

### DIFF
--- a/docs/adapter/azure.md
+++ b/docs/adapter/azure.md
@@ -15,7 +15,7 @@ composer require league/flysystem-azure
 ## Usage
 
 ~~~ php
-use WindowsAzure\Common\ServicesBuilder;
+use MicrosoftAzure\Storage\Common\ServicesBuilder;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Azure\AzureAdapter;
 


### PR DESCRIPTION
The root namespace was changed in microsoft/azure-storage:0.10.0 according to their [Changelog](https://github.com/Azure/azure-storage-php/blob/master/ChangeLog.md):

    Change root namespace from "WindowsAzure" to "MicrosoftAzure/Storage"