### PR TITLE
Add PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "league/mime-type-detection": "^1.0.0"
     },


### PR DESCRIPTION
Add support of PHP 8 in `composer.json` file.
Only one problem : `friendsofphp/php-cs-fixer` package is not compatible with PHP 8