### PR TITLE
Nullify iterator to release directory lock

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -286,6 +286,8 @@ class Local extends AbstractAdapter
 
             $result[] = $this->normalizeFileInfo($file);
         }
+		
+		$iterator = null;
 
         return array_filter($result);
     }
@@ -411,6 +413,8 @@ class Local extends AbstractAdapter
             $this->guardAgainstUnreadableFileInfo($file);
             $this->deleteFileInfoObject($file);
         }
+		
+		$contents = null;
 
         return rmdir($location);
     }


### PR DESCRIPTION
This PR is backward compatible. It simply nullifies `RecursiveIteratorIterator` to release directory lock and solve issue #1103.