### PR TITLE
Correct "disc" to "disk"

### DIFF
--- a/docs/guides/deterministic-programming.md
+++ b/docs/guides/deterministic-programming.md
@@ -13,7 +13,7 @@ problematic.
 ## Filesystems are slow.
 
 In general, filesystem interaction is slow. Every operation that
-hits the disc in one way or another is slow. While some operations absolutely
+hits the disk in one way or another is slow. While some operations absolutely
 require filesystem interaction, there's a number of cases where filesystem
 operations can be prevented in order to eliminate the associated penalties.
 


### PR DESCRIPTION
"Disc" (with a C) is used for audio records, CDs and the like, whereas a computer hard-drive is a "disk" (with a K)