### PR TITLE
Improve FTP connection healthcheck speed

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -531,12 +531,8 @@ class Ftp extends AbstractFtpAdapter
     public function isConnected()
     {
         try {
-            return is_resource($this->connection) && ftp_rawlist($this->connection, $this->getRoot()) !== false;
+            return is_resource($this->connection) && ftp_exec($this->connection, 'NOOP');
         } catch (ErrorException $e) {
-            if (strpos($e->getMessage(), 'ftp_rawlist') === false) {
-                throw $e;
-            }
-
             return false;
         }
     }

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -572,7 +572,7 @@ class Ftp extends AbstractFtpAdapter
 
         return (int)preg_replace(
             '/\D/',
-            null,
+            '',
             implode(' ', $response)
         );
     }

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -566,7 +566,7 @@ class Ftp extends AbstractFtpAdapter
         return ftp_rawlist($connection, $options . ' ' . $path);
     }
 
-    public function getRawExecResponseCode($command)
+    protected function getRawExecResponseCode($command)
     {
         $response = ftp_raw($this->connection, trim($command));
 

--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -531,7 +531,7 @@ class Ftp extends AbstractFtpAdapter
     public function isConnected()
     {
         try {
-            return is_resource($this->connection) && ftp_exec($this->connection, 'NOOP');
+            return is_resource($this->connection) && $this->getRawExecResponseCode('NOOP') === 200;
         } catch (ErrorException $e) {
             return false;
         }
@@ -564,5 +564,16 @@ class Ftp extends AbstractFtpAdapter
         }
 
         return ftp_rawlist($connection, $options . ' ' . $path);
+    }
+
+    public function getRawExecResponseCode($command)
+    {
+        $response = ftp_raw($this->connection, trim($command));
+
+        return (int)preg_replace(
+            '/\D/',
+            null,
+            implode(' ', $response)
+        );
     }
 }

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -124,7 +124,7 @@ function ftp_raw($connection, $command)
 
     if ($command === 'NOOP') {
         if (getenv('FTP_CLOSE_THROW') === 'DISCONNECT_CATCH') {
-            return [0 => "500 Internal error"];
+            return [0 => '500 Internal error'];
         }
         return [0 => '200 Zzz...'];
     }

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -122,6 +122,13 @@ function ftp_raw($connection, $command)
         return [0 => '200 UTF8 set to on'];
     }
 
+    if ($command === 'NOOP') {
+        if (getenv('FTP_CLOSE_THROW') === 'DISCONNECT_CATCH') {
+            return [0 => "500 Internal error"];
+        }
+        return [0 => '200 Zzz...'];
+    }
+
     if ($command === 'STAT syno.not.found') {
         return [0 => '211- status of syno.not.found:', 1 => 'ftpd: assd: No such file or directory.' ,2 => '211 End of status'];
     }
@@ -438,19 +445,6 @@ class FtpTests extends TestCase
         $this->assertTrue($adapter->isConnected());
         $adapter->disconnect();
         $this->assertFalse($adapter->isConnected());
-    }
-
-    /**
-     * @depends testInstantiable
-     */
-    public function testIsConnectedTimeoutPassthu()
-    {
-        putenv('FTP_CLOSE_THROW=DISCONNECT_RETHROW');
-
-        $this->expectException('ErrorException');
-        $adapter = new Ftp(array_merge($this->options, ['host' => 'disconnect.check']));
-        $adapter->connect();
-        $adapter->isConnected();
     }
 
     /**


### PR DESCRIPTION
Listing files can be very slow. `NOOP` command is enough in most cases and it is very fast.
NOOP reference - http://ftpguide.com/NOOP.htm

I profiled my code by blackfire and that change increased speed 10 times. Usage of `ftp_rawlist` is bottleneck.