### PR TITLE
catch error exceptions on reconnect

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -643,7 +643,19 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
 
         while ( ! $this->isConnected() && $tries < 3) {
             $tries++;
-            $this->disconnect();
+
+            // when there was an unexpected connection loss (especially some
+            // SSL errors), disconnect will throw an ErrorException.
+            // But we try to reconnect here, so it's better to catch this error
+            // once and allow a retry nonetheless.
+            try {
+                $this->disconnect();
+            } catch (\ErrorException $e) {
+                if ($tries > 1) {
+                    throw $e;
+                }
+            }
+
             $this->connect();
         }
 


### PR DESCRIPTION
Hello there

We found an issue with the FTP-adapter with SSL-encrypted connection.

**Our use-case**
we run workers which download files from an FTP-Server periodically. There are several list-files and downloads per minute. The worker keeps its connection up after start until stop/restart, which can be between several days and several months.

But very occasionally, we se in our error log `ftp_close(): SSL read failed `. We assume this happens when the SSL-connection times out after some days, because it’s never to be seen for at least some hours after restart.

**Our fix**
For some days now we use the fix now provided in our PR and don’t see this issue anymore, which confirms above assumption.

We add error handling to the `getConnection()`-method. In our opinion, it doesn’t make sense that this method allows several tries to connect, but doesn’t catch an exception when disconnect fails, especially due connection loss.
