### PR TITLE
Setting metadata when uploading an object into a GCS bucket

### DIFF
--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -22,6 +22,8 @@ use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\Visibility;
+use League\MimeTypeDetection\FinfoMimeTypeDetector;
+use League\MimeTypeDetection\MimeTypeDetector;
 use Throwable;
 
 class GoogleCloudStorageAdapter implements FilesystemAdapter
@@ -46,12 +48,23 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
      */
     private $defaultVisibility;
 
-    public function __construct(Bucket $bucket, string $prefix = '', VisibilityHandler $visibilityHandler = null, string $defaultVisibility = Visibility::PRIVATE)
-    {
+    /**
+     * @var MimeTypeDetector
+     */
+    private $mimeTypeDetector;
+
+    public function __construct(
+        Bucket $bucket,
+        string $prefix = '',
+        VisibilityHandler $visibilityHandler = null,
+        string $defaultVisibility = Visibility::PRIVATE,
+        MimeTypeDetector $mimeTypeDetector = null
+    ) {
         $this->bucket = $bucket;
         $this->prefixer = new PathPrefixer($prefix);
         $this->visibilityHandler = $visibilityHandler ?: new PortableVisibilityHandler();
         $this->defaultVisibility = $defaultVisibility;
+        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
     }
 
     public function fileExists(string $path): bool
@@ -77,10 +90,7 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
     private function upload(string $path, $contents, Config $config): void
     {
         $prefixedPath = $this->prefixer->prefixPath($path);
-        $options = [
-            'name' => $prefixedPath,
-            'metadata' => $config->get('metadata', []),
-        ];
+        $options = ['name' => $prefixedPath];
 
         $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
         $predefinedAcl = $this->visibilityHandler->visibilityToPredefinedAcl($visibility);
@@ -88,6 +98,13 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
         if ($predefinedAcl !== PortableVisibilityHandler::NO_PREDEFINED_VISIBILITY) {
             $options['predefinedAcl'] = $predefinedAcl;
         }
+
+        $metadata = $config->get('metadata', []);
+        $shouldDetermineMimetype = $contents !== '' && ! array_key_exists('contentType', $metadata);
+        if ($shouldDetermineMimetype && $mimeType = $this->mimeTypeDetector->detectMimeType($path, $contents)) {
+            $metadata['contentType'] = $mimeType;
+        }
+        $options['metadata'] = $metadata;
 
         try {
             $this->bucket->upload($contents, $options);

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -77,7 +77,10 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
     private function upload(string $path, $contents, Config $config): void
     {
         $prefixedPath = $this->prefixer->prefixPath($path);
-        $options = ['name' => $prefixedPath];
+        $options = [
+            'name' => $prefixedPath,
+            'metadata' => $config->get('metadata', []),
+        ];
 
         $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
         $predefinedAcl = $this->visibilityHandler->visibilityToPredefinedAcl($visibility);

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapterTest.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapterTest.php
@@ -57,6 +57,17 @@ class GoogleCloudStorageAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function writing_with_specific_metadata(): void
+    {
+        $adapter = $this->adapter();
+        $adapter->write('some/path.txt', 'contents', new Config(['metadata' => ['contentType' => 'text/plain+special']]));
+        $mimeType = $adapter->mimeType('some/path.txt')->mimeType();
+        $this->assertEquals('text/plain+special', $mimeType);
+    }
+
+    /**
+     * @test
+     */
     public function fetching_visibility_of_non_existing_file(): void
     {
         $this->markTestSkipped("

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapterTest.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapterTest.php
@@ -68,6 +68,17 @@ class GoogleCloudStorageAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function guessing_the_mime_type_when_writing(): void
+    {
+        $adapter = $this->adapter();
+        $adapter->write('some/config.txt', '<?xml version="1.0" encoding="UTF-8"?><test/>', new Config());
+        $mimeType = $adapter->mimeType('some/config.txt')->mimeType();
+        $this->assertEquals('text/xml', $mimeType);
+    }
+
+    /**
+     * @test
+     */
     public function fetching_visibility_of_non_existing_file(): void
     {
         $this->markTestSkipped("


### PR DESCRIPTION
Allow setting metadata when writing to a GCS bucket. Specifically, this would allow defining the object's mime type through the `metadata['contentType']` entry (if omitted, GCS will serve the object as `application/octet-stream`)

Fixes https://github.com/thephpleague/flysystem-google-cloud-storage/issues/2