### PR TITLE
Fixed deletion iteration bug in Local::deleteDir()

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -410,11 +410,16 @@ class Local extends AbstractAdapter
 
         /** @var SplFileInfo $file */
         foreach ($contents as $file) {
+            $files[] = $file;
+        }
+    
+        /** @var SplFileInfo $file */
+        foreach ($files as $file) {
             $this->guardAgainstUnreadableFileInfo($file);
             $this->deleteFileInfoObject($file);
         }
-
-        unset($contents);
+        
+        unset($contents, $files);
 
         return rmdir($location);
     }


### PR DESCRIPTION
When removing files during an RecursiveIteratorIterator iteration, the iteration is perturbed, producing incorrect results (skipping files). Storing the files in an array before and iterating the array afterwards solves the problem.

Similar problems reported here: 
https://github.com/emscripten-core/emscripten/issues/2528
https://forge.typo3.org/issues/88524