### PR TITLE
Improve isConnected()

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -529,7 +529,7 @@ class Ftp extends AbstractFtpAdapter
     public function isConnected()
     {
         try {
-            return is_resource($this->connection) && ftp_rawlist($this->connection, '/') !== false;
+            return is_resource($this->connection) && ftp_rawlist($this->connection, $this->getRoot()) !== false;
         } catch (ErrorException $e) {
             if (strpos($e->getMessage(), 'ftp_rawlist') === false) {
                 throw $e;


### PR DESCRIPTION
The `isConnected()` function always lists the root directory of the ftp server to determine if the connection is active. 

This changes that to list the root of the adapter instead. It's useful for when you have a very large root directory causing LIST commands to take a long time and you want to specify a sub-directory as root to speed things up.