### PR TITLE
Remove "--ignore-platform-req=php" composer flag when testing php 8.0

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -33,7 +33,7 @@ jobs:
         phpunit-flags: [ '--coverage-text' ]
         include:
           - php: '8.0'
-            composer-flags: '--ignore-platform-req=php'
+            composer-flags: ''
             phpunit-flags: '--no-coverage'
             upgrade-aws-sdk: 'yes'
           - php: '7.2'


### PR DESCRIPTION
It seems the flag "--ignore-platform-req=php" is not needed anymore. 

Also I'm not sure if php 8.0 should go to matrix.php (screen below). If needed I can do that change

![зображення](https://user-images.githubusercontent.com/8986207/117289082-dbae3a80-ae74-11eb-896d-3e6da3b0ae94.png)
