### PR TITLE
Add own __call magic method of Filesystem class

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -2,6 +2,7 @@
 
 namespace League\Flysystem;
 
+use BadMethodCallException;
 use InvalidArgumentException;
 use League\Flysystem\Adapter\CanOverwriteFiles;
 use League\Flysystem\Plugin\PluggableTrait;
@@ -17,7 +18,9 @@ use League\Flysystem\Util\ContentListingFormatter;
  */
 class Filesystem implements FilesystemInterface
 {
-    use PluggableTrait;
+    use PluggableTrait {
+        __call as pluggableCall;
+    }
     use ConfigAwareTrait;
 
     /**
@@ -403,6 +406,16 @@ class Filesystem implements FilesystemInterface
     {
         if ($this->config->get('disable_asserts', false) === false && $this->has($path)) {
             throw new FileExistsException($path);
+        }
+    }
+
+    public function __call($method, array $arguments)
+    {
+        try {
+            return $this->getAdapter()->$method($arguments);
+        }catch(BadMethodCallException $e)
+        {
+            return $this->pluggableCall($method, $arguments);
         }
     }
 }


### PR DESCRIPTION
This PR implements the possibilite of call a method available in the adapter that is not available in the Filesystem. 

Example: Let's say a want to call the method getThumbnail in DropboxFilesystem. Because it is not in the Filesystem interface it will throw a BadMethodCallException. But I can call the method getAdapter() to get the custom adapter and then call the method that is only in the CustomAdapter.

It is a bit confusing but it worth it.

If any thing is wrong, even the whole PR, please trying yo implement that feature.

Thanks!