### PR TITLE
Update Filesystem.php method createDir with the option to return the object

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -254,12 +254,16 @@ class Filesystem implements FilesystemInterface
     /**
      * @inheritdoc
      */
-    public function createDir($dirname, array $config = [])
+    public function createDir($dirname, array $config = [], $return_object = false)
     {
         $dirname = Util::normalizePath($dirname);
         $config = $this->prepareConfig($config);
-
-        return (bool) $this->getAdapter()->createDir($dirname, $config);
+        
+        if (!$return_object) {
+            return (bool) $this->getAdapter()->createDir($dirname, $config);
+        }
+        
+        return $this->getAdapter()->createDir($dirname, $config);
     }
 
     /**


### PR DESCRIPTION
Added parameter to return the object from `createDir`, otherwise defaults to current behavior of returning bool.

Use Case: I wold be nice to get the response from the adapter, in my case https://github.com/nao-pon/flysystem-google-drive returns an object/array of the path in Google Drive which I need.