### PR TITLE
Adding missing groups on tests

### DIFF
--- a/src/Ftp/FtpAdapterTest.php
+++ b/src/Ftp/FtpAdapterTest.php
@@ -6,6 +6,9 @@ namespace League\Flysystem\Ftp;
 
 use League\Flysystem\FilesystemAdapter;
 
+/**
+ * @group ftp
+ */
 class FtpAdapterTest extends FtpAdapterTestCase
 {
     protected static function createFilesystemAdapter(): FilesystemAdapter

--- a/src/Ftp/RawListFtpConnectivityCheckerTest.php
+++ b/src/Ftp/RawListFtpConnectivityCheckerTest.php
@@ -4,6 +4,9 @@ namespace League\Flysystem\Ftp;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group ftp
+ */
 class RawListFtpConnectivityCheckerTest extends TestCase
 {
     /**


### PR DESCRIPTION
With this I can run tests quickly with
```
❯ ./vendor/bin/phpunit --exclude-group ftp,sftp,ftpd
```