### PR TITLE
Fix setRoot on AbstractFtpAdapter

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -212,7 +212,11 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
     public function setRoot($root)
     {
         $this->root = rtrim($root, '\\/') . $this->separator;
-
+        
+        if (method_exists($this, 'setConnectionRoot')) {
+            $this->setConnectionRoot();
+        }
+        
         return $this;
     }
 


### PR DESCRIPTION
i use laravel filesystem but have problem if  i  change root folder first ftp use folder not changed
before fix:
        $storage->createDir('root');
        $storage->getDriver()->getAdapter()->setRoot($storage->getDriver()->getAdapter()->getRoot() . '/root');
        $storage->createDir('products');
folders:
  /root
  /products

after:
folders:
  /root
  /root/products