### PR TITLE
Added RDF extension to mimetype util

### DIFF
--- a/src/Util/MimeType.php
+++ b/src/Util/MimeType.php
@@ -58,6 +58,7 @@ class MimeType
         'z'     => 'application/x-compress',
         'xhtml' => 'application/xhtml+xml',
         'xht'   => 'application/xhtml+xml',
+        'rdf'   => 'application/rdf+xml',
         'zip'   => 'application/x-zip',
         'rar'   => 'application/x-rar',
         'mid'   => 'audio/midi',


### PR DESCRIPTION
When retrieving files with the .rdf extension we get `text/plain` as a ContentType. We would however expect to see `application/rdf+xml` set as a ContentType.

This pull request adds the rdf extension to the mimetype util, and resolves this issue.