### PR TITLE
Feature/docs default credential provider usage

### DIFF
--- a/docs/adapter/aws-s3-v3.md
+++ b/docs/adapter/aws-s3-v3.md
@@ -101,7 +101,7 @@ $adapter = new AwsS3Adapter($client, 'your-bucket-name', 'optional/path/prefix')
 $filesystem = new Filesystem($adapter);
 ``` 
 
-For further details on the default credentials provider, see https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#defaultprovider-provider
+For further details see https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#defaultprovider-provider
 
 ---
 

--- a/docs/adapter/aws-s3-v3.md
+++ b/docs/adapter/aws-s3-v3.md
@@ -83,14 +83,14 @@ $client = new S3Client([
 
 ### Default credential provider usage
 
-If an IAM role is assigned to your EC2 instances then it is not necessary to set environment or config based key and secret credentials. Alternatively, the default credential provider can be used by omitting the `credentials` array when creating an S3 client.
+If an IAM role is assigned to your EC2 instances, it is not necessary to specifically set environment or config based key and secret credentials. The default credential provider can simply be used by omitting `credentials` when creating an S3 client.
 
 ```php
 use Aws\S3\S3Client;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
 use League\Flysystem\Filesystem;
 
-// Credentals omitted. Default credential provider will be used
+// Credentials omitted. Default credential provider will be used
 $client = new S3Client([
     'region' => 'your-region',
     'version' => 'latest|version',

--- a/docs/adapter/aws-s3-v3.md
+++ b/docs/adapter/aws-s3-v3.md
@@ -83,7 +83,7 @@ $client = new S3Client([
 
 ### Default credential provider usage
 
-If an IAM role is assigned to your EC2 instances, it is not necessary to specifically set environment or config based key and secret credentials. The default credential provider can simply be used by omitting `credentials` when creating an S3 client.
+If an IAM role is assigned to your EC2 instances, it is not necessary to specifically set environment or config based key and secret credentials. The default credential provider can be used by omitting `credentials` when creating an S3 client.
 
 ```php
 use Aws\S3\S3Client;

--- a/docs/adapter/aws-s3-v3.md
+++ b/docs/adapter/aws-s3-v3.md
@@ -81,6 +81,28 @@ $client = new S3Client([
 ]);
 ```
 
+### Default credential provider usage
+
+If an IAM role is assigned to your EC2 instances then it is not necessary to set environment or config based key and secret credentials. Alternatively, the default credential provider can be used by omitting the `credentials` array when creating an S3 client.
+
+```php
+use Aws\S3\S3Client;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\Filesystem;
+
+// Credentals omitted. Default credential provider will be used
+$client = new S3Client([
+    'region' => 'your-region',
+    'version' => 'latest|version',
+]);
+
+$adapter = new AwsS3Adapter($client, 'your-bucket-name', 'optional/path/prefix');
+
+$filesystem = new Filesystem($adapter);
+``` 
+
+For further details on the default credentials provider, see https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#defaultprovider-provider
+
 ---
 
 ## 🚨 Aws S3 Adapter - SDK V2 (LEGACY ADAPTER)

--- a/docs/adapter/aws-s3-v3.md
+++ b/docs/adapter/aws-s3-v3.md
@@ -101,6 +101,8 @@ $adapter = new AwsS3Adapter($client, 'your-bucket-name', 'optional/path/prefix')
 $filesystem = new Filesystem($adapter);
 ``` 
 
+The default credential provider will attempt to load credentials from sources such as environment variables, configuration files and then from the instance profile, such as EC2 metadata. 
+
 For further details see https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#defaultprovider-provider
 
 ---


### PR DESCRIPTION
- Added section to docs - `adapter/aws-s3-v3` for `Default credential provider usage`. There is no need to specifically include `credentials.key` and `credentials.secret` configuration values when IAM Role is already assigned to the EC2. The documentation should point this out.