### PR TITLE
Fixed another PHP 7.4 bug

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -60,7 +60,7 @@ abstract class Handler
     {
         $metadata = $this->filesystem->getMetadata($this->path);
 
-        return $metadata['type'];
+        return $metadata ? $metadata['type'] : 'dir';
     }
 
     /**


### PR DESCRIPTION
The `$metadata` may be `false`, in which case, we should probably treat it as a `dir`, the same as what `get` in `Filesystem` does.