### PR TITLE
Replace the description of the getTimestamp method

### DIFF
--- a/src/ReadInterface.php
+++ b/src/ReadInterface.php
@@ -69,7 +69,7 @@ interface ReadInterface
     public function getMimetype($path);
 
     /**
-     * Get the timestamp of a file.
+     * Get the last modified time of a file as a timestamp.
      *
      * @param string $path
      *


### PR DESCRIPTION
Since the original description of the getTimestamp method did not describe that the method returns the last modified time of the file, replace the description to make it clear that the getTimestamp method returns the last modified time of the file as a timestamp.

Closes thephpleague/flysystem#836