### PR TITLE
FTP: Update resource to allow new FTPConnection objects

### DIFF
--- a/src/Ftp/ConnectionProvider.php
+++ b/src/Ftp/ConnectionProvider.php
@@ -7,7 +7,7 @@ namespace League\Flysystem\Ftp;
 interface ConnectionProvider
 {
     /**
-     * @return resource
+     * @return resource|\FTPConnection
      */
     public function createConnection(FtpConnectionOptions $options);
 }

--- a/src/Ftp/ConnectivityChecker.php
+++ b/src/Ftp/ConnectivityChecker.php
@@ -7,7 +7,7 @@ namespace League\Flysystem\Ftp;
 interface ConnectivityChecker
 {
     /**
-     * @param resource $connection
+     * @param resource|\FTPConnection $connection
      */
     public function isConnected($connection): bool;
 }

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -48,7 +48,7 @@ class FtpAdapter implements FilesystemAdapter
     private $connectivityChecker;
 
     /**
-     * @var resource|false
+     * @var resource|\FTPConnection|false
      */
     private $connection = false;
 
@@ -93,12 +93,12 @@ class FtpAdapter implements FilesystemAdapter
     }
 
     /**
-     * @return resource
+     * @return resource|\FTPConnection
      */
     private function connection()
     {
         start:
-        if ( ! is_resource($this->connection)) {
+        if ( ! is_resource($this->connection) && ! $this->connection instanceof \FTPConnection) {
             $this->connection = $this->connectionProvider->createConnection($this->connectionOptions);
         }
 
@@ -204,7 +204,7 @@ class FtpAdapter implements FilesystemAdapter
     }
 
     /**
-     * @param resource $connection
+     * @param resource|\FTPConnection $connection
      */
     private function deleteFile(string $path, $connection): void
     {

--- a/src/Ftp/FtpConnectionProvider.php
+++ b/src/Ftp/FtpConnectionProvider.php
@@ -9,7 +9,7 @@ use const FTP_USEPASVADDRESS;
 class FtpConnectionProvider implements ConnectionProvider
 {
     /**
-     * @return resource
+     * @return resource|\FTPConnection
      *
      * @throws FtpConnectionException
      */
@@ -36,13 +36,13 @@ class FtpConnectionProvider implements ConnectionProvider
     }
 
     /**
-     * @return resource
+     * @return resource|\FTPConnection
      */
     private function createConnectionResource(string $host, int $port, int $timeout, bool $ssl)
     {
         $connection = $ssl ? @ftp_ssl_connect($host, $port, $timeout) : @ftp_connect($host, $port, $timeout);
 
-        if ( ! is_resource($connection)) {
+        if ($connection === false) {
             throw UnableToConnectToFtpHost::forHost($host, $port, $ssl);
         }
 
@@ -50,7 +50,7 @@ class FtpConnectionProvider implements ConnectionProvider
     }
 
     /**
-     * @param resource $connection
+     * @param resource|\FTPConnection $connection
      */
     private function authenticate(FtpConnectionOptions $options, $connection): void
     {
@@ -60,7 +60,7 @@ class FtpConnectionProvider implements ConnectionProvider
     }
 
     /**
-     * @param resource $connection
+     * @param resource|\FTPConnection $connection
      */
     private function enableUtf8Mode(FtpConnectionOptions $options, $connection): void
     {
@@ -78,7 +78,7 @@ class FtpConnectionProvider implements ConnectionProvider
     }
 
     /**
-     * @param resource $connection
+     * @param resource|\FTPConnection $connection
      */
     private function ignorePassiveAddress(FtpConnectionOptions $options, $connection): void
     {
@@ -94,7 +94,7 @@ class FtpConnectionProvider implements ConnectionProvider
     }
 
     /**
-     * @param resource $connection
+     * @param resource|\FTPConnection $connection
      */
     private function makeConnectionPassive(FtpConnectionOptions $options, $connection): void
     {


### PR DESCRIPTION
In PHP 8.1, `ftp` resources are [migrated to `FTPConnection` class objects](https://php.watch/versions/8.1/FTPConnection-resource). This PR updates all `is_resource` checks and DocBlock types to accept/indicate the new class objects.

This is probably a PR to send quite early, but given the extreme popularity of flysystem, I think there will be people running their builds in PHP nightly builds. This change in PHP was done a few weeks ago, and is part of the resource of object migration plan, hence there was no RFCs or lengthy discussions.