### PR TITLE
Disconnect FTP connection

### DIFF
--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -93,6 +93,17 @@ class FtpAdapter implements FilesystemAdapter
     }
 
     /**
+     * Disconnect FTP connection on destruct.
+     */
+    public function __destruct()
+    {
+        if ($this->connection !== false) {
+            @ftp_close($this->connection);
+            $this->connection = false;
+        }
+    }
+
+    /**
      * @return resource
      */
     private function connection()

--- a/src/Ftp/FtpAdapterTest.php
+++ b/src/Ftp/FtpAdapterTest.php
@@ -26,4 +26,21 @@ class FtpAdapterTest extends FtpAdapterTestCase
 
         return new FtpAdapter($options, null, static::$connectivityChecker);
     }
+
+    /**
+     * @test
+     */
+    public function disconnect_after_destruct(): void
+    {
+        $adapter = $this->createFilesystemAdapter();
+        $reflection = new \ReflectionObject($adapter);
+        $adapter->fileExists('foo.txt');
+        $reflectionProperty = $reflection->getProperty('connection');
+        $reflectionProperty->setAccessible(true);
+        $connection = $reflectionProperty->getValue($adapter);
+
+        $this->assertTrue(false !== ftp_pwd($connection));
+        unset($adapter);
+        $this->assertFalse(ftp_pwd($connection));
+    }
 }


### PR DESCRIPTION
This will fix #1256

When the FTP adapter is destructed, then we should disconnect the FTP connection. 

I don't understand why my tests are failing. It is like `ftp_close` have no effect...