### PR TITLE
FTP: Fix manual recursion mode

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -507,7 +507,7 @@ class Ftp extends AbstractFtpAdapter
      */
     protected function listDirectoryContentsRecursive($directory)
     {
-        $listing = $this->normalizeListing($this->ftpRawlist('-aln', $directory) ?: []);
+        $listing = $this->normalizeListing($this->ftpRawlist('-aln', $directory) ?: [], $directory);
         $output = [];
 
         foreach ($listing as $directory) {

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -163,6 +163,12 @@ function ftp_rawlist($connection, $directory)
         }
     }
 
+    if (strpos($directory, 'recurse.manually/recurse.folder') !== false) {
+        return [
+            '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01 file1.txt',
+        ];
+    }
+
     if (strpos($directory, 'recurse.manually') !== false) {
         return [
             'drwxr-xr-x   2 ftp      ftp          4096 Nov 24 13:59 recurse.folder',
@@ -170,9 +176,7 @@ function ftp_rawlist($connection, $directory)
     }
 
     if (strpos($directory, 'recurse.folder') !== false) {
-        return [
-            '-rw-r--r--   1 ftp      ftp           409 Aug 19 09:01 file1.txt',
-        ];
+        return false;
     }
 
     if (strpos($directory, 'fail.rawlist') !== false) {
@@ -425,6 +429,8 @@ class FtpTests extends TestCase
         $adapter->setRecurseManually(true);
         $result = $adapter->listContents('recurse.manually', true);
         $this->assertCount(2, $result);
+        $this->assertEquals('recurse.manually/recurse.folder', $result[0]['path']);
+        $this->assertEquals('recurse.manually/recurse.folder/file1.txt', $result[1]['path']);
     }
 
     /**


### PR DESCRIPTION
FTP listings must be normalized by prepending the base directory to all paths.

Automatic recursion mode already does that (note the `$directory` parameter): https://github.com/thephpleague/flysystem/blob/3b7394d78ad5936dab8a7041c63ac83722af27d9/src/Adapter/Ftp.php#L500