### PR TITLE
Migrate phpunit XML configuration

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -4,12 +4,18 @@ on:
   push:
     paths:
       - src/**/*.php
+      - phpunit.xml.dist
+      - phpunit.php
+      - mocked-functions.php
       - .github/workflows/quality-assurance.yml
     branches:
       - 2.x
   pull_request:
     paths:
       - src/**/*.php
+      - phpunit.xml.dist
+      - phpunit.php
+      - mocked-functions.php
       - .github/workflows/quality-assurance.yml
     branches:
       - 2.x

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="phpunit.php">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    colors="true"
+    bootstrap="phpunit.php"
+>
     <testsuites>
         <testsuite name="Flysystem">
             <directory suffix="Test.php">src/</directory>
@@ -8,12 +13,12 @@
     <php>
         <env name="FLYSYSTEM_TEST_SFTP" value="yes" />
     </php>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/</directory>
-            <exclude>
-                <directory suffix="Test.php">src/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory suffix="Test.php">src/</directory>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
Running PHPUnit, emitted a notice:

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

Converted with:
```
$ ./vendor/bin/phpunit --migrate-configuration
```

With a manual adjustment to keep existing indenation.