### PR TITLE
Closes #1080: Corrected the mime type

### DIFF
--- a/src/Util/MimeType.php
+++ b/src/Util/MimeType.php
@@ -108,7 +108,7 @@ class MimeType
         'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         'docm' => 'application/vnd.ms-word.template.macroEnabled.12',
         'dot' => 'application/msword',
-        'dotx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'dotx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
         'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         'word' => 'application/msword',
         'xl' => 'application/excel',


### PR DESCRIPTION
According to https://blogs.msdn.microsoft.com/vsofficedeveloper/2008/05/08/office-2007-file-format-mime-types-for-http-content-streaming-2/ the correct mime type for dotx is   `application/vnd.openxmlformats-officedocument.wordprocessingml.template`