### PR TITLE
Fixed `get(...)` on PHP 7.4

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -365,7 +365,7 @@ class Filesystem implements FilesystemInterface
 
         if ( ! $handler) {
             $metadata = $this->getMetadata($path);
-            $handler = $metadata['type'] === 'file' ? new File($this, $path) : new Directory($this, $path);
+            $handler = ($metadata && $metadata['type'] === 'file') ? new File($this, $path) : new Directory($this, $path);
         }
 
         $handler->setPath($path);


### PR DESCRIPTION
PHP 7.4 doesn't allow array access on non-arrays any more. This problem was actually picked up by my Laravel Flysystem test suite: https://travis-ci.org/GrahamCampbell/Laravel-Flysystem/builds/622314799.