### PR TITLE
Don't guess mimeType when it's known

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -249,7 +249,7 @@ class Ftp extends AbstractFtpAdapter
         }
 
         $result['contents'] = $contents;
-        $result['mimetype'] = Util::guessMimeType($path, $contents);
+        $result['mimetype'] = $config->get('mimetype') ?: Util::guessMimeType($path, $contents);
 
         return $result;
     }

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -207,7 +207,7 @@ class Local extends AbstractAdapter
 
         $result = compact('type', 'path', 'size', 'contents');
 
-        if ($mimetype = Util::guessMimeType($path, $contents)) {
+        if ($mimetype = $config->get('mimetype') ?: Util::guessMimeType($path, $contents)) {
             $result['mimetype'] = $mimetype;
         }
 


### PR DESCRIPTION
Right now in our API calling the guessMimeType method is causing out of memory exceptions because it loads the entire file into a buffer. 
See `return $finfo->buffer($content) ?: null;` in `MimeType.php`