### PR TITLE
Allow to mount/unmount filesystems

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -249,9 +249,37 @@ class MountManager implements FilesystemOperator
         }
     }
 
-    private function mountFilesystem(string $key, FilesystemOperator $filesystem): void
+    /**
+     * Mount filesystem.
+     *
+     * @param string $key
+     * @param FilesystemOperator $filesystem
+     */
+    public function mountFilesystem(string $key, FilesystemOperator $filesystem): void
     {
         $this->filesystems[$key] = $filesystem;
+    }
+
+    /**
+     * Unmount filesystem.
+     *
+     * @param string $key
+     */
+    public function unmountFilesystem(string $key): void
+    {
+        unset($this->filesystems[$key]);
+    }
+
+    /**
+     * Has filesystem mounted?
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function hasFilesystem(string $key): bool
+    {
+        return array_key_exists($key, $this->filesystems);
     }
 
     /**

--- a/src/MountManagerTest.php
+++ b/src/MountManagerTest.php
@@ -407,4 +407,55 @@ class MountManagerTest extends TestCase
 
         $this->mountManager->read('unknown://location.txt');
     }
+
+    /**
+     * @test
+     */
+    public function mount_filesystem(): void
+    {
+        $this->mountManager = new MountManager();
+        $this->mountManager->mountFilesystem('first', new Filesystem($this->firstStubAdapter));
+        $this->mountManager->mountFilesystem('second', new Filesystem($this->secondStubAdapter));
+
+        $this->firstFilesystem->write('location.txt', 'contents');
+        $this->secondFilesystem->write('location.txt', 'contents2');
+
+        $contents = $this->mountManager->read('first://location.txt');
+        $this->assertEquals('contents', $contents);
+
+        $contents = $this->mountManager->read('second://location.txt');
+        $this->assertEquals('contents2', $contents);
+    }
+
+    /**
+     * @test
+     */
+    public function has_filesystem(): void
+    {
+        $this->mountManager = new MountManager();
+        $this->mountManager->mountFilesystem('first', new Filesystem($this->firstStubAdapter));
+        $this->mountManager->mountFilesystem('second', new Filesystem($this->secondStubAdapter));
+
+        $this->assertTrue($this->mountManager->hasFilesystem('first'));
+        $this->assertTrue($this->mountManager->hasFilesystem('second'));
+        $this->assertFalse($this->mountManager->hasFilesystem('third'));
+    }
+
+    /**
+     * @test
+     */
+    public function unmount_filesystem(): void
+    {
+        $this->mountManager = new MountManager();
+        $this->mountManager->mountFilesystem('first', new Filesystem($this->firstStubAdapter));
+        $this->mountManager->mountFilesystem('second', new Filesystem($this->secondStubAdapter));
+
+        $this->assertTrue($this->mountManager->hasFilesystem('first'));
+        $this->assertTrue($this->mountManager->hasFilesystem('second'));
+
+        $this->mountManager->unmountFilesystem('second');
+
+        $this->assertTrue($this->mountManager->hasFilesystem('first'));
+        $this->assertFalse($this->mountManager->hasFilesystem('second'));
+    }
 }


### PR DESCRIPTION
Expose methods of MountManager class:

- `MountManager::mountFilesystem(string $key, FilesystemOperator $filesystem): void` Mount new filesystem in the manager
- `MountManager::unmountFilesystem(string $key): void` Unmount filesystem from manager
- `MountManager::hasFilesystem(string $key): bool` Know if a filesystem is mounted

Alternative naming proposal:

- `MountManager::mount(...)`
- `MountManager::unmount(...)`
- `MountManager::isMounted(...)`