### PR TITLE
Local adapter umask MUST be removed

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -131,6 +131,7 @@ class Local extends AbstractAdapter
 
     /**
      * @inheritdoc
+     *
      * @throws Exception
      */
     public function write($path, $contents, Config $config)
@@ -155,6 +156,7 @@ class Local extends AbstractAdapter
 
     /**
      * @inheritdoc
+     *
      * @throws Exception
      */
     public function writeStream($path, $resource, Config $config)
@@ -191,6 +193,7 @@ class Local extends AbstractAdapter
 
     /**
      * @inheritdoc
+     *
      * @throws Exception
      */
     public function updateStream($path, $resource, Config $config)


### PR DESCRIPTION
umask can lead to unexpected behavioir on multithreaded webservers. 

See notes on https://www.php.net/manual/en/function.umask.php :

>Avoid using this function in multithreaded webservers. It is better to change the file permissions with chmod() after creating the file. Using umask() can lead to unexpected behavior of concurrently running scripts and the webserver itself because they all use the same umask.