### PR TITLE
[2.x] Google Drive third party adapter migrated to v2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ for which ever storage is right for you.
 ### Third party Adapters
 
 * **[Gitlab](https://github.com/RoyVoetman/flysystem-gitlab-storage)**
+* **[Google Drive (using regular paths)](https://github.com/masbug/flysystem-google-drive-ext)**
 
 You can always [create an adapter](https://flysystem.thephpleague.com/v2/docs/advanced/creating-an-adapter/) yourself.
 


### PR DESCRIPTION
[masbug/flysystem-google-drive-ext:"2.x"](https://github.com/masbug/flysystem-google-drive-ext/tree/2.x)

[GoogleDriveAdapterTests.php](https://github.com/masbug/flysystem-google-drive-ext/blob/2.x/tests/GoogleDriveAdapterTests.php) according `AdapterTestUtilitiesFilesystemAdapterTestCase` all the tests passed  .

```
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.5
Configuration:  \google-drive-flysystem\phpunit.xml.dist

BEGIN: .............................................                    46 / 46 (100%)

Time: 02:23.580, Memory: 10.00 MB

OK (46 tests, 75 assertions)
```