### PR TITLE
improved coerency between interfaces

### DIFF
--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -115,4 +115,38 @@ interface AdapterInterface extends ReadInterface
      * @return array|false file meta data
      */
     public function setVisibility($path, $visibility);
+
+    /**
+     * Set the path prefix.
+     *
+     * @param string $prefix
+     *
+     * @return void
+     */
+    public function setPathPrefix($prefix);
+
+    /**
+     * Get the path prefix.
+     *
+     * @return string|null path prefix or null if pathPrefix is empty
+     */
+    public function getPathPrefix();
+
+    /**
+     * Prefix a path.
+     *
+     * @param string $path
+     *
+     * @return string prefixed path
+     */
+    public function applyPathPrefix($path);
+
+    /**
+     * Remove a path prefix.
+     *
+     * @param string $path
+     *
+     * @return string path without the prefix
+     */
+    public function removePathPrefix($path);
 }

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -281,4 +281,11 @@ interface FilesystemInterface
      * @return $this
      */
     public function addPlugin(PluginInterface $plugin);
+
+    /**
+     * Get the Adapter.
+     *
+     * @return AdapterInterface adapter
+     */
+    public function getAdapter();
 }

--- a/stub/FileOverwritingAdapterStub.php
+++ b/stub/FileOverwritingAdapterStub.php
@@ -97,4 +97,20 @@ class FileOverwritingAdapterStub implements AdapterInterface, CanOverwriteFiles
     public function getVisibility($path)
     {
     }
+
+    public function setPathPrefix($prefix)
+    {
+    }
+
+    public function getPathPrefix()
+    {
+    }
+
+    public function applyPathPrefix($path)
+    {
+    }
+
+    public function removePathPrefix($path)
+    {
+    }
 }

--- a/stub/FilesystemSpy.php
+++ b/stub/FilesystemSpy.php
@@ -3,6 +3,7 @@
 namespace League\Flysystem\Stub;
 
 use InvalidArgumentException;
+use League\Flysystem\AdapterInterface;
 use League\Flysystem\FileExistsException;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
@@ -350,5 +351,9 @@ class FilesystemSpy implements FilesystemInterface
     public function get($path, Handler $handler = null)
     {
         $this->lastCall = [__METHOD__, func_get_args()];
+    }
+
+    public function getAdapter()
+    {
     }
 }


### PR DESCRIPTION
Hi, I've modified two interfaces:

- FilesystemInterface need to expose the getAdapter() method

- AdapterInterface need to expose the methods included in the AbstractAdapter. All the adapter extends  the AbstractAdapter, but the getAdapter() of Filesystem class return only an AdapterInterface without several important methods like getPathPrefix()