### PR TITLE
Add FilesystemInterface implements on MountManager

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -43,7 +43,7 @@ use League\Flysystem\Plugin\PluginNotFoundException;
  * @method void assertAbsent($path)
  * @method Filesystem addPlugin(PluginInterface $plugin)
  */
-class MountManager
+class MountManager implements FilesystemInterface
 {
     use PluggableTrait;
 


### PR DESCRIPTION
Thanks for this great package :) !

I am currently working on an application requiring quite complex filesystem management needs and I think the Flysystem MountManager could help me a lot on this level. However, I would love to be able to swap the MountManager to something else in tests easily, to ease testing.

Would it make sense to let the MountManager implement the FilesystemInterface for that, to let developers typehint the Filesystem interface? I'm not sure whether or not other filesystem implementations would actually work with schemes.

If it's not a good idea, could it be possible to add a MountManager interface, in order to ease typehinting (and for instance allow autowiring in the context of Symfony 4)?