### PR TITLE
Add `ignorePassiveAddress` option to docs

### DIFF
--- a/docs/adapter/ftp.md
+++ b/docs/adapter/ftp.md
@@ -24,5 +24,6 @@ $filesystem = new Filesystem(new Adapter([
     'passive' => true,
     'ssl' => true,
     'timeout' => 30,
+    'ignorePassiveAddress' => false,
 ]));
 ```


### PR DESCRIPTION
The option `ignorePassiveAddress` of the FTP adapter is missing in the documentation. I don't know if `false` should be the documented value though 🤔 !