### PR TITLE
Fix name of AwsS3V3Adapter in documentation 

### DIFF
--- a/v2/adapter/aws-s3-v3.md
+++ b/v2/adapter/aws-s3-v3.md
@@ -5,7 +5,7 @@ permalink: /v2/docs/adapter/aws-s3-v3/
 ---
 
 Interacting with Aws S3 through Flysystem can be done
-by using the `League\Flysystem\AwsS3V3\AwsS3V3Adapter`.
+by using the `League\Flysystem\AwsS3V3\AwsS3V3Filesystem`.
 
 ## Simple usage:
 
@@ -14,7 +14,7 @@ by using the `League\Flysystem\AwsS3V3\AwsS3V3Adapter`.
 $client = new Aws\S3\S3Client($options);
 
 // The internal adapter
-$adapter = new League\Flysystem\AwsS3V3\AwsS3V3Adapter(
+$adapter = new League\Flysystem\AwsS3V3\AwsS3V3Filesystem(
     // S3Client
     $client,
     // Bucket name
@@ -32,7 +32,7 @@ $filesystem = new League\Flysystem\Filesystem($adapter);
 $client = new Aws\S3\S3Client($options);
 
 // The internal adapter
-$adapter = new League\Flysystem\AwsS3V3\AwsS3V3Adapter(
+$adapter = new League\Flysystem\AwsS3V3\AwsS3V3Filesystem(
     // S3Client
     $client,
     // Bucket name


### PR DESCRIPTION
It seems that the adapter name on AwsS3V3 is different than described in the documentation. See here https://github.com/thephpleague/flysystem-aws-s3-v3/blob/2.0.0-alpha.2/AwsS3V3Filesystem.php. Led to some confusion on my side. Might be helpful to change it in the documentation then.