### PR TITLE
Fix deprecation message

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -557,6 +557,10 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
      */
     protected function normalizePermissions($permissions)
     {
+        if (is_numeric($permissions)) {
+            return $permissions & 0777;
+        }
+
         // remove the type identifier
         $permissions = substr($permissions, 1);
 


### PR DESCRIPTION
The `normalizePermissions` method can receive permissions in their string format (ex. `-rw-r--r--`) but also in decimal format `33188`. This change will add support for the decimal format as previously it would be first truncated to 3188, which would then be interpreted as octal number and converted to decimal. After PHP 7.4, parsing a non-octal number with `octdec` will make PHP emit a Deprecation notice. 

Fixes: #1113 