### PR TITLE
Change param name to match parents

### DIFF
--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -146,7 +146,7 @@ class FtpAdapter implements FilesystemAdapter
         }
     }
 
-    public function writeStream(string $path, $resource, Config $config): void
+    public function writeStream(string $path, $contents, Config $config): void
     {
         try {
             $this->ensureParentDirectoryExists($path, $config->get(Config::OPTION_DIRECTORY_VISIBILITY));
@@ -156,7 +156,7 @@ class FtpAdapter implements FilesystemAdapter
 
         $location = $this->prefixer->prefixPath($path);
 
-        if ( ! ftp_fput($this->connection(), $location, $resource, $this->connectionOptions->transferMode())) {
+        if ( ! ftp_fput($this->connection(), $location, $contents, $this->connectionOptions->transferMode())) {
             throw UnableToWriteFile::atLocation($path, 'writing the file failed');
         }
 

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -154,9 +154,9 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         return new FileAttributes($path, $this->files[$path]->fileSize());
     }
 
-    public function listContents(string $prefix, bool $deep): iterable
+    public function listContents(string $path, bool $deep): iterable
     {
-        $prefix = rtrim($this->preparePath($prefix), '/') . '/';
+        $prefix = rtrim($this->preparePath($path), '/') . '/';
         $prefixLength = strlen($prefix);
         $listedDirectories = [];
 

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -96,9 +96,9 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
     }
 
-    public function write(string $location, string $contents, Config $config): void
+    public function write(string $path, string $contents, Config $config): void
     {
-        $prefixedLocation = $this->prefixer->prefixPath($location);
+        $prefixedLocation = $this->prefixer->prefixPath($path);
         $this->ensureDirectoryExists(
             dirname($prefixedLocation),
             $this->resolveDirectoryVisibility($config->get(Config::OPTION_DIRECTORY_VISIBILITY))
@@ -106,17 +106,17 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         error_clear_last();
 
         if (($size = @file_put_contents($prefixedLocation, $contents, $this->writeFlags)) === false) {
-            throw UnableToWriteFile::atLocation($location, error_get_last()['message'] ?? '');
+            throw UnableToWriteFile::atLocation($path, error_get_last()['message'] ?? '');
         }
 
         if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
-            $this->setVisibility($location, (string) $visibility);
+            $this->setVisibility($path, (string) $visibility);
         }
     }
 
-    public function writeStream(string $location, $contents, Config $config): void
+    public function writeStream(string $path, $contents, Config $config): void
     {
-        $path = $this->prefixer->prefixPath($location);
+        $path = $this->prefixer->prefixPath($path);
         $this->ensureDirectoryExists(
             dirname($path),
             $this->resolveDirectoryVisibility($config->get(Config::OPTION_DIRECTORY_VISIBILITY))
@@ -131,7 +131,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         }
 
         if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
-            $this->setVisibility($location, (string) $visibility);
+            $this->setVisibility($path, (string) $visibility);
         }
     }
 

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -116,18 +116,18 @@ class LocalFilesystemAdapter implements FilesystemAdapter
 
     public function writeStream(string $path, $contents, Config $config): void
     {
-        $path = $this->prefixer->prefixPath($path);
+        $prefixedLocation = $this->prefixer->prefixPath($path);
         $this->ensureDirectoryExists(
-            dirname($path),
+            dirname($prefixedLocation),
             $this->resolveDirectoryVisibility($config->get(Config::OPTION_DIRECTORY_VISIBILITY))
         );
 
         error_clear_last();
-        $stream = @fopen($path, 'w+b');
+        $stream = @fopen($prefixedLocation, 'w+b');
 
         if ( ! ($stream && false !== stream_copy_to_stream($contents, $stream) && fclose($stream))) {
             $reason = error_get_last()['message'] ?? '';
-            throw UnableToWriteFile::atLocation($path, $reason);
+            throw UnableToWriteFile::atLocation($prefixedLocation, $reason);
         }
 
         if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -132,10 +132,10 @@ class MountManager implements FilesystemOperator
         $filesystem->writeStream($path, $contents, $config);
     }
 
-    public function setVisibility(string $location, string $visibility): void
+    public function setVisibility(string $path, string $visibility): void
     {
         /** @var FilesystemOperator $filesystem */
-        [$filesystem, $path] = $this->determineFilesystemAndPath($location);
+        [$filesystem, $path] = $this->determineFilesystemAndPath($path);
         $filesystem->setVisibility($path, $visibility);
     }
 


### PR DESCRIPTION
Hi,

This PR propose changing parameter names when they don't match the signature in their parents.

This change prepares the release of PHP8 which allow calling methods with named parameters. When there is a mismatch, there is a risk of a runtime error.

This is a change suggested by Psalm, here is the full rationale: https://psalm.dev/docs/running_psalm/issues/ParamNameMismatch/