### PR TITLE
Suppressed Warnings on unlink and added tests to support change.

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -261,7 +261,7 @@ class Local extends AbstractAdapter
     {
         $location = $this->applyPathPrefix($path);
 
-        return unlink($location);
+        return @unlink($location);
     }
 
     /**

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -458,6 +458,17 @@ class LocalAdapterTests extends TestCase
         $this->assertEquals('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $adapter->getMimetype('test.xlsx')['mimetype']);
     }
 
+    public function testDeleteFileShouldReturnTrue(){
+        $root = __DIR__ . '/files/';
+        $original = $root . 'delete.txt';
+        file_put_contents($original, 'something');
+        $this->assertTrue($this->adapter->delete('delete.txt'));
+    }
+
+    public function testDeleteMissingFileShouldReturnFalse(){
+        $this->assertFalse($this->adapter->delete('missing.txt'));
+    }
+
     /**
      * @expectedException \League\Flysystem\Exception
      */


### PR DESCRIPTION
A PHP Warning is thrown if the file to delete is missing, this can be due to a race condition.

This fix suppresses the warning allowing unlink to return true/false as expected.