### PR TITLE
fix some typo in docs about `Create Directories`

### DIFF
--- a/docs/usage/filesystem-api.md
+++ b/docs/usage/filesystem-api.md
@@ -240,7 +240,7 @@ $response = $filesystem->createDir($path);
 param         | description               | type
 ------------- | ------------------------- | -----------
 `$path`       | location of a file        | `string`
-`$response`   | size of a file            | `integer`
+`$response`   | success boolean           | `boolean`
 
 Directories are also made implicitly when writing to a deeper path.
 In general creating a directory is __not__ required in order to write


### PR DESCRIPTION
the Create Directories has some typo of the description and type for $response.

change it same to Delete Directories