### PR TITLE
Check if file exist to prevent E_WARNING

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -212,7 +212,12 @@ class Local extends AbstractAdapter
      */
     public function read($path)
     {
-        $location = $this->applyPathPrefix($path);
+        $location = $this->applyPathPrefix($path);        
+
+        if (! file_exists($location)) {
+            return false;
+        }
+
         $contents = file_get_contents($location);
 
         if ($contents === false) {


### PR DESCRIPTION
Fixes #940. See https://github.com/1up-lab/OneupFlysystemBundle/issues/180

From it's documentation: 
> This function returns false for files inaccessible due to safe mode restrictions. However these files still can be included if they are located in safe_mode_include_dir.

I'm not sure if this is a problem. Any ideas?