### PR TITLE
add 'application/x-empty' for 7.4

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -319,7 +319,7 @@ class Local extends AbstractAdapter
         $finfo = new Finfo(FILEINFO_MIME_TYPE);
         $mimetype = $finfo->file($location);
 
-        if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty'])) {
+        if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
             $mimetype = Util\MimeType::detectByFilename($location);
         }
 


### PR DESCRIPTION
With PHP 7.4.0RC3

```
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.0RC3
Configuration: /dev/shm/BUILD/flysystem-33c91155537c6dc899eacdc54a13ac6303f156e6/phpunit.xml

...............................................................  63 / 354 ( 17%)
............................................................... 126 / 354 ( 35%)
............................................................... 189 / 354 ( 53%)
..........F...R................................................ 252 / 354 ( 71%)
............................................................... 315 / 354 ( 88%)
.......................................                         354 / 354 (100%)

Time: 185 ms, Memory: 14.00MB

There was 1 failure:

1) League\Flysystem\Adapter\LocalAdapterTests::testMimetypeFallbackOnExtension
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+'application/x-empty'

/dev/shm/BUILD/flysystem-33c91155537c6dc899eacdc54a13ac6303f156e6/tests/LocalAdapterTests.php:546

--

There was 1 risky test:

1) MountManagerTests::testInstantiable
This test did not perform any assertions

FAILURES!
Tests: 354, Assertions: 566, Failures: 1, Risky: 1.

```