### PR TITLE
InMemoryAdapter must return the number of bytes

### DIFF
--- a/src/InMemory/InMemoryFile.php
+++ b/src/InMemory/InMemoryFile.php
@@ -58,9 +58,7 @@ class InMemoryFile
 
     public function fileSize(): int
     {
-        return function_exists('mb_strlen')
-            ? mb_strlen($this->contents)
-            : strlen($this->contents);
+        return strlen($this->contents);
     }
 
     public function mimeType(): string


### PR DESCRIPTION
Currently, it returns the length of the content. 

This will fix #1275


```php
echo mb_strlen('täst'); // => 4
echo strlen('täst'); // => 5
```

We are always interested the byte length.