### PR TITLE
Ftp::listContents support for 'timestamp' attribute

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.51 - 2019-03-20
+
+* [Ftp::listContents] Added support to return 'timestamp' attribute. Note that accuracy is limited
+  due to limitations in the 'LIST' command.
+
 ## 1.0.50 - 2019-02-01
 
 * Added option `'case_sensitive'` (default `true`) for cases like Dropbox which are not.

--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -77,6 +77,13 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
     protected $safeStorage;
 
     /**
+     * True to enable timestamps for FTP servers that return unix-style listings
+     *
+     * @var bool
+     */
+    protected $enableTimestampsOnUnixListings = false;
+
+    /**
      * Constructor.
      *
      * @param array $config
@@ -310,6 +317,18 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
     }
 
     /**
+     * True to enable timestamps for FTP servers that return unix-style listings
+     *
+     * @param bool $bool
+     * @return $this
+     */
+    public function setEnableTimestampsOnUnixListings($bool = false) {
+        $this->enableTimestampsOnUnixListings = $bool;
+
+        return $this;
+    }
+
+    /**
      * @inheritdoc
      */
     public function listContents($directory = '', $recursive = false)
@@ -426,9 +445,12 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
         $visibility = $permissions & 0044 ? AdapterInterface::VISIBILITY_PUBLIC : AdapterInterface::VISIBILITY_PRIVATE;
         $size = (int) $size;
 
-        $timestamp = $this->normalizeUnixTimestamp($month, $day, $timeOrYear);
-
-        return compact('type', 'path', 'visibility', 'size', 'timestamp');
+        $result = compact('type', 'path', 'visibility', 'size');
+        if ($this->enableTimestampsOnUnixListings) {
+            $timestamp = $this->normalizeUnixTimestamp($month, $day, $timeOrYear);
+            $result += compact('timestamp');
+        }
+        return $result;
     }
 
     /**

--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -461,9 +461,9 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
      * Note: The 'MLSD' command is a machine-readable replacement for 'LIST'
      * but many FTP servers do not support it :(
      *
-     * @param $month
-     * @param $day
-     * @param $timeOrYear
+     * @param string $month e.g. 'Aug'
+     * @param string $day e.g. '19'
+     * @param string $timeOrYear e.g. '09:01' OR '2015'
      * @return int
      */
     protected function normalizeUnixTimestamp($month, $day, $timeOrYear) {

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -53,6 +53,7 @@ class Ftp extends AbstractFtpAdapter
         'ignorePassiveAddress',
         'recurseManually',
         'utf8',
+        'enableTimestampsOnUnixListings',
     ];
 
     /**

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -605,7 +605,6 @@ class FtpTests extends TestCase
         $adapter = new Ftp($this->options);
 
         $listing = $adapter->listContents('lastfiledir');
-
         $last_modified_file = reset($listing);
         foreach ($listing as $file) {
             $file_time = $adapter->getTimestamp($file['path'])['timestamp'];
@@ -634,14 +633,119 @@ class FtpTests extends TestCase
     /**
      * @depends testInstantiable
      */
-    public function testListingDoNotIncludeTimestamp()
+    public function testListingNotEmpty()
     {
         $adapter = new Ftp($this->options);
 
         $listing = $adapter->listContents('');
 
         $this->assertNotEmpty($listing);
-        $this->assertArrayNotHasKey('timestamp', $listing);
+    }
+
+    public function expectedUnixListings() {
+        return [
+            [
+                /*$directory=*/ '',
+                /*$recursive=*/ false,
+                /*'expectedListing'=>*/ [
+                    [
+                        'type' => 'dir',
+                        'path' => 'cgi-bin',
+                    ],
+                    [
+                        'type' => 'dir',
+                        'path' => 'folder',
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'index.html',
+                        'visibility' => 'public',
+                        'size' => 409,
+                        'timestamp' => 1350086400,
+                    ],
+                    // TODO: Should this entry be here? (recursive=false)... is it a bug?
+                    [
+                        'type' => 'file',
+                        'path' => 'somewhere/folder/dummy.txt',
+                        'visibility' => 'public',
+                        'size' => 0,
+                        'timestamp' => 1574603940,
+                    ],
+                ]
+            ],
+            [
+                /*$directory=*/ '',
+                /*$recursive=*/ true,
+                /*'expectedListing'=>*/ [
+                    [
+                        'type' => 'dir',
+                        'path' => 'cgi-bin',
+                    ],
+                    [
+                        'type' => 'dir',
+                        'path' => 'folder',
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'index.html',
+                        'visibility' => 'public',
+                        'size' => 409,
+                        'timestamp' => 1350086400,
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'somewhere/folder/dummy.txt',
+                        'visibility' => 'public',
+                        'size' => 0,
+                        'timestamp' => 1574603940,
+                    ],
+                ]
+            ],
+            [
+                /*$directory=*/ 'lastfiledir',
+                /*$recursive=*/ true,
+                /*'expectedListing'=>*/ [
+                [
+                    'type' => 'file',
+                    'path' => 'lastfiledir/file1.txt',
+                    'visibility' => 'public',
+                    'size' => 409,
+                    'timestamp' => 1566205260,
+                ],
+                [
+                    'type' => 'file',
+                    'path' => 'lastfiledir/file2.txt',
+                    'visibility' => 'public',
+                    'size' => 409,
+                    'timestamp' => 1565773260,
+                ],
+                [
+                    'type' => 'file',
+                    'path' => 'lastfiledir/file3.txt',
+                    'visibility' => 'public',
+                    'size' => 409,
+                    'timestamp' => 1549447560,
+                ],
+                [
+                    'type' => 'file',
+                    'path' => 'lastfiledir/file4.txt',
+                    'visibility' => 'public',
+                    'size' => 409,
+                    'timestamp' => 1395273600,
+                ],
+            ]
+            ]
+        ];
+    }
+
+    /**
+     * @depends testInstantiable
+     * @dataProvider expectedUnixListings
+     */
+    public function testListingFromUnixFormat($directory, $recursive, $expectedListing) {
+        $adapter = new Ftp($this->options);
+        $listing = $adapter->listContents($directory, $recursive);
+        $this->assertEquals($listing, $expectedListing);
     }
 
     /**

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -647,6 +647,7 @@ class FtpTests extends TestCase
             [
                 /*$directory=*/ '',
                 /*$recursive=*/ false,
