### PR TITLE
Fix CHANGELOG header inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version 2.x Changelog
 
-## 2.0.0 - 2020-24-11
+## 2.0.0 - 2020-11-24
 
 ## Changed
 
@@ -30,7 +30,7 @@
 
 - DirectoryAttributes now have a `lastModified` accessor.
 
-## 2.0.0-beta.2 2020-08-08
+## 2.0.0-beta.2 - 2020-08-08
 
 ### Fixes
 
@@ -56,19 +56,19 @@
 
 * Allow creation of files with empty streams.
 
-## 2.0.0-alpha.3 2020-03-21
+## 2.0.0-alpha.3 - 2020-03-21
 
 ### Fixes
 
 * Corrected the required version for the sub-split packages.
 
-## 2.0.0-alpha.2 2020-03-17
+## 2.0.0-alpha.2 - 2020-03-17
 
 ### Changes
 
 * The `League\Flysystem\FilesystemAdapter::listContents` method returns an `iterable` instead of a `Generator`.
 * The `League\Flysystem\DirectoryListing` class accepts an `iterable` instead of a `Generator`.
 
-## 2.0.0-alpha.1 2020-03-09
+## 2.0.0-alpha.1 - 2020-03-09
 
 * Initial 2.0.0 alpha release


### PR DESCRIPTION
- Fixed 2.0.0's date format
- Added `-`s where missing