### PR TITLE
Added details of installing the in memory adapter

### DIFF
--- a/v2/adapter/in-memory.md
+++ b/v2/adapter/in-memory.md
@@ -7,6 +7,12 @@ permalink: /v2/docs/adapter/in-memory/
 Interacting with the local filesystem through Flysystem can be done
 by using the `League\Flysystem\InMemory\InMemoryFilesystemAdapter`.
 
+## Installation:
+
+```bash
+composer require league/flysystem-memory
+```
+
 ## Usage:
 
 ```php


### PR DESCRIPTION
The v1 docs included a note on how to install, but was missing here, so added.