### PR TITLE
mkdir() side effects

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -101,7 +101,8 @@ class Local extends AbstractAdapter
         if ( ! is_dir($root)) {
             $umask = umask(0);
 
-            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
+            if ( ! @
+                ($root, $this->permissionMap['dir']['public'], true)) {
                 $mkdirError = error_get_last();
             }
 
@@ -365,6 +366,8 @@ class Local extends AbstractAdapter
 
     /**
      * @inheritdoc
+     *
+     * @throws \ErrorException
      */
     public function createDir($dirname, Config $config)
     {


### PR DESCRIPTION
mkdir() may emit E_WARNING type error, which can transform into \ErrorException exception.