### PR TITLE
Add support for PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5 || ^9.4",
         "phpstan/phpstan": "^0.12.26",
         "phpseclib/phpseclib": "^2.0",
         "aws/aws-sdk-php": "^3.132.4",

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -614,4 +614,24 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
     {
         return new LocalFilesystemAdapter(static::ROOT);
     }
+
+    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+    {
+        if (is_callable('parent::assertFileDoesNotExist')) {
+            // PHPUnit 9+
+            parent::assertFileDoesNotExist($filename, $message);
+        } else {
+            self::assertFileNotExists($filename, $message);
+        }
+    }
+
+    public static function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
+    {
+        if (is_callable('parent::assertDirectoryDoesNotExist')) {
+            // PHPUnit 9+
+            parent::assertDirectoryDoesNotExist($directory, $message);
+        } else {
+            self::assertDirectoryNotExists($directory, $message);
+        }
+    }
 }

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -165,7 +165,7 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         $adapter = new LocalFilesystemAdapter(static::ROOT);
         file_put_contents(static::ROOT . '/file.txt', 'contents');
         $adapter->delete('/file.txt');
-        $this->assertFileNotExists(static::ROOT . '/file.txt');
+        $this->assertFileDoesNotExist(static::ROOT . '/file.txt');
     }
 
     /**
@@ -299,9 +299,9 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         file_put_contents(static::ROOT . '/directory/subdir/file.txt', 'content');
         symlink(static::ROOT . '/directory/subdir/file.txt', static::ROOT . '/directory/subdir/link.txt');
         $adapter->deleteDirectory('directory/subdir');
-        $this->assertDirectoryNotExists(static::ROOT . '/directory/subdir/');
+        $this->assertDirectoryDoesNotExist(static::ROOT . '/directory/subdir/');
         $adapter->deleteDirectory('directory');
-        $this->assertDirectoryNotExists(static::ROOT . '/directory/');
+        $this->assertDirectoryDoesNotExist(static::ROOT . '/directory/');
     }
 
     /**
@@ -313,7 +313,7 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         $adapter->write('a/b/c/d/e.txt', 'contents', new Config());
         $adapter->deleteDirectory('a/b');
         $this->assertDirectoryExists(static::ROOT . '/a');
-        $this->assertDirectoryNotExists(static::ROOT . '/a/b');
+        $this->assertDirectoryDoesNotExist(static::ROOT . '/a/b');
     }
 
     /**
@@ -427,7 +427,7 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         $this->assertFileExists(static::ROOT . '/first.txt');
         $adapter->move('first.txt', 'second.txt', new Config());
         $this->assertFileExists(static::ROOT . '/second.txt');
-        $this->assertFileNotExists(static::ROOT . '/first.txt');
+        $this->assertFileDoesNotExist(static::ROOT . '/first.txt');
     }
 
     /**


### PR DESCRIPTION
PHPUnit 9 is the only version with PHP8 support. 