### PR TITLE
Introduced new CanOverwriteFiles method in AdapterInterface

### DIFF
--- a/spec/FilesystemSpec.php
+++ b/spec/FilesystemSpec.php
@@ -2,11 +2,15 @@
 
 namespace spec\League\Flysystem;
 
+use League\Flysystem\AdapterInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class FilesystemSpec extends ObjectBehavior
 {
+    /**
+     * @var AdapterInterface
+     */
     protected $adapter;
     protected $cache;
 
@@ -116,6 +120,7 @@ class FilesystemSpec extends ObjectBehavior
             'path' => 'file',
             'contents' => 'contents',
         ]);
+        $this->adapter->canOverwriteFiles()->willReturn(false);
         $this->put('file', 'contents')->shouldReturn(true);
     }
 
@@ -126,6 +131,7 @@ class FilesystemSpec extends ObjectBehavior
         $this->adapter->writeStream('file', $stream, Argument::type('League\Flysystem\Config'))->willReturn($cache = [
             'path' => 'file',
         ]);
+        $this->adapter->canOverwriteFiles()->willReturn(false);
         $this->putStream('file', $stream)->shouldReturn(true);
         fclose($stream);
     }
@@ -137,6 +143,7 @@ class FilesystemSpec extends ObjectBehavior
             'path' => 'file',
             'contents' => 'contents',
         ]);
+        $this->adapter->canOverwriteFiles()->willReturn(false);
         $this->put('file', 'contents')->shouldReturn(true);
     }
 
@@ -147,6 +154,7 @@ class FilesystemSpec extends ObjectBehavior
         $this->adapter->updateStream('file', $stream, Argument::type('League\Flysystem\Config'))->willReturn($cache = [
             'path' => 'file',
         ]);
+        $this->adapter->canOverwriteFiles()->willReturn(false);
         $this->putStream('file', $stream)->shouldReturn(true);
         fclose($stream);
     }

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -68,4 +68,14 @@ abstract class AbstractAdapter implements AdapterInterface
     {
         return substr($path, strlen($this->getPathPrefix()));
     }
+
+    /**
+     * Can adapter overwrite files
+     *
+     * @return bool
+     */
+    public function canOverwriteFiles()
+    {
+        return false;
+    }
 }

--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -625,4 +625,14 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
      * @return bool
      */
     abstract public function isConnected();
+
+    /**
+     * Can adapter overwrite files
+     *
+     * @return bool
+     */
+    public function canOverwriteFiles()
+    {
+        return true;
+    }
 }

--- a/src/Adapter/CanOverwriteFiles.php
+++ b/src/Adapter/CanOverwriteFiles.php
@@ -6,5 +6,7 @@ namespace League\Flysystem\Adapter;
 /**
  * Adapters that implement this interface let the Filesystem know that it files can be overwritten using the write
  * functions and don't need the update function to be called. This can help improve performance when asserts are disabled.
+ *
+ * @deprecated will be dropped in 2.0, use AdapterInterface::canOverwriteFiles instead
  */
 interface CanOverwriteFiles {}

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -507,4 +507,14 @@ class Local extends AbstractAdapter
             throw UnreadableFileException::forFileInfo($file);
         }
     }
+
+    /**
+     * Can adapter overwrite files
+     *
+     * @return bool
+     */
+    public function canOverwriteFiles()
+    {
+        return true;
+    }
 }

--- a/src/Adapter/NullAdapter.php
+++ b/src/Adapter/NullAdapter.php
@@ -141,4 +141,14 @@ class NullAdapter extends AbstractAdapter
     {
         return false;
     }
+
+    /**
+     * Can adapter overwrite files
+     *
+     * @return bool
+     */
+    public function canOverwriteFiles()
+    {
+        return true;
+    }
 }

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -115,4 +115,11 @@ interface AdapterInterface extends ReadInterface
      * @return array|false file meta data
      */
     public function setVisibility($path, $visibility);
