### PR TITLE
Change adapter Local::listContents() to a generator

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -269,7 +269,6 @@ class Local extends AbstractAdapter
      */
     public function listContents($directory = '', $recursive = false)
     {
-        $result = [];
         $location = $this->applyPathPrefix($directory);
 
         if ( ! is_dir($location)) {
@@ -285,10 +284,12 @@ class Local extends AbstractAdapter
                 continue;
             }
 
-            $result[] = $this->normalizeFileInfo($file);
-        }
+            $result = $this->normalizeFileInfo($file);
 
-        return array_filter($result);
+            if ($result) {
+                yield $result;
+            }
+        }
     }
 
     /**

--- a/src/ReadInterface.php
+++ b/src/ReadInterface.php
@@ -2,6 +2,8 @@
 
 namespace League\Flysystem;
 
+use Generator;
+
 interface ReadInterface
 {
     /**
@@ -37,7 +39,7 @@ interface ReadInterface
      * @param string $directory
      * @param bool   $recursive
      *
-     * @return array
+     * @return Generator|array
      */
     public function listContents($directory = '', $recursive = false);
 


### PR DESCRIPTION
To prevent extensive memory usage on reading large directories.