### PR TITLE
Keep identifier in paths when MountManager list contents is called

### DIFF
--- a/src/MountManagerTest.php
+++ b/src/MountManagerTest.php
@@ -235,6 +235,29 @@ class MountManagerTest extends TestCase
     /**
      * @test
      */
+    public function list_directory(): void
+    {
+        $this->mountManager->createDirectory('first://directory');
+        $this->mountManager->write('first://directory/file', 'foo');
+
+        $directoryListing = $this->mountManager->listContents('first://', Filesystem::LIST_DEEP)->toArray();
+
+        $this->assertCount(2, $directoryListing);
+
+        /** @var DirectoryAttributes $directory */
+        $directory = $directoryListing[0];
+        $this->assertInstanceOf(DirectoryAttributes::class, $directory);
+        $this->assertEquals('first://directory', $directory->path());
+
+        /** @var FileAttributes $file */
+        $file = $directoryListing[1];
+        $this->assertInstanceOf(FileAttributes::class, $file);
+        $this->assertEquals('first://directory/file', $file->path());
+    }
+
+    /**
+     * @test
+     */
     public function copying_in_the_same_filesystem(): void
     {
         $this->firstFilesystem->write('location.txt', 'contents');


### PR DESCRIPTION
Example:
```
first://directory
first://directory/file.txt
first://directory/file2.txt
second://directory
second://directory/file.txt
```

Actual, to filter, map... we need to concate identifier and path result:

```php
$mountManager
    ->listContents('first://')
    ->filter(fn(StorageAttributes $attr) => $attr->isFile());
    ->filter(fn(FileAttributes $attr) => $mountManager->mimeType('first://' . $attr->path()) === 'plain/text');
```

With fix:

```php
$mountManager
    ->listContents('first://')
    ->filter(fn(StorageAttributes $attr) => $attr->isFile());
    ->filter(fn(FileAttributes $attr) => $mountManager->mimeType($attr->path()) === 'plain/text');
```