### PR TITLE
Added Scaleway Object Storage to list of adapters

### DIFF
--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -17,6 +17,7 @@ Adapters:
     Azure: '/docs/adapter/azure/'
     AWS S3: '/docs/adapter/aws-s3/'
     DigitalOcean Spaces: '/docs/adapter/digitalocean-spaces/'
+    Scaleway Object Storage: '/docs/adapter/scaleway-object-storage/'
     Dropbox: '/docs/adapter/dropbox/'
     FTP: '/docs/adapter/ftp/'
     Memory: '/docs/adapter/memory/'

--- a/docs/adapter/scaleway-object-storage.md
+++ b/docs/adapter/scaleway-object-storage.md
@@ -1,0 +1,37 @@
+---
+layout: default
+permalink: /docs/adapter/scaleway-object-storage/
+redirect_from: /adapter/scaleway-object-storage/
+title: Scaleway Object Storage
+---
+
+The Scaleway Object Storage api are compatible with those of S3, from Flysystem's perspective this means you can use the
+`league/flysystem-aws-s3-v3` adapter.
+
+## Installation
+
+~~~ bash
+composer require league/flysystem-aws-s3-v3
+~~~
+
+## Usage
+
+```php
+use Aws\S3\S3Client;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\Filesystem;
+
+$client = new S3Client([
+    'credentials' => [
+        'key'    => 'your-key',
+        'secret' => 'your-secret',
+    ],
+    'region' => 'your-region',
+    'version' => 'latest|version',
+    'endpoint' => 'https://s3.your-region.scw.cloud',
+]);
+
+$adapter = new AwsS3Adapter($client, 'your-bucket-name');
+
+$filesystem = new Filesystem($adapter);
+```


### PR DESCRIPTION
Hello,

Would it be possible to add [Scaleway Object Storage](https://www.scaleway.com/object-storage/) to the list of adapters?

Their API is S3 compliant. I also verified that it works.