### PR TITLE
Added missing equal sign in documentation

### DIFF
--- a/docs/usage/filesystem-api.md
+++ b/docs/usage/filesystem-api.md
@@ -179,7 +179,7 @@ param         | description              | type
 ## Copy Files
 
 ```php
-$response $filesystem->copy($from, $to);
+$response = $filesystem->copy($from, $to);
 ```
 
 param         | description              | type


### PR DESCRIPTION
I noticed there is a missing equals sign in the docs.