### PR TITLE
Revert "ignore test-functions.php"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,6 @@ src/PHPSecLibV2 export-ignore
 .gitignore export-ignore
 build/ export-ignore
 mocked-functions.php export-ignore
-test-functions.php export-ignore
 test_files/ export-ignore
 **/*Test.php export-ignore
 **/*Stub.php export-ignore


### PR DESCRIPTION
Methods in this file are used by FilesystemAdapterTestCase (which is not ignored)

This changed prevent 3rd to use the AbstractAdapter for testing their adapter.