### PR TITLE
Fixed phpdoc and in FTP check root content instead of isset

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -7,7 +7,7 @@ use League\Flysystem\AdapterInterface;
 abstract class AbstractAdapter implements AdapterInterface
 {
     /**
-     * @var string path prefix
+     * @var string|null path prefix
      */
     protected $pathPrefix;
 
@@ -38,7 +38,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Get the path prefix.
      *
-     * @return string path prefix
+     * @return string|null path prefix or null if pathPrefix is empty
      */
     public function getPathPrefix()
     {

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -185,7 +185,7 @@ class Ftp extends AbstractFtpAdapter
         $root = $this->getRoot();
         $connection = $this->connection;
 
-        if (isset($root) && ! ftp_chdir($connection, $root)) {
+        if ($root && ! ftp_chdir($connection, $root)) {
             throw new RuntimeException('Root is invalid or does not exist: ' . $this->getRoot());
         }
 
@@ -540,7 +540,7 @@ class Ftp extends AbstractFtpAdapter
     }
 
     /**
-     * @return null|string
+     * @return bool
      */
     protected function isPureFtpdServer()
     {

--- a/src/File.php
+++ b/src/File.php
@@ -17,7 +17,7 @@ class File extends Handler
     /**
      * Read the file.
      *
-     * @return string file contents
+     * @return string|false file contents
      */
     public function read()
     {
@@ -27,7 +27,7 @@ class File extends Handler
     /**
      * Read the file as a stream.
      *
-     * @return resource file stream
+     * @return resource|false file stream
      */
     public function readStream()
     {
@@ -143,7 +143,7 @@ class File extends Handler
     /**
      * Get the file's timestamp.
      *
-     * @return int unix timestamp
+     * @return string|false The timestamp or false on failure.
      */
     public function getTimestamp()
     {
@@ -153,7 +153,7 @@ class File extends Handler
     /**
      * Get the file's mimetype.
      *
-     * @return string mimetime
+     * @return string|false The file mime-type or false on failure.
      */
     public function getMimetype()
     {
@@ -163,7 +163,7 @@ class File extends Handler
     /**
      * Get the file's visibility.
      *
-     * @return string visibility
+     * @return string|false The visibility (public|private) or false on failure.
      */
     public function getVisibility()
     {
@@ -173,7 +173,7 @@ class File extends Handler
     /**
      * Get the file's metadata.
      *
-     * @return array
+     * @return array|false The file metadata or false on failure.
      */
     public function getMetadata()
     {
@@ -183,7 +183,7 @@ class File extends Handler
     /**
      * Get the file size.
      *
-     * @return int file size
+     * @return int|false The file size or false on failure.
      */
     public function getSize()
     {

--- a/src/Plugin/EmptyDir.php
+++ b/src/Plugin/EmptyDir.php
@@ -17,7 +17,7 @@ class EmptyDir extends AbstractPlugin
     /**
      * Empty a directory's contents.
      *
-     * @param $dirname
+     * @param string $dirname
      */
     public function handle($dirname)
     {

--- a/src/Plugin/ListWith.php
+++ b/src/Plugin/ListWith.php
@@ -40,8 +40,8 @@ class ListWith extends AbstractPlugin
     /**
      * Get a meta-data value by key name.
      *
-     * @param array $object
-     * @param       $key
+     * @param array  $object
+     * @param string $key
      *
      * @return array
      */

--- a/src/Util/ContentListingFormatter.php
+++ b/src/Util/ContentListingFormatter.php
@@ -75,7 +75,7 @@ class ContentListingFormatter
     /**
      * Check if the entry resides within the parent directory.
      *
-     * @param $entry
+     * @param array $entry
      *
      * @return bool
      */
@@ -91,7 +91,7 @@ class ContentListingFormatter
     /**
      * Check if the entry is a direct child of the directory.
      *
-     * @param $entry
+     * @param array $entry
      *
      * @return bool
      */

--- a/src/Util/MimeType.php
+++ b/src/Util/MimeType.php
@@ -2,7 +2,7 @@
 
 namespace League\Flysystem\Util;
 
-use Finfo;
+use finfo;
 use ErrorException;
 
 /**
@@ -19,11 +19,11 @@ class MimeType
      */
     public static function detectByContent($content)
     {
-        if ( ! class_exists('Finfo') || ! is_string($content)) {
-            return;
+        if ( ! class_exists('finfo') || ! is_string($content)) {
+            return null;
         }
         try {
-            $finfo = new Finfo(FILEINFO_MIME_TYPE);
+            $finfo = new finfo(FILEINFO_MIME_TYPE);
 
             return $finfo->buffer($content) ?: null;
         // @codeCoverageIgnoreStart
@@ -57,7 +57,7 @@ class MimeType
     /**
      * @param string $filename
      *
-     * @return string
+     * @return string|null MIME Type or NULL if no extension detected
      */
     public static function detectByFilename($filename)
     {

--- a/src/Util/StreamHasher.php
+++ b/src/Util/StreamHasher.php
@@ -20,7 +20,7 @@ class StreamHasher
     }
 
     /**
-     * @param $resource
+     * @param resource $resource
      *
      * @return string
      */


### PR DESCRIPTION
* $root in Ftp::setConnectionRoot is always defined, but sometimes it doesn't have value. Check $root instead of isset($root)
* Fixed many phpdoc errors.
* Correct case for finfo instead of Finfo

I found these errors thanks to phpstan static analysis tool. phpstan can be executed with following script:
``` sh
ls phpstan.phar || wget https://raw.githubusercontent.com/phpstan/phpstan-shim/0.9.1/phpstan.phar && \
chmod 777 phpstan.phar && \
./phpstan.phar analyse -a vendor/autoload.php -l 7 src
```