### PR TITLE
Refactoring for capture exceptions 

### DIFF
--- a/src/ConnectionErrorException.php
+++ b/src/ConnectionErrorException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace League\Flysystem;
+
+use ErrorException;
+
+class ConnectionErrorException extends ErrorException implements FlysystemException
+{
+}

--- a/src/ConnectionRuntimeException.php
+++ b/src/ConnectionRuntimeException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace League\Flysystem;
+
+use RuntimeException;
+
+class ConnectionRuntimeException extends RuntimeException implements FlysystemException
+{
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -2,7 +2,7 @@
 
 namespace League\Flysystem;
 
-class Exception extends \Exception
+class Exception extends \Exception implements FlysystemException
 {
     //
 }

--- a/src/FilesystemNotFoundException.php
+++ b/src/FilesystemNotFoundException.php
@@ -7,6 +7,6 @@ use LogicException;
 /**
  * Thrown when the MountManager cannot find a filesystem.
  */
-class FilesystemNotFoundException extends LogicException
+class FilesystemNotFoundException extends LogicException implements FlysystemException
 {
 }

--- a/src/FlysystemException.php
+++ b/src/FlysystemException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\Flysystem;
+
+interface FlysystemException
+{
+}

--- a/src/InvalidRootException.php
+++ b/src/InvalidRootException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace League\Flysystem;
+
+use RuntimeException;
+
+class InvalidRootException extends RuntimeException implements FlysystemException
+{
+}

--- a/src/NotSupportedException.php
+++ b/src/NotSupportedException.php
@@ -5,7 +5,7 @@ namespace League\Flysystem;
 use RuntimeException;
 use SplFileInfo;
 
-class NotSupportedException extends RuntimeException
+class NotSupportedException extends RuntimeException implements FlysystemException
 {
     /**
      * Create a new exception for a link.

--- a/src/RootViolationException.php
+++ b/src/RootViolationException.php
@@ -4,7 +4,7 @@ namespace League\Flysystem;
 
 use LogicException;
 
-class RootViolationException extends LogicException
+class RootViolationException extends LogicException implements FlysystemException
 {
     //
 }


### PR DESCRIPTION
The change will allow you to better capture particular exceptions and catch all the exceptions by iterface `FlysystemException ` (the main thing I needed).

This is not a BC break, as the new expetion inherits from the original. As evidenced by successful tests, see https://github.com/eddycek/flysystem/blob/refactoring-exception/tests/FtpTests.php#L446 and https://github.com/eddycek/flysystem/blob/refactoring-exception/tests/FtpTests.php#L794 etc.

The related PR has already been approved in `flysystem-sftp`, see https://github.com/thephpleague/flysystem-sftp/pull/86