+
+    /**
+     * Can adapter overwrite files
+     *
+     * @return bool
+     */
+    public function canOverwriteFiles();
 }

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -94,8 +94,9 @@ class Filesystem implements FilesystemInterface
     {
         $path = Util::normalizePath($path);
         $config = $this->prepareConfig($config);
+        $canOverwrite = $this->adapter->canOverwriteFiles() || $this->getAdapter() instanceof CanOverwriteFiles;
 
-        if ( ! $this->getAdapter() instanceof CanOverwriteFiles && $this->has($path)) {
+        if ( ! $canOverwrite && $this->has($path)) {
             return (bool) $this->getAdapter()->update($path, $contents, $config);
         }
 
@@ -114,8 +115,9 @@ class Filesystem implements FilesystemInterface
         $path = Util::normalizePath($path);
         $config = $this->prepareConfig($config);
         Util::rewindStream($resource);
+        $canOverwrite = $this->adapter->canOverwriteFiles() || $this->getAdapter() instanceof CanOverwriteFiles;
 
-        if ( ! $this->getAdapter() instanceof CanOverwriteFiles &&$this->has($path)) {
+        if ( ! $canOverwrite && $this->has($path)) {
             return (bool) $this->getAdapter()->updateStream($path, $resource, $config);
         }
 

--- a/stub/FileOverwritingAdapterStub.php
+++ b/stub/FileOverwritingAdapterStub.php
@@ -114,4 +114,9 @@ class FileOverwritingAdapterStub implements AdapterInterface, CanOverwriteFiles
     {
 
     }
+
+    public function canOverwriteFiles()
+    {
+
+    }
 }

--- a/tests/FilesystemTests.php
+++ b/tests/FilesystemTests.php
@@ -1,5 +1,6 @@
 <?php
 
+use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Util;
@@ -13,7 +14,7 @@ class FilesystemTests extends TestCase
     use \PHPUnitHacks;
 
     /**
-     * @var ObjectProphecy
+     * @var ObjectProphecy|AdapterInterface
      */
     protected $prophecy;
 
@@ -118,6 +119,7 @@ class FilesystemTests extends TestCase
         $contents = 'contents';
         $this->prophecy->has($path)->willReturn(false);
         $this->prophecy->write($path, $contents, $this->config)->willReturn(compact('path', 'contents'));
+        $this->prophecy->canOverwriteFiles()->willReturn(false);
         $this->assertTrue($this->filesystem->put($path, $contents));
     }
 
@@ -127,6 +129,7 @@ class FilesystemTests extends TestCase
         $stream = tmpfile();
         $this->prophecy->has($path)->willReturn(false);
         $this->prophecy->writeStream($path, $stream, $this->config)->willReturn(compact('path'));
+        $this->prophecy->canOverwriteFiles()->willReturn(false);
         $this->assertTrue($this->filesystem->putStream($path, $stream));
         fclose($stream);
     }
@@ -137,6 +140,7 @@ class FilesystemTests extends TestCase
         $contents = 'contents';
         $this->prophecy->has($path)->willReturn(true);
         $this->prophecy->update($path, $contents, $this->config)->willReturn(compact('path', 'contents'));
+        $this->prophecy->canOverwriteFiles()->willReturn(false);
         $this->assertTrue($this->filesystem->put($path, $contents));
     }
 
@@ -146,6 +150,7 @@ class FilesystemTests extends TestCase
         $stream = tmpfile();
         $this->prophecy->has($path)->willReturn(true);
         $this->prophecy->updateStream($path, $stream, $this->config)->willReturn(compact('path'));
+        $this->prophecy->canOverwriteFiles()->willReturn(false);
         $this->assertTrue($this->filesystem->putStream($path, $stream));
         fclose($stream);
     }


### PR DESCRIPTION
The existing interface CanOverwriteFiles can't be easily decorated, because adapter can either implement it or not, but it can't keep original behavior.

The changes are backward compatible, anything that implements the existing CanOverwriteFiles will still work as before. Additional change is that Local, Null and Ftp adapters can overwrite files now to spare one more has call and improve performance.

I noticed this issue when we decorated one of network file systems and we ended up with 2x slowdown, the reason was that the decorated adapter didn't implement the CanOverwriteFiles interface.