### PR TITLE
Add a mode conversion utility

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -69,7 +69,7 @@ class Local extends AbstractAdapter
                 'private' => Util\Mode::mode('0700'),
             ],
         ];
-        
+
         $root = is_link($root) ? realpath($root) : $root;
         $this->permissionMap = array_replace_recursive($defaultPermissions, $permissions);
         $this->ensureDirectory($root);

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -28,20 +28,6 @@ class Local extends AbstractAdapter
     const DISALLOW_LINKS = 0002;
 
     /**
-     * @var array
-     */
-    protected static $permissions = [
-        'file' => [
-            'public' => Util::mode('0644'),
-            'private' => Util::mode('0600'),
-        ],
-        'dir' => [
-            'public' => Util::mode('0755'),
-            'private' => Util::mode('0700'),
-        ],
-    ];
-
-    /**
      * @var string
      */
     protected $pathSeparator = DIRECTORY_SEPARATOR;
@@ -73,8 +59,19 @@ class Local extends AbstractAdapter
      */
     public function __construct($root, $writeFlags = LOCK_EX, $linkHandling = self::DISALLOW_LINKS, array $permissions = [])
     {
+        $defaultPermissions = [
+            'file' => [
+                'public' => Util\Mode::mode('0644'),
+                'private' => Util\Mode::mode('0600'),
+            ],
+            'dir' => [
+                'public' => Util\Mode::mode('0755'),
+                'private' => Util\Mode::mode('0700'),
+            ],
+        ];
+        
         $root = is_link($root) ? realpath($root) : $root;
-        $this->permissionMap = array_replace_recursive(static::$permissions, $permissions);
+        $this->permissionMap = array_replace_recursive($defaultPermissions, $permissions);
         $this->ensureDirectory($root);
 
         if ( ! is_dir($root) || ! is_readable($root)) {

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -32,12 +32,12 @@ class Local extends AbstractAdapter
      */
     protected static $permissions = [
         'file' => [
-            'public' => 0644,
-            'private' => 0600,
+            'public' => Util::mode('0644'),
+            'private' => Util::mode('0600'),
         ],
         'dir' => [
-            'public' => 0755,
-            'private' => 0700,
+            'public' => Util::mode('0755'),
+            'private' => Util::mode('0700'),
         ],
     ];
 

--- a/src/Util/Mode.php
+++ b/src/Util/Mode.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace League\Flysystem\Util;
 
 class Mode

--- a/src/Util/Mode.php
+++ b/src/Util/Mode.php
@@ -13,18 +13,20 @@ class Mode
     public static function mode($modeString)
     {
         // we don't process it if it's not a string
-        if (!is_string($modeString))
+        if (!is_string($modeString)) {
             return $modeString;
+        }
 
         // this takes care of '755', '0755', '1755', '01755' 
-        if (is_numeric($modeString))
+        if (is_numeric($modeString)) {
             return octdec($modeString);
+        }
 
         // this point is reached in case of something like 'drwSrwxr-T'
-        
+
         // here we'll store the three usual octets for start
         $mode = 0;
-        
+
         // this will hold the first octet; we'll merge it in $mode at the end
         $special = 0;
 
@@ -37,8 +39,9 @@ class Mode
 
             // we must also shift the special bits once every three chars
             // works for both drwxrwxrwt and rwxrwxrwt
-            if (0 == $i % 3)
+            if (0 == $i % 3) {
                 $special = $special << 1;
+            }
 
             $char = $modeString[$i];
 
@@ -48,8 +51,9 @@ class Mode
                 $special |= 1;
 
             // these letters are the only that don't set the corresponding bit in mode
-            if (in_array($char, ['-', 'S', 'T', 'd']))
+            if (in_array($char, ['-', 'S', 'T', 'd'])) {
                 continue;
+            }
 
             // if we reached this, set the bit on
             $mode |= 1;

--- a/src/Util/Mode.php
+++ b/src/Util/Mode.php
@@ -47,8 +47,9 @@ class Mode
 
             // the special bit is set on these letters taking the place of execution bit
             // their order is fixed so it's enough to check if we got any of those
-            if (in_array($char, ['S', 's', 'T', 't']))
+            if (in_array($char, ['S', 's', 'T', 't'])) {
                 $special |= 1;
+            }
 
             // these letters are the only that don't set the corresponding bit in mode
             if (in_array($char, ['-', 'S', 'T', 'd'])) {

--- a/src/Util/Mode.php
+++ b/src/Util/Mode.php
@@ -17,7 +17,7 @@ class Mode
             return $modeString;
         }
 
-        // this takes care of '755', '0755', '1755', '01755' 
+        // this takes care of '755', '0755', '1755', '01755'
         if (is_numeric($modeString)) {
             return octdec($modeString);
         }
@@ -31,8 +31,7 @@ class Mode
         $special = 0;
 
         // let's go through the string char by char
-        for ($i = 0; $i < strlen($modeString); $i++)
-        {
+        for ($i = 0; $i < strlen($modeString); $i++) {
             // for each iteration we shift the mode by one bit
             // thus putting a 0 at the end
             $mode = $mode << 1;

--- a/src/Util/Mode.php
+++ b/src/Util/Mode.php
@@ -1,0 +1,61 @@
+<?php
+namespace League\Flysystem\Util;
+
+class Mode
+{
+    /**
+     * Converts mode from string representation to decimal if necessary
+     *
+     * @param mixed $modeString
+     *
+     * @return int
+     */
+    public static function mode($modeString)
+    {
+        // we don't process it if it's not a string
+        if (!is_string($modeString))
+            return $modeString;
+
+        // this takes care of '755', '0755', '1755', '01755' 
+        if (is_numeric($modeString))
+            return octdec($modeString);
+
+        // this point is reached in case of something like 'drwSrwxr-T'
+        
+        // here we'll store the three usual octets for start
+        $mode = 0;
+        
+        // this will hold the first octet; we'll merge it in $mode at the end
+        $special = 0;
+
+        // let's go through the string char by char
+        for ($i = 0; $i < strlen($modeString); $i++)
+        {
+            // for each iteration we shift the mode by one bit
+            // thus putting a 0 at the end
+            $mode = $mode << 1;
+
+            // we must also shift the special bits once every three chars
+            // works for both drwxrwxrwt and rwxrwxrwt
+            if (0 == $i % 3)
+                $special = $special << 1;
+
+            $char = $modeString[$i];
+
+            // the special bit is set on these letters taking the place of execution bit
+            // their order is fixed so it's enough to check if we got any of those
+            if (in_array($char, ['S', 's', 'T', 't']))
+                $special |= 1;
+
+            // these letters are the only that don't set the corresponding bit in mode
+            if (in_array($char, ['-', 'S', 'T', 'd']))
+                continue;
+
+            // if we reached this, set the bit on
+            $mode |= 1;
+        }
+
+        // finally shift the special bits so they come first and return everything
+        return $mode |= ($special << 9);
+    }
+}

--- a/src/Util/Mode.php
+++ b/src/Util/Mode.php
@@ -5,7 +5,7 @@ namespace League\Flysystem\Util;
 class Mode
 {
     /**
-     * Converts mode from string representation to decimal if necessary
+     * Converts mode from string representation to decimal if necessary.
      *
      * @param mixed $modeString
      *
@@ -14,7 +14,7 @@ class Mode
     public static function mode($modeString)
     {
         // we don't process it if it's not a string
-        if (!is_string($modeString)) {
+        if ( ! is_string($modeString)) {
             return $modeString;
         }
 

--- a/tests/UtilModeTests.php
+++ b/tests/UtilModeTests.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace League\Flysystem\Util;
+
+use PHPUnit\Framework\TestCase;
+
+class UtilModeTests extends TestCase
+{
+    public function testNumbersPassThrough()
+    {
+        $this->assertEquals(0755, Mode::mode(0755));
+        $this->assertEquals(493, Mode::mode(493));
+    }
+    
+    public function testOctetStringsAreConverted()
+    {
+        $this->assertEquals(0755, Mode::mode('755'));
+        $this->assertEquals(0755, Mode::mode('0755'));
+        $this->assertEquals(04755, Mode::mode('4755'));
+        $this->assertEquals(04755, Mode::mode('04755'));
+    }
+    
+    public function testFlagStringsAreConverted()
+    {
+        $this->assertEquals(0755, Mode::mode('rwxr-xr-x'));
+        $this->assertEquals(0264, Mode::mode('-w-rw-r--'));
+    }
+    
+    public function testSpecialOctetIsSet()
+    {
+        $this->assertEquals(04755, Mode::mode('rwsr-xr-x'));
+        $this->assertEquals(02755, Mode::mode('rwxr-sr-x'));
+        $this->assertEquals(01755, Mode::mode('rwxr-xr-t'));
+        $this->assertEquals(07644, Mode::mode('rwSr-Sr-T'));
+    }
+    
+    public function testCharDDoesntMatter()
+    {
+        $this->assertEquals(0755, Mode::mode('drwxr-xr-x'));
+        $this->assertEquals(0264, Mode::mode('-w-rw-r--'));
+        
+        $this->assertEquals(04755, Mode::mode('drwsr-xr-x'));
+        $this->assertEquals(02755, Mode::mode('drwxr-sr-x'));
+        $this->assertEquals(01755, Mode::mode('drwxr-xr-t'));
+        $this->assertEquals(07644, Mode::mode('drwSr-Sr-T'));
+    }
+}

--- a/tests/UtilModeTests.php
+++ b/tests/UtilModeTests.php
@@ -11,7 +11,7 @@ class UtilModeTests extends TestCase
         $this->assertEquals(0755, Mode::mode(0755));
         $this->assertEquals(493, Mode::mode(493));
     }
-    
+
     public function testOctetStringsAreConverted()
     {
         $this->assertEquals(0755, Mode::mode('755'));
@@ -19,13 +19,13 @@ class UtilModeTests extends TestCase
         $this->assertEquals(04755, Mode::mode('4755'));
         $this->assertEquals(04755, Mode::mode('04755'));
     }
-    
+
     public function testFlagStringsAreConverted()
     {
         $this->assertEquals(0755, Mode::mode('rwxr-xr-x'));
         $this->assertEquals(0264, Mode::mode('-w-rw-r--'));
     }
-    
+
     public function testSpecialOctetIsSet()
     {
         $this->assertEquals(04755, Mode::mode('rwsr-xr-x'));
@@ -33,7 +33,7 @@ class UtilModeTests extends TestCase
         $this->assertEquals(01755, Mode::mode('rwxr-xr-t'));
         $this->assertEquals(07644, Mode::mode('rwSr-Sr-T'));
     }
-    
+
     public function testCharDDoesntMatter()
     {
         $this->assertEquals(0755, Mode::mode('drwxr-xr-x'));


### PR DESCRIPTION
A PR of what I proposed in #1051 . The current problem is that if one naively changes `'public' => 0755` to `'public' => 1755` the result is not `rwxr-xr-t` but `-wx-ws-wt` (`03333`).

This adds a utility function that converts mode strings to correct represntations.

- `Mode::mode(0755)` and `Mode::mode(1755)` just passes it through.
- `Mode::mode('0755')` and `Mode::mode('1755')` assumes the chars to be octets and sets mode to `rwxr-xr-x` and `rwxr-xr-t` respectively - that works according to naive scenario. `Mode::mode('01755')` works as well.
- `Mode::mode('rwxr-xr-x')` sets mode to `rwxr-xr-x`. Adding `d` or placing guid, suid and sticky bits also work as expected, both with executable bit on or off.

Each of the features described above is tested as well.

I went ahead and used the function in `Local` adapter. That's the purpose of this PR - to provide the local adapter with a default that's safe to copy and edit without running into unexpected results.