### PR TITLE
Catch exceptions thrown by SplFileInfo

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -14,6 +14,7 @@ use League\Flysystem\Util;
 use LogicException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use RuntimeException;
 use SplFileInfo;
 
 class Local extends AbstractAdapter
@@ -490,15 +491,28 @@ class Local extends AbstractAdapter
      */
     protected function mapFileInfo(SplFileInfo $file)
     {
-        $normalized = [
-            'type' => $file->getType(),
-            'path' => $this->getFilePath($file),
-        ];
+        $normalized = [];
 
-        $normalized['timestamp'] = $file->getMTime();
+        try {
+            $normalized['type'] = $file->getType();
+        } catch (RuntimeException $e) {
+        }
 
-        if ($normalized['type'] === 'file') {
-            $normalized['size'] = $file->getSize();
+        try {
+            $normalized['path'] = $this->getFilePath($file);
+        } catch (RuntimeException $e) {
+        }
+
+        try {
+            $normalized['timestamp'] = $file->getMTime();
+        } catch (RuntimeException $e) {
+        }
+
+        try {
+            if (array_key_exists('type', $normalized) && $normalized['type'] === 'file') {
+                $normalized['size'] = $file->getSize();
+            }
+        } catch (RuntimeException $e) {
         }
 
         return $normalized;


### PR DESCRIPTION
Methods such as `SplFileInfo::getType()`, `SplFileInfo::getMTime()` and `SplFileInfo::getSize()` throw `RuntimeException`s when they fail. Such exceptions should be caught and dealt with. In this case, when generating the file info map, the information is simply not populated for calls that fail.