### PR TITLE
Fix #1264 - fix_usage '/' as a root

### DIFF
--- a/src/PathPrefixer.php
+++ b/src/PathPrefixer.php
@@ -22,10 +22,14 @@ final class PathPrefixer
 
     public function __construct(string $prefix, string $separator = '/')
     {
-        $this->prefix = rtrim($prefix, '\\/');
+        if ($prefix === '/' || $prefix === '\\') {
+            $this->prefix = $prefix;
+        } else {
+            $this->prefix = rtrim($prefix, '\\/');
 
-        if ($prefix !== '') {
-            $this->prefix .= $separator;
+            if ($this->prefix !== '') {
+                $this->prefix .= $separator;
+            }
         }
 
         $this->separator = $separator;


### PR DESCRIPTION
Fix usage '/' as a root for the storage adapter