### PR TITLE
Use phpseclib2_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-fileinfo": "*",
         "phpunit/phpunit": "^8.5 || ^9.4",
         "phpstan/phpstan": "^0.12.26",
-        "phpseclib/phpseclib": "^2.0",
+        "phpseclib/phpseclib2_compat": "1.0.x-dev",
         "aws/aws-sdk-php": "^3.132.4",
         "composer/semver": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/src/PhpseclibV2/SftpConnectionProvider.php
+++ b/src/PhpseclibV2/SftpConnectionProvider.php
@@ -124,6 +124,14 @@ class SftpConnectionProvider implements ConnectionProvider
     private function setupConnection(): SFTP
     {
         $connection = new SFTP($this->host, $this->port, $this->timeout);
+        $connection->setPreferredAlgorithms([
+            'hostkey' => [
+                'ssh-rsa',
+                'ssh-dss',
+                'rsa-sha2-512',
+                'rsa-sha2-256',
+            ],
+        ]);
         $connection->disableStatCache();
 
         try {

--- a/src/PhpseclibV2/composer.json
+++ b/src/PhpseclibV2/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.2 || ^8.0",
         "league/flysystem": "^2.0.0",
         "league/mime-type-detection": "^1.0.0",
-        "phpseclib/phpseclib": "^2.0"
+        "phpseclib/phpseclib2_compat": "1.0.x-dev"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This PR replaces `phpseclib/phpseclib` with `phpseclib/phpseclib2_compat` providing a bridge between v3 and v2. 
This should make it easier for users to migrate to newer version of the lib and easier native flysystem support for phpseclib3: #1257.
The biggest breaking change is preferring ed25519 over RSA keys - that's why we had to manually adjust the algorithm order accordingly. I've temporarily required an unreleased https://github.com/phpseclib/phpseclib2_compat version because last stable version throws an error during private key loading (Fixed in https://github.com/phpseclib/phpseclib2_compat/pull/7).