### PR TITLE
Updated backup-manager Github URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ composer require league/flysystem
 
 Want to get started quickly? Check out some of these integrations:
 
-* Backup manager: https://github.com/heybigname/backup-manager
+* Backup manager: https://github.com/backup-manager/backup-manager
 * CakePHP integration: https://github.com/WyriHaximus/FlyPie
 * Cilex integration: https://github.com/WyriHaximus/cli-fly
 * Drupal: https://www.drupal.org/project/flysystem


### PR DESCRIPTION
The `README.md` at https://github.com/heybigname/backup-manager suggest the repo should no longer be used, and users are redirected to https://github.com/backup-manager.