### PR TITLE
Remove rawurlencode() from CopySource argument

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -294,7 +294,7 @@ class AsyncAwsS3Adapter implements FilesystemAdapter
             'ACL' => $this->visibility->visibilityToAcl($visibility),
             'Bucket' => $this->bucket,
             'Key' => $this->prefixer->prefixPath($destination),
-            'CopySource' => rawurlencode($this->bucket . '/' . $this->prefixer->prefixPath($source)),
+            'CopySource' => $this->bucket . '/' . $this->prefixer->prefixPath($source),
         ];
 
         try {


### PR DESCRIPTION
I currently have the problem that I'm unable to copy files on a DigitalOcean S3 bucket using Flysystem and the AsyncAWS adapter. Digging into this issue, I suspected that the source file name is URL-encoded twice in the HTTP requests. In fact, if I remove the `rawurlencode()` call, it works like a charm.