### PR TITLE
Update the MIME type of CSV files.

### DIFF
--- a/src/Util/MimeType.php
+++ b/src/Util/MimeType.php
@@ -13,7 +13,7 @@ class MimeType
     protected static $extensionToMimeTypeMap = [
         'hqx'   => 'application/mac-binhex40',
         'cpt'   => 'application/mac-compactpro',
-        'csv'   => 'text/x-comma-separated-values',
+        'csv'   => 'text/csv',
         'bin'   => 'application/octet-stream',
         'dms'   => 'application/octet-stream',
         'lha'   => 'application/octet-stream',


### PR DESCRIPTION
In order to comply with the last RFC (https://tools.ietf.org/html/rfc7111)
referring to the MIME type of the CSV files these should be of the text/csv type.