### PR TITLE
Fix private dir permission default for fromArray call

### DIFF
--- a/src/UnixVisibility/PortableVisibilityConverter.php
+++ b/src/UnixVisibility/PortableVisibilityConverter.php
@@ -102,7 +102,7 @@ class PortableVisibilityConverter implements VisibilityConverter
             $permissionMap['file']['public'] ?? 0644,
             $permissionMap['file']['private'] ?? 0600,
             $permissionMap['dir']['public'] ?? 0755,
-            $permissionMap['dir']['private'] ?? 0755,
+            $permissionMap['dir']['private'] ?? 0700,
             $defaultForDirectories
         );
     }


### PR DESCRIPTION
Perhaps the defaults should be private class constants, to avoid sync copy-paste error again.