### PR TITLE
Built-In PHP Function Problematic in Some Cases

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -77,7 +77,17 @@ class Local extends AbstractAdapter
         $this->permissionMap = array_replace_recursive(static::$permissions, $permissions);
         $this->ensureDirectory($root);
 
-        if ( ! is_dir($root) || ! is_readable($root)) {
+        // If UNC path...
+        if (substr($root, 0, 2) === str_repeat($this->pathSeparator, 2)) {
+
+            $readable = file_exists($root);
+
+        } else {
+
+            $readable = is_readable($root);
+        }
+
+        if ( ! is_dir($root) || $readable === false) {
             throw new LogicException('The root path ' . $root . ' is not readable.');
         }
 


### PR DESCRIPTION
In certain PHP releases, there's a known issue (https://bugs.php.net/bug.php?id=62199) in PHP's built-in `is_readable()` function and SMB file shares. The PHP built-in `is_writable()` function (alias `is_writeable()`) appears similarly affected.

In certain cases, these functions incorrectly return `FALSE` for a given UNC file path even though the target is, in fact, readable in the case `is_readable()`, or writable in the case of `is_writable()`.

Until such a time as this bug is fixed, I'd like to suggest a small work-around (or something like it) for the most reliable use of UNC paths in the `League\Flysystem\Adapter\Local` class.

Reference:
* https://www.php.net/manual/en/function.is-readable.php
* https://www.php.net/manual/en/function.is-writable.php
* https://www.php.net/manual/en/function.is-writeable.php
* https://bugs.php.net/bug.php?id=62199
* https://github.com/thephpleague/flysystem/issues/791