### PR TITLE
Include timestamp to result from normalizeUnixObject for directory results

### DIFF
--- a/src/Adapter/AbstractFtpAdapter.php
+++ b/src/Adapter/AbstractFtpAdapter.php
@@ -440,7 +440,13 @@ abstract class AbstractFtpAdapter extends AbstractAdapter
         $path = $base === '' ? $name : $base . $this->separator . $name;
 
         if ($type === 'dir') {
-            return compact('type', 'path');
+            $result = compact('type', 'path');
+            if ($this->enableTimestampsOnUnixListings) {
+                $timestamp = $this->normalizeUnixTimestamp($month, $day, $timeOrYear);
+                $result += compact('timestamp');
+            }
+
+            return $result;
         }
 
         $permissions = $this->normalizePermissions($permissions);

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -653,10 +653,12 @@ class FtpTests extends TestCase
                     [
                         'type' => 'dir',
                         'path' => 'cgi-bin',
+                        'timestamp' => 1350086400,
                     ],
                     [
                         'type' => 'dir',
                         'path' => 'folder',
+                        'timestamp' => 1606226340,
                     ],
                     [
                         'type' => 'file',
@@ -682,10 +684,12 @@ class FtpTests extends TestCase
                     [
                         'type' => 'dir',
                         'path' => 'cgi-bin',
+                        'timestamp' => 1350086400,
                     ],
                     [
                         'type' => 'dir',
                         'path' => 'folder',
+                        'timestamp' => 1606226340,
                     ],
                     [
                         'type' => 'file',


### PR DESCRIPTION
Include timestamp to result from normalizeUnixObject when enableTimestampsOnUnixListings is true for directories

Current implementation currently doesn't return the timestamp for directories for normalizeUnixObject method, while normalizeWindowsObject does so.