### PR TITLE
Added additional global configuration options

### DIFF
--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -50,6 +50,8 @@ $filesystem = new Filesystem($adapter, ['visibility' => 'public']);
 
 The global available configuration options are:
 
-option        | description              | type
-------------- | ------------------------ | -----------
-`visibility`  | default visibility       | `string`
+option | description | type
+--- | --- | ---
+`visibility` | default visibility | `string`
+`disable_asserts` | disable extra calls to assert whether or not a file exists, see [Performance](/docs/advanced/performance/) | `bool`
+`case_sensitive` | whether or not the adapter's file system is case sensitive, e.g. [Dropbox](/docs/adapter/dropbox/) is case insensitive | `bool`


### PR DESCRIPTION
I might be being pedantic but I've added `disable_asserts` to table of global configuration options with a link to the Performance page.

I also added `case_sensitive` to confirm that this relates just to the adapter's file system. You can't, for example, pass a case insensitive directory name and expect Flysystem to return the correct case for a case sensitive adapter.