### PR TITLE
[feature]: optimize MountManager to make it extendable

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -21,9 +21,7 @@ class MountManager implements MountManagerInterface, FilesystemOperator
     public function __construct(array $filesystems = [])
     {
         foreach ($filesystems as $key => $filesystem) {
-            if ($this->isFilesystemExists($key)) {
-                continue;
-            }
+            $this->guardAgainstInvalidMount($key, $filesystem);
 
             $this->mountFilesystem($key, $filesystem);
         }
@@ -31,7 +29,9 @@ class MountManager implements MountManagerInterface, FilesystemOperator
 
     public function mountFilesystem(string $key, FilesystemOperator $filesystem): void
     {
-        $this->guardAgainstInvalidMount($key, $filesystem);
+        if ($this->isFilesystemExists($key)) {
+            return;
+        }
 
         $this->filesystems[$key] = $filesystem;
     }

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -29,16 +29,26 @@ class MountManager implements MountManagerInterface, FilesystemOperator
 
     public function mountFilesystem(string $key, FilesystemOperator $filesystem): void
     {
-        if ($this->isFilesystemExists($key)) {
+        if ($this->isFileSystemExists($key)) {
             return;
         }
 
         $this->filesystems[$key] = $filesystem;
     }
 
-    public function isFilesystemExists(string $key): bool
+    public function isFileSystemExists(string $key): bool
     {
         return array_key_exists($key, $this->filesystems);
+    }
+
+    public function getFileSystem(string $key): ?FilesystemOperator
+    {
+        return $this->isFileSystemExists($key) ? $this->filesystems[$key] : null;
+    }
+
+    public function extractMountedFileSystemsKeys(): array
+    {
+        return array_keys($this->filesystems);
     }
 
     public function fileExists(string $location): bool

--- a/src/MountManagerInterface.php
+++ b/src/MountManagerInterface.php
@@ -8,5 +8,5 @@ interface MountManagerInterface
 {
     public function mountFilesystem(string $key, FilesystemOperator $filesystem): void;
 
-    public function isFilesystemExists(string $key): bool;
+    public function isFileSystemExists(string $key): bool;
 }

--- a/src/MountManagerInterface.php
+++ b/src/MountManagerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem;
+
+interface MountManagerInterface
+{
+    public function mountFilesystem(string $key, FilesystemOperator $filesystem): void;
+
+    public function isFilesystemExists(string $key): bool;
+}

--- a/src/MountManagerTest.php
+++ b/src/MountManagerTest.php
@@ -382,4 +382,45 @@ class MountManagerTest extends TestCase
 
         $this->mountManager->read('unknown://location.txt');
     }
+
+    /**
+     * @test
+     */
+    public function is_file_system_exists(): void
+    {
+        $this->assertTrue($this->mountManager->isFileSystemExists('first'));
+        $this->assertFalse($this->mountManager->isFileSystemExists('missed'));
+    }
+
+    /**
+     * @test
+     */
+    public function get_file_system(): void
+    {
+        $this->assertSame($this->firstFilesystem, $this->mountManager->getFileSystem('first'));
+        $this->assertSame($this->secondFilesystem, $this->mountManager->getFileSystem('second'));
+        $this->assertNull($this->mountManager->getFileSystem('missed'));
+    }
+
+    /**
+     * @test
+     */
+    public function extract_mounted_file_systems_keys(): void
+    {
+        $this->assertEquals(['first', 'second'], $this->mountManager->extractMountedFileSystemsKeys());
+    }
+
+    /**
+     * @test
+     */
+    public function try_to_mount_existing_file_system(): void
+    {
+        $mountManager = new MountManager(
+            ['first' => $this->firstFilesystem]
+        );
+
+        $mountManager->mountFilesystem('first', $this->secondFilesystem);
+
+        $this->assertSame($mountManager->getFileSystem('first'), $this->firstFilesystem);
+    }
 }


### PR DESCRIPTION
This modification can help to reuse MountManager or use it in more flexible way.
Using separator in const can be used to provide another pattern for filepath storages