### PR TITLE
Correct to correct use of capitals in GitLab

### DIFF
--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -21,7 +21,7 @@ Adapters:
     Scaleway Object Storage: '/docs/adapter/scaleway-object-storage/'
     Dropbox: '/docs/adapter/dropbox/'
     FTP: '/docs/adapter/ftp/'
-    Gitlab: '/docs/adapter/gitlab/'
+    GitLab: '/docs/adapter/gitlab/'
     Google Cloud Storage: '/docs/adapter/google-cloud-storage/'
     Memory: '/docs/adapter/memory/'
     Null / Test: '/docs/adapter/null-test/'


### PR DESCRIPTION
In order to complete the chin addition to #1075 this PR will correct Gitlab to GitLab in the left menu under Adapters