### PR TITLE
Set locale when testing UTF-8 compatibility

### DIFF
--- a/tests/UtilTests.php
+++ b/tests/UtilTests.php
@@ -258,6 +258,10 @@ class UtilTests extends TestCase
 
     public function testPathinfoHandlesUtf8()
     {
+        if (setlocale(LC_ALL, 'C.UTF-8', 'C.utf8') === false) {
+            $this->markTestSkipped('testPathinfoHandlesUtf8 requires UTF-8.');
+        }
+
         $path = 'files/繁體中文字/test.txt';
         $expected = [
             'path' => 'files/繁體中文字/test.txt',


### PR DESCRIPTION
This test case tests UTF-8 compatibility and fails if the current
system locale is itself not UTF-8 compatible.