### PR TITLE
[2.x] Add extra metadata to DirectoryAttributes (Consistent with FileAttributes)

### DIFF
--- a/src/DirectoryAttributes.php
+++ b/src/DirectoryAttributes.php
@@ -90,7 +90,7 @@ class DirectoryAttributes implements StorageAttributes
             $attributes[StorageAttributes::ATTRIBUTE_PATH],
             $attributes[StorageAttributes::ATTRIBUTE_VISIBILITY] ?? null,
             $attributes[StorageAttributes::ATTRIBUTE_LAST_MODIFIED] ?? null,
-            $attributes[StorageAttributes::ATTRIBUTE_EXTRA_METADATA] ?? [],
+            $attributes[StorageAttributes::ATTRIBUTE_EXTRA_METADATA] ?? []
         );
     }
 

--- a/src/DirectoryAttributes.php
+++ b/src/DirectoryAttributes.php
@@ -28,11 +28,17 @@ class DirectoryAttributes implements StorageAttributes
      */
     private $lastModified;
 
-    public function __construct(string $path, ?string $visibility = null, ?int $lastModified = null)
+    /**
+     * @var array
+     */
+    private $extraMetadata;
+
+    public function __construct(string $path, ?string $visibility = null, ?int $lastModified = null, array $extraMetadata = [])
     {
         $this->path = $path;
         $this->visibility = $visibility;
         $this->lastModified = $lastModified;
+        $this->extraMetadata = $extraMetadata;
     }
 
     public function path(): string
@@ -53,6 +59,11 @@ class DirectoryAttributes implements StorageAttributes
     public function lastModified(): ?int
     {
         return $this->lastModified;
+    }
+
+    public function extraMetadata(): array
+    {
+        return $this->extraMetadata;
     }
 
     public function isFile(): bool
@@ -78,7 +89,8 @@ class DirectoryAttributes implements StorageAttributes
         return new DirectoryAttributes(
             $attributes[StorageAttributes::ATTRIBUTE_PATH],
             $attributes[StorageAttributes::ATTRIBUTE_VISIBILITY] ?? null,
-            $attributes[StorageAttributes::ATTRIBUTE_LAST_MODIFIED] ?? null
+            $attributes[StorageAttributes::ATTRIBUTE_LAST_MODIFIED] ?? null,
+            $attributes[StorageAttributes::ATTRIBUTE_EXTRA_METADATA] ?? [],
         );
     }
 
@@ -92,6 +104,7 @@ class DirectoryAttributes implements StorageAttributes
             StorageAttributes::ATTRIBUTE_PATH => $this->path,
             StorageAttributes::ATTRIBUTE_VISIBILITY => $this->visibility,
             StorageAttributes::ATTRIBUTE_LAST_MODIFIED => $this->lastModified,
+            StorageAttributes::ATTRIBUTE_EXTRA_METADATA => $this->extraMetadata,
         ];
     }
 }

--- a/src/DirectoryAttributesTest.php
+++ b/src/DirectoryAttributesTest.php
@@ -21,7 +21,6 @@ class DirectoryAttributesTest extends TestCase
         $this->assertNull($attrs->visibility());
     }
 
-
     /**
      * @test
      */

--- a/src/DirectoryAttributesTest.php
+++ b/src/DirectoryAttributesTest.php
@@ -21,6 +21,7 @@ class DirectoryAttributesTest extends TestCase
         $this->assertNull($attrs->visibility());
     }
 
+
     /**
      * @test
      */
@@ -37,6 +38,15 @@ class DirectoryAttributesTest extends TestCase
     {
         $attrs = new DirectoryAttributes('some/path', null, $timestamp = time());
         $this->assertEquals($timestamp, $attrs->lastModified());
+    }
+
+    /**
+     * @test
+     */
+    public function exposing_extra_meta_data(): void
+    {
+        $attrs = new DirectoryAttributes('some/path', null, null, ['key' => 'value']);
+        $this->assertEquals(['key' => 'value'], $attrs->extraMetadata());
     }
 
     /**


### PR DESCRIPTION
Please help.

I'm migrating custom adapter to V2 and i need extra metadata for directories, not breaking changes, with test and consistent with FileAttributes

This fix me a bug with laravel 9.x, @Nyholm suggestions?