### PR TITLE
More precise signatures

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -8,13 +8,13 @@ use League\Flysystem\Plugin\PluggableTrait;
 use League\Flysystem\Util\ContentListingFormatter;
 
 /**
- * @method void  emptyDir(string $dirname)
- * @method array getWithMetadata(string $path, array $metadata)
- * @method bool  forceCopy(string $path, string $newpath)
- * @method bool  forceRename(string $path, string $newpath)
- * @method array listFiles(string $path = '', boolean $recursive = false)
- * @method array listPaths(string $path = '', boolean $recursive = false)
- * @method array listWith(array $keys = [], $directory = '', $recursive = false)
+ * @method void        emptyDir(string $dirname)
+ * @method array|false getWithMetadata(string $path, string[] $metadata)
+ * @method bool        forceCopy(string $path, string $newpath)
+ * @method bool        forceRename(string $path, string $newpath)
+ * @method array       listFiles(string $path = '', boolean $recursive = false)
+ * @method string[]    listPaths(string $path = '', boolean $recursive = false)
+ * @method array       listWith(string[] $keys = [], $directory = '', $recursive = false)
  */
 class Filesystem implements FilesystemInterface
 {

--- a/src/Plugin/GetWithMetadata.php
+++ b/src/Plugin/GetWithMetadata.php
@@ -20,8 +20,8 @@ class GetWithMetadata extends AbstractPlugin
     /**
      * Get metadata for an object with required metadata.
      *
-     * @param string $path     path to file
-     * @param array  $metadata metadata keys
+     * @param string   $path     path to file
+     * @param string[] $metadata metadata keys
      *
      * @throws InvalidArgumentException
      * @throws FileNotFoundException

--- a/src/Plugin/ListPaths.php
+++ b/src/Plugin/ListPaths.php
@@ -20,7 +20,7 @@ class ListPaths extends AbstractPlugin
      * @param string $directory
      * @param bool   $recursive
      *
-     * @return array paths
+     * @return string[] paths
      */
     public function handle($directory = '', $recursive = false)
     {

--- a/src/Plugin/ListWith.php
+++ b/src/Plugin/ListWith.php
@@ -17,9 +17,9 @@ class ListWith extends AbstractPlugin
     /**
      * List contents with metadata.
      *
-     * @param array  $keys
-     * @param string $directory
-     * @param bool   $recursive
+     * @param string[] $keys
+     * @param string   $directory
+     * @param bool     $recursive
      *
      * @return array listing with metadata
      */


### PR DESCRIPTION
Some signatures are incomplete or imprecise:  

- **getWithMetadata**: this can return either an [array or false](https://github.com/thephpleague/flysystem/blob/1.x/src/Plugin/GetWithMetadata.php#L36)
- **getWithMetadata**: metadatas is an [array of string](https://github.com/thephpleague/flysystem/blob/1.x/src/Plugin/GetWithMetadata.php#L39)
- **listPaths**: returns an [array of strings](https://github.com/thephpleague/flysystem/blob/1.x/src/Plugin/ListPaths.php#L31)
- **listWith**: keys is an [array of strings](https://github.com/thephpleague/flysystem/blob/1.x/src/Plugin/ListWith.php#L32)