### PR TITLE
Fixed listing of the existing directory in Ftpd

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.54 - 2019-08-11
+
+* Fixed metadata fetching of the existing directory in Ftpd.
+
 ## 1.0.53 - 2019-06-18
 
 * Clear stat cache before getting file metadata.

--- a/src/Adapter/Ftpd.php
+++ b/src/Adapter/Ftpd.php
@@ -12,6 +12,11 @@ class Ftpd extends Ftp
         if ($path === '') {
             return ['type' => 'dir', 'path' => ''];
         }
+        if (@ftp_chdir($this->getConnection(), $path) === true) {
+            $this->setConnectionRoot();
+
+            return ['type' => 'dir', 'path' => $path];
+        }
 
         if ( ! ($object = ftp_raw($this->getConnection(), 'STAT ' . $path)) || count($object) < 3) {
             return false;

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -88,15 +88,19 @@ function ftp_chdir($connection, $directory)
         return false;
     }
 
-    if ($directory === 'not.found') {
-        return false;
-    }
-
-    if ($directory === 'windows.not.found') {
-        return false;
-    }
-
-    if (in_array($directory, ['rawlist-total-0.txt', 'file1.txt', 'file2.txt', 'file3.txt', 'file4.txt', 'dir1', 'file1.with-total-line.txt', 'file1.with-invalid-line.txt'])) {
+    if (in_array($directory, [
+        'not.found',
+        'windows.not.found',
+        'syno.not.found',
+        'rawlist-total-0.txt',
+        'file1.txt',
+        'file2.txt',
+        'file3.txt',
+        'file4.txt',
+        'dir1',
+        'file1.with-total-line.txt',
+        'file1.with-invalid-line.txt',
+    ], true)) {
         return false;
     }
 

--- a/tests/FtpdTests.php
+++ b/tests/FtpdTests.php
@@ -41,6 +41,26 @@ class FtpdTests extends TestCase
     /**
      * @depends testInstantiable
      */
+    public function testGetExistingDirMetadata()
+    {
+        $adapter = new Ftpd($this->options);
+        $dirMetadata = $adapter->getMetadata('spaced.files');
+        $this->assertSame(['type' => 'dir', 'path' => 'spaced.files'], $dirMetadata);
+    }
+
+    /**
+     * @depends testInstantiable
+     */
+    public function testGetMissingDirMetadata()
+    {
+        $adapter = new Ftpd($this->options);
+        $dirMetadata = $adapter->getMetadata('syno.not.found');
+        $this->assertFalse($dirMetadata);
+    }
+
+    /**
+     * @depends testInstantiable
+     */
     public function testRawlistFail()
     {
         $adapter = new Ftpd($this->options);


### PR DESCRIPTION
Follows the parent class fix 5901bb55
Before the change, calling getMetadata() over an existing directory produced a fatal error.

```
PHP Fatal error:  Uncaught RuntimeException: Metadata can't be parsed from item 'total 334920' , not enough parts. in /app/vendor/league/flysystem/src/Adapter/AbstractFtpAdapter.php:435
```

Ftpd produces the following output on `STAT` call over directory:

```
array(46) {
  [0]=>
  string(32) "212- Status of content10/export:"
  [1]=>
  string(12) "total 334920"
  [2]=>
  string(72) "-rw-r--r--  1 1000  1000   3645884 Jul 18 06:10 movie.ts"
  
  [....]

  [45]=>
  string(18) "212 End of status."
}
```

Then, it can not be parsed by `normalizeObject`