### PR TITLE
Fixed Local::getVisibility not working correctly with customised visibilities

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -343,9 +343,14 @@ class Local extends AbstractAdapter
         $location = $this->applyPathPrefix($path);
         clearstatcache(false, $location);
         $permissions = octdec(substr(sprintf('%o', fileperms($location)), -4));
-        $visibility = $permissions & 0044 ? AdapterInterface::VISIBILITY_PUBLIC : AdapterInterface::VISIBILITY_PRIVATE;
-
-        return compact('path', 'visibility');
+        $type  = is_dir($location) ? 'dir' : 'file';
+		
+		foreach ($this->permissionMap[$type] as $visibility => $visibilityPermissions)
+			if ($visibilityPermissions == $permissions)
+				return compact('path', 'visibility');
+		
+		$visibility = substr(sprintf('%o', fileperms($location)), -4);
+		return compact('path', 'visibility');
     }
 
     /**

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -540,7 +540,7 @@ class LocalAdapterTests extends TestCase
 
     public function testMimetypeFallbackOnExtension()
     {
-        $this->adapter->write('test.xlsx', '', new Config);
+        $this->adapter->write('test.xlsx', '', new Config());
         $this->assertEquals('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $this->adapter->getMimetype('test.xlsx')['mimetype']);
     }
 

--- a/tests/LocalAdapterTests.php
+++ b/tests/LocalAdapterTests.php
@@ -381,14 +381,14 @@ class LocalAdapterTests extends TestCase
             $this->markTestSkipped("Visibility not supported on Windows.");
 		
 		$umask = umask(0);
-        mkdir($this->root.'subdir', 0777);
+        mkdir($this->root.'subdir', 0750);
         umask($umask);
 		
         $output = $this->adapter->getVisibility('subdir');
 		
-        $this->assertNotEquals('private', $output['visibility']);  // private is 0700 not 0777
-        $this->assertNotEquals('public', $output['visibility']);  // public is 0755 not 0777
-        $this->assertEquals('0777', $output['visibility']);
+        $this->assertNotEquals('private', $output['visibility']);  // private is 0700 not 0750
+        $this->assertNotEquals('public', $output['visibility']);  // public is 0755 not 0750
+        $this->assertEquals('0750', $output['visibility']);
     }
 	
     public function testCustomizedVisibility()
@@ -396,23 +396,19 @@ class LocalAdapterTests extends TestCase
         if (IS_WINDOWS)
             $this->markTestSkipped("Visibility not supported on Windows.");
         
+		// override a permission mapping
         $permissions = [
-            'file' => [
-                'public' => 0644,
-                'private' => 0660,  // private to me and the gang
-            ],
             'dir' => [
-                'public' => 0755,
                 'private' => 0770,  // private to me and the gang
             ],
         ];
         
-        $customizedAdapter = new Local($this->root, LOCK_EX, Local::DISALLOW_LINKS, $permissions);
+        $adapter = new Local($this->root, LOCK_EX, Local::DISALLOW_LINKS, $permissions);
 		
-        $customizedAdapter->createDir('private-dir', new Config());
-        $customizedAdapter->setVisibility('private-dir', 'private');
+        $adapter->createDir('private-dir', new Config());
+        $adapter->setVisibility('private-dir', 'private');
 		
-        $output = $customizedAdapter->getVisibility('private-dir');
+        $output = $adapter->getVisibility('private-dir');
         
 		$this->assertEquals('private', $output['visibility']);
 		$this->assertEquals('0770', substr(sprintf('%o', fileperms($this->root.'private-dir')), -4));
@@ -423,27 +419,21 @@ class LocalAdapterTests extends TestCase
         if (IS_WINDOWS)
             $this->markTestSkipped("Visibility not supported on Windows.");
         
+		// add a permission mapping
         $permissions = [
-            'file' => [
-				'yolo' => 0666,
-                'public' => 0644,
-                'private' => 0600,
-            ],
             'dir' => [
 				'yolo' => 0777,
-                'public' => 0755,
-                'private' => 0700,
             ],
         ];
         
-        $customizedAdapter = new Local($this->root, LOCK_EX, Local::DISALLOW_LINKS, $permissions);
+        $adapter = new Local($this->root, LOCK_EX, Local::DISALLOW_LINKS, $permissions);
         
-        $customizedAdapter->createDir('yolo-dir', new Config());
-        $customizedAdapter->setVisibility('yolo-dir', 'yolo');
+        $adapter->createDir('yolo-dir', new Config());
+        $adapter->setVisibility('yolo-dir', 'yolo');
         
 		$location = $this->root.'yolo-dir';
 		
-        $output = $customizedAdapter->getVisibility('yolo-dir');
+        $output = $adapter->getVisibility('yolo-dir');
         $this->assertEquals('yolo', $output['visibility']);
 		$this->assertEquals('0777', substr(sprintf('%o', fileperms($location)), -4));
     }
@@ -465,12 +455,12 @@ class LocalAdapterTests extends TestCase
             ],
         ];
         
-        $customizedAdapter = new Local($this->root, LOCK_EX, Local::DISALLOW_LINKS, $permissions);
+        $adapter = new Local($this->root, LOCK_EX, Local::DISALLOW_LINKS, $permissions);
         
-        $customizedAdapter->createDir('sticky-dir', new Config());
-        $customizedAdapter->setVisibility('sticky-dir', 'sticky');
+        $adapter->createDir('sticky-dir', new Config());
+        $adapter->setVisibility('sticky-dir', 'sticky');
         
-        $output = $customizedAdapter->getVisibility('sticky-dir');
+        $output = $adapter->getVisibility('sticky-dir');
         $this->assertEquals('sticky', $output['visibility']);
 		$this->assertEquals('1777', substr(sprintf('%o', fileperms($this->root.'sticky-dir')), -4));
     }


### PR DESCRIPTION
I will outline the main problems in a codeblock:

```php
mkdir($this->root.'subdir', 0750);
$output = $this->adapter->getVisibility('subdir');  
// wrong response - returns public, but public is 0755 by default


$permissions = [
	'dir' => [
		'yolo' => 0777,
		'private' => 0770,  // private to me and the gang
	],
];

$adapter = new Local($this->root, LOCK_EX, Local::DISALLOW_LINKS, $permissions);

$adapter->createDir('private-dir', new Config());
$adapter->setVisibility('private-dir', 'private');
$output = $adapter->getVisibility('private-dir');  
// wrong response - returns public not private

$adapter->createDir('yolo-dir', new Config());
$adapter->setVisibility('yolo-dir', 'yolo');
$output = $adapter->getVisibility('yolo-dir');
// wrong response - returns public not yolo
```

I've added tests that check setting and getting custom or customized permissions. Setting worked fine already, but getting works wrong with the current implementation of `getVisibility`.

I changed the `getVisibility` method on the local adapter to return correct values. I am not sure what should be returned when the visibility is not among the defined ones, currently I return the permission string itself.

In addition I added a test for setting the first permission octet and refined some of the existing tests, changing explicit code to `$this->adapter` and `$this->root` where appropriate.