### PR TITLE
Add directory support to the Local::copy method

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -258,10 +258,9 @@ class Local extends AbstractAdapter
                 $returnCheck = true;
 
                 $dest = $destination . DIRECTORY_SEPARATOR . $directoryIterator->getSubPathName();
+                $this->ensureDirectory(dirname($dest));
 
-                if ($item->isDir()) {
-                    $this->ensureDirectory($dest);
-                } else {
+                if (!$item->isDir()) {
                     $returnCheck = copy($item, $dest);
                 }
 

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -250,7 +250,30 @@ class Local extends AbstractAdapter
         $destination = $this->applyPathPrefix($newpath);
         $this->ensureDirectory(dirname($destination));
 
-        return copy($location, $destination);
+        if (is_dir($location)) {
+            $finalReturn = true;
+
+            $directoryIterator = $this->getRecursiveDirectoryIterator($location);
+            foreach ($directoryIterator as $item) {
+                $returnCheck = true;
+
+                $dest = $destination . DIRECTORY_SEPARATOR . $directoryIterator->getSubPathName();
+
+                if ($item->isDir()) {
+                    $this->ensureDirectory($dest);
+                } else {
+                    $returnCheck = copy($item, $dest);
+                }
+
+                if (!$returnCheck) {
+                    $finalReturn = $returnCheck;
+                }
+            }
+
+            return $finalReturn;
+        } else {
+            return copy($location, $destination);
+        }
     }
 
     /**


### PR DESCRIPTION
This is solving the missing directory support for the Local::copy method as outlined in #1140.