### PR TITLE
Updated README.md with link to new Google Drive adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Want to get started quickly? Check out some of these integrations:
 * Gaufrette: https://github.com/jenkoian/flysystem-gaufrette
 * Google Cloud Storage: https://github.com/Superbalist/flysystem-google-storage
 * Google Drive: https://github.com/nao-pon/flysystem-google-drive
+* Google Drive V2 (using regular paths): https://github.com/masbug/flysystem-google-drive-ext
 * OneDrive: https://github.com/jacekbarecki/flysystem-onedrive
 * OpenStack Swift: https://github.com/nimbusoftltd/flysystem-openstack-swift
 * Redis (through Predis): https://github.com/danhunsaker/flysystem-redis


### PR DESCRIPTION
Hi,

I've made an adaptation of flysystem-google-drive adapter which allows you to use regular paths instead of paths built from unique identifiers. All ID handling is performed in the adapter (also with heavy built-in caching).
For example:
"native google drive path" **/Xa3X9GlR6EmbnY1RLVTk5VUtOVkk/0B3X9GlR6EmbnY1RLVTk5VUtOVkk** 
becomes **/My Nice Dir/myFile.ext**

I also included a fix for Google_Http_MediaFileUpload which reduces memory usage by using Psr7 streams and sends everything in chunks instead of loading the whole file in memory before sending.

This PR request adds a link to the new Google Drive adapter.
