### PR TITLE
Tweak the Silverstripe guide to reflect official silverstripe branding

### DIFF
--- a/_data/menu_v1.yml
+++ b/_data/menu_v1.yml
@@ -11,7 +11,7 @@ Usage:
 Guides:
     Laravel Usage: '/v1/docs/guides/laravel-usage/'
     Symfony Usage: '/v1/docs/guides/symfony-usage/'
-    SilverStripe Usage: '/v1/docs/guides/silverstripe-usage/'
+    Silverstripe CMS Usage: '/v1/docs/guides/silverstripe-usage/'
     Nette Usage: '/v1/docs/guides/nette-usage/'
     Deterministic Code: '/v1/docs/guides/deterministic-programming/'
     Handling Uploads: '/v1/docs/guides/uploads/'

--- a/v1/guides/silverstripe-usage.md
+++ b/v1/guides/silverstripe-usage.md
@@ -3,20 +3,20 @@ layout: default
 permalink: /v1/docs/guides/silverstripe-usage/
 redirect_from:
     - /docs/guides/silverstripe-usage/
-title: SilverStripe Usage
+title: Silverstripe CMS Usage
 ---
-Flysystem comes bundled with SilverStripe 4 and newer.
+Flysystem comes bundled with Silverstripe CMS 4 and newer.
 
-SilverStripe uses a thin wrapper around Flysystem adapters for implementing public and private files.
+Silverstripe CMS uses a thin wrapper around Flysystem adapters for implementing public and protected files.
 
-Per default files are saved locally. There are custom adapters for SilverStripe available:
+Per default files are saved locally. There are custom adapters for Silverstripe CMS available:
 
 * <a href="https://github.com/silverstripe/silverstripe-s3">AWS S3</a>
 * <a href="https://github.com/obj63mc/silverstripe-google-cloud-storage">Google Cloud Storage</a>
 
 More adapters can be found at <a href="https://packagist.org/packages/cloudinary/cloudinary_php?query=flysystem&type=silverstripe-vendormodule">packagist.org</a>.
 
-More information can be found in the <a href="https://docs.silverstripe.org/en/4/developer_guides/files/file_storage/">SilverStripe documentation</a>.
+More information can be found in the <a href="https://docs.silverstripe.org/en/4/developer_guides/files/file_storage/">Silverstripe CMS documentation</a>.
 
 <div class="flex my-6">
     <a target="_blank" href="https://silverstripe.org" class="flex-no-grow w-1/3 bg-white rounded shadow-md mr-4 overflow-hidden">


### PR DESCRIPTION
The official branding for Silverstripe was tweaked to better distinguished "Silverstripe" the CMS from "Silverstripe" the Company.

You can get more info on our [official blog post](https://www.silverstripe.org/blog/new-silverstripe-logos-and-brand-family/).