+                /*$enableTimestamps=*/ true,
                 /*'expectedListing'=>*/ [
                     [
                         'type' => 'dir',
@@ -676,6 +677,7 @@ class FtpTests extends TestCase
             [
                 /*$directory=*/ '',
                 /*$recursive=*/ true,
+                /*$enableTimestamps=*/ true,
                 /*'expectedListing'=>*/ [
                     [
                         'type' => 'dir',
@@ -704,36 +706,68 @@ class FtpTests extends TestCase
             [
                 /*$directory=*/ 'lastfiledir',
                 /*$recursive=*/ true,
+                /*$enableTimestamps=*/ true,
                 /*'expectedListing'=>*/ [
-                [
-                    'type' => 'file',
-                    'path' => 'lastfiledir/file1.txt',
-                    'visibility' => 'public',
-                    'size' => 409,
-                    'timestamp' => 1566205260,
-                ],
-                [
-                    'type' => 'file',
-                    'path' => 'lastfiledir/file2.txt',
-                    'visibility' => 'public',
-                    'size' => 409,
-                    'timestamp' => 1565773260,
-                ],
-                [
-                    'type' => 'file',
-                    'path' => 'lastfiledir/file3.txt',
-                    'visibility' => 'public',
-                    'size' => 409,
-                    'timestamp' => 1549447560,
-                ],
-                [
-                    'type' => 'file',
-                    'path' => 'lastfiledir/file4.txt',
-                    'visibility' => 'public',
-                    'size' => 409,
-                    'timestamp' => 1395273600,
-                ],
-            ]
+                    [
+                        'type' => 'file',
+                        'path' => 'lastfiledir/file1.txt',
+                        'visibility' => 'public',
+                        'size' => 409,
+                        'timestamp' => 1566205260,
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'lastfiledir/file2.txt',
+                        'visibility' => 'public',
+                        'size' => 409,
+                        'timestamp' => 1565773260,
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'lastfiledir/file3.txt',
+                        'visibility' => 'public',
+                        'size' => 409,
+                        'timestamp' => 1549447560,
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'lastfiledir/file4.txt',
+                        'visibility' => 'public',
+                        'size' => 409,
+                        'timestamp' => 1395273600,
+                    ],
+                ]
+            ],
+            [
+                /*$directory=*/ 'lastfiledir',
+                /*$recursive=*/ true,
+                /*$enableTimestamps=*/ false,
+                /*'expectedListing'=>*/ [
+                    [
+                        'type' => 'file',
+                        'path' => 'lastfiledir/file1.txt',
+                        'visibility' => 'public',
+                        'size' => 409,
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'lastfiledir/file2.txt',
+                        'visibility' => 'public',
+                        'size' => 409,
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'lastfiledir/file3.txt',
+                        'visibility' => 'public',
+                        'size' => 409,
+                    ],
+                    [
+                        'type' => 'file',
+                        'path' => 'lastfiledir/file4.txt',
+                        'visibility' => 'public',
+                        'size' => 409,
+                    ],
+                ]
             ]
         ];
     }
@@ -742,8 +776,8 @@ class FtpTests extends TestCase
      * @depends testInstantiable
      * @dataProvider expectedUnixListings
      */
-    public function testListingFromUnixFormat($directory, $recursive, $expectedListing) {
-        $adapter = new Ftp($this->options);
+    public function testListingFromUnixFormat($directory, $recursive, $enableTimestamps, $expectedListing) {
+        $adapter = new Ftp($this->options += ['enableTimestampsOnUnixListings' => $enableTimestamps]);
         $listing = $adapter->listContents($directory, $recursive);
         $this->assertEquals($listing, $expectedListing);
     }


### PR DESCRIPTION
I've been using the 'timestamp' property to sort/filter files on local and ftp filesystems.

Calls to listContents depending on the 'timestamp' property had been working on some FTP servers and crashing on others (due to missing 'timestamp'), discovered it was due to 'windows' listings returning timestamps, but 'unix' listings not.

This patch provides returning a best-effort (given the limitations of the 'LIST' command) listContents timestamp for FTP servers using 'unix' style listings.