### PR TITLE
Added FileExistsException to MountManager::copy annotations

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -195,6 +195,7 @@ class MountManager
      *
      * @throws InvalidArgumentException
      * @throws FilesystemNotFoundException
+     * @throws FileExistsException
      *
      * @return bool
      */


### PR DESCRIPTION
FilesystemInterface::writeStream can throw a FileExistsException, as a result MountManager::copy throws it as well