### PR TITLE
Local::ensureDirectory - improve error message; clearstatcache

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -105,7 +105,8 @@ class Local extends AbstractAdapter
             umask($umask);
             clearstatcache();
             if ( ! is_dir($root)) {
-                throw new Exception(sprintf('Impossible to create the root directory "%s". ' . $mkdirErrorArray['message'], $root));
+                $errorMessage = isset($mkdirErrorArray['message']) ? $mkdirErrorArray['message'] : '';
+                throw new Exception(sprintf('Impossible to create the root directory "%s". %s' , $root, $errorMessage));
             }
         }
     }

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -103,7 +103,6 @@ class Local extends AbstractAdapter
                 $mkdirErrorArray = error_get_last();
             }
             umask($umask);
-            clearstatcache();
             if ( ! is_dir($root)) {
                 $errorMessage = isset($mkdirErrorArray['message']) ? $mkdirErrorArray['message'] : '';
                 throw new Exception(sprintf('Impossible to create the root directory "%s". %s' , $root, $errorMessage));

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -99,11 +99,13 @@ class Local extends AbstractAdapter
     {
         if ( ! is_dir($root)) {
             $umask = umask(0);
-            @mkdir($root, $this->permissionMap['dir']['public'], true);
+            if( ! @mkdir($root, $this->permissionMap['dir']['public'], true)){
+                $mkdirErrorArray = error_get_last();
+            }
             umask($umask);
-
+            clearstatcache();
             if ( ! is_dir($root)) {
-                throw new Exception(sprintf('Impossible to create the root directory "%s".', $root));
+                throw new Exception(sprintf('Impossible to create the root directory "%s". ' . $mkdirErrorArray['message'], $root));
             }
         }
     }


### PR DESCRIPTION
That would be great to be able to get the error message with exact reason why the directory was not created.

Also the result of `is_dir` function is cached. So if directory was created by another php process, then it still will return `false`. So the cache should be cleared before the second `is_dir` call