### PR TITLE
Improve .m3u/.m3u8 file detection

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -321,7 +321,7 @@ class Local extends AbstractAdapter
         $finfo = new Finfo(FILEINFO_MIME_TYPE);
         $mimetype = $finfo->file($location);
 
-        if (in_array($mimetype, ['application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
+        if (in_array($mimetype, ['text/plain', 'application/octet-stream', 'inode/x-empty', 'application/x-empty'])) {
             $mimetype = Util\MimeType::detectByFilename($location);
         }
 

--- a/src/Util/MimeType.php
+++ b/src/Util/MimeType.php
@@ -158,6 +158,7 @@ class MimeType
         'aac' => 'audio/x-acc',
         'm4u' => 'application/vnd.mpegurl',
         'm3u' => 'application/mpegurl',
+        'm3u8' => 'application/mpegurl',
         'xspf' => 'application/xspf+xml',
         'vlc' => 'application/videolan',
         'wmv' => 'video/x-ms-wmv',

--- a/src/Util/MimeType.php
+++ b/src/Util/MimeType.php
@@ -157,7 +157,7 @@ class MimeType
         'webm' => 'video/webm',
         'aac' => 'audio/x-acc',
         'm4u' => 'application/vnd.mpegurl',
-        'm3u' => 'text/plain',
+        'm3u' => 'application/mpegurl',
         'xspf' => 'application/xspf+xml',
         'vlc' => 'application/videolan',
         'wmv' => 'video/x-ms-wmv',


### PR DESCRIPTION
Hi,

Here's what I believe to be a fix for #1098.

**My understanding of the problem**

Currently, `.m3u` and `.m3u8` files are detected as `text/plain` instead of a _proper_ MIME type. I believe the `finfo` class used by this library is unable to properly detect `m3u` files or intentionally returns the broader `text/plain` MIME type instead.

After a quick read on the [Wikipedia page](https://en.wikipedia.org/wiki/M3U#Internet_media_types) of this file format, it appears that no standard media type has been registered with the IANA for these files. 

There seems to be a set of commonly used MIME types for these files though:

- `application/vnd.apple.mpegurl`
- `audio/mpegurl`
- `application/mpegurl`
- `application/x-mpegurl`
- `audio/mpegurl`
- `audio/x-mpegurl`
- `application/vnd.apple.mpegurl.audio`

**My solution**

This pull request alters the `$extensionToMimeTypeMap` array by changing the MIME type for `.m3u` files from `text/plain` to `application/mpegurl` and by adding support for the `.m3u8` file extension with the same `application/mpegurl` MIME type.

Since the `finfo` class returns `text/plain` when trying to detect these file types, this PR also modifies the detection fallback strategy by adding `text/plain` to the `in_array` function call in `League\Flysystem\Adapter\Local::getMimetype`

**To discuss**

Please, bear in mind that I'm no expert in MIME types and have little to no knowledge of this file format apart from what is was able to gather on Wikipedia. I chose the `application/mpegurl` because it is the one that made the more sense to me. If someone has a strong opinion about some other type that should be used instead, please share your thoughts.

Cheers :)
