### PR TITLE
Don't ship docs with composer installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto
 
 /build export-ignore
+/docs export-ignore
 /spec export-ignore
 /stub export-ignore
 /tests export-ignore
@@ -15,3 +16,4 @@
 /changelog.md export-ignore
 /appveyor.yml export-ignore
 /README.md export-ignore
+/wait_for_ftp_service.php export-ignore


### PR DESCRIPTION
Docs are not needed for composer installs.

Also I'm not sure why `wait_for_ftp_service.php` is shipped.