### PR TITLE
Use $config parameter in copy operation

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -393,6 +393,12 @@ class AwsS3V3Adapter implements FilesystemAdapter
             );
         }
 
+        $options = $this->createOptionsFromConfig($config);
+
+        if ($metadataDirective = $config->get('MetadataDirective')) {
+            $options['MetadataDirective'] = $metadataDirective;
+        }
+
         try {
             $this->client->copy(
                 $this->bucket,
@@ -400,7 +406,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
                 $this->bucket,
                 $this->prefixer->prefixPath($destination),
                 $this->visibility->visibilityToAcl($visibility),
-                $this->options
+                $options
             );
         } catch (Throwable $exception) {
             throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);

--- a/src/AwsS3V3/AwsS3V3AdapterTest.php
+++ b/src/AwsS3V3/AwsS3V3AdapterTest.php
@@ -244,6 +244,23 @@ class AwsS3V3AdapterTest extends FilesystemAdapterTestCase
         $this->assertTrue($metadata['seekable']);
     }
 
+    /**
+     * @test
+     */
+    public function moving_with_updated_metadata(): void
+    {
+        $adapter = $this->adapter();
+        $adapter->write('source.txt', 'contents to be moved', new Config(['ContentType' => 'text/plain']));
+        $mimeTypeSource = $adapter->mimeType('source.txt')->mimeType();
+        $this->assertSame('text/plain', $mimeTypeSource);
+
+        $adapter->move('source.txt', 'destination.txt', new Config(
+            ['ContentType' => 'text/plain+special', 'MetadataDirective' => 'REPLACE']
+        ));
+        $mimeTypeDestination = $adapter->mimeType('destination.txt')->mimeType();
+        $this->assertSame('text/plain+special', $mimeTypeDestination);
+    }
+
     protected static function createFilesystemAdapter(bool $streaming = true, array $options = []): FilesystemAdapter
     {
         static::$stubS3Client = new S3ClientStub(static::s3Client());


### PR DESCRIPTION
I noticed that when copying a file, the `$config` param is not used. This is a problem if you require the object to be encrypted, for example. This fixes the problem by merging the config with the config that the class is instantiated with.