### PR TITLE
Update documentation uploads.md Plain PHP Upload section

### DIFF
--- a/docs/guides/uploads.md
+++ b/docs/guides/uploads.md
@@ -13,7 +13,9 @@ $filesystem->writeStream(
     'uploads/'.$_FILES[$uploadname]['name'],
     $stream
 );
-fclose($stream);
+if (is_resource($stream)) {
+    fclose($stream);
+}
 ```
 
 ## Laravel 5 - DI


### PR DESCRIPTION
The Plain PHP Upload section in uploads.md does not include a condition for is_resource, which can lead to a warning.

***

The `Plain PHP Upload` section in uploads.md does not include a test for is_resource.  When I used the code provided I got an error.  I found the solution at stackoverflow.  After looking further in the documentations I saw that you are mentioning in [Filesystem-api](https://flysystem.thephpleague.com/docs/usage/filesystem-api/#using-streams-for-reads-and-writes) how to check if the stream is closed.

> Some SDK’s close streams after consuming them, therefore, before calling fclose on the resource, check if it’s still valid using is_resource.

Adding this change to the documentation would make it easier for developers like myself who have no idea about checking for is_resource