### PR TITLE
Fix time-related tests failing in 2021

### DIFF
--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -662,7 +662,7 @@ class FtpTests extends TestCase
                     [
                         'type' => 'dir',
                         'path' => 'folder',
-                        'timestamp' => 1606226340,
+                        'timestamp' => DateTime::createFromFormat('M d H:i', 'Nov 24 13:59')->getTimestamp(),
                     ],
                     [
                         'type' => 'file',
@@ -693,7 +693,7 @@ class FtpTests extends TestCase
                     [
                         'type' => 'dir',
                         'path' => 'folder',
-                        'timestamp' => 1606226340,
+                        'timestamp' => DateTime::createFromFormat('M d H:i', 'Nov 24 13:59')->getTimestamp(),
                     ],
                     [
                         'type' => 'file',


### PR DESCRIPTION
Two tests related to Unix file listings are failing now in 2021 due to
the expectation that a timestamp without an explicit year is from 2020.

The expectation is adjusted to always use the current year. This
solution was already used for a different file in the same dataset.