### PR TITLE
Allow fetching extra metadata

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -254,6 +254,17 @@ class AsyncAwsS3Adapter implements FilesystemAdapter
         return $attributes;
     }
 
+    public function extraMetadata(string $path): FileAttributes
+    {
+        $attributes = $this->fetchFileMetadata($path, FileAttributes::ATTRIBUTE_EXTRA_METADATA);
+
+        if (null === $attributes->extraMetadata()) {
+            throw UnableToRetrieveMetadata::extraMetadata($path);
+        }
+
+        return $attributes;
+    }
+
     public function listContents(string $path, bool $deep): iterable
     {
         $prefix = trim($this->prefixer->prefixPath($path), '/');

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -349,6 +349,17 @@ class AwsS3V3Adapter implements FilesystemAdapter
         return $attributes;
     }
 
+    public function extraMetadata(string $path): FileAttributes
+    {
+        $attributes = $this->fetchFileMetadata($path, FileAttributes::ATTRIBUTE_EXTRA_METADATA);
+
+        if ($attributes->extraMetadata() === null) {
+            throw UnableToRetrieveMetadata::extraMetadata($path);
+        }
+
+        return $attributes;
+    }
+
     public function listContents(string $path, bool $deep): iterable
     {
         $prefix = trim($this->prefixer->prefixPath($path), '/');

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -125,6 +125,11 @@ class Filesystem implements FilesystemOperator
         return $this->adapter->mimeType($this->pathNormalizer->normalizePath($path))->mimeType();
     }
 
+    public function extraMetadata(string $path): array
+    {
+        return $this->adapter->extraMetadata($this->pathNormalizer->normalizePath($path))->extraMetadata();
+    }
+
     public function setVisibility(string $path, string $visibility): void
     {
         $this->adapter->setVisibility($this->pathNormalizer->normalizePath($path), $visibility);

--- a/src/FilesystemAdapter.php
+++ b/src/FilesystemAdapter.php
@@ -88,6 +88,12 @@ interface FilesystemAdapter
     public function fileSize(string $path): FileAttributes;
 
     /**
+     * @throws UnableToRetrieveMetadata
+     * @throws FilesystemException
+     */
+    public function extraMetadata(string $path): FileAttributes;
+
+    /**
      * @return iterable<StorageAttributes>
      *
      * @throws FilesystemException

--- a/src/FilesystemReader.php
+++ b/src/FilesystemReader.php
@@ -63,4 +63,10 @@ interface FilesystemReader
      * @throws FilesystemException
      */
     public function visibility(string $path): string;
+
+    /**
+     * @throws UnableToRetrieveMetadata
+     * @throws FilesystemException
+     */
+    public function extraMetadata(string $path): FileAttributes;
 }

--- a/src/FilesystemReader.php
+++ b/src/FilesystemReader.php
@@ -68,5 +68,5 @@ interface FilesystemReader
      * @throws UnableToRetrieveMetadata
      * @throws FilesystemException
      */
-    public function extraMetadata(string $path): FileAttributes;
+    public function extraMetadata(string $path): array;
 }

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -332,6 +332,11 @@ class FtpAdapter implements FilesystemAdapter
         return $this->fetchMetadata($path, FileAttributes::ATTRIBUTE_VISIBILITY);
     }
 
+    public function extraMetadata(string $path): FileAttributes
+    {
+        return $this->fetchMetadata($path, FileAttributes::ATTRIBUTE_EXTRA_METADATA);
+    }
+
     public function fileSize(string $path): FileAttributes
     {
         $location = $this->prefixer->prefixPath($path);

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -195,6 +195,11 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
         return $this->fileAttributes($path, 'fileSize');
     }
 
+    public function extraMetadata(string $path): FileAttributes
+    {
+        return $this->fileAttributes($path, 'extraMetadata');
+    }
+
     private function fileAttributes(string $path, string $type): FileAttributes
     {
         $exception = null;

--- a/src/InMemory/InMemoryFile.php
+++ b/src/InMemory/InMemoryFile.php
@@ -27,6 +27,11 @@ class InMemoryFile
      */
     private $visibility;
 
+    /**
+     * @var array[]
+     */
+    private $extraMetadata;
+
     public function updateContents(string $contents): void
     {
         $this->contents = $contents;
@@ -74,5 +79,15 @@ class InMemoryFile
     public function visibility(): ?string
     {
         return $this->visibility;
+    }
+
+    public function extraMetadata(): array
+    {
+        return $this->extraMetadata;
+    }
+
+    public function setExtraMetadata(array $extraMetadata): void
+    {
+        $this->extraMetadata = $extraMetadata;
     }
 }

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -168,6 +168,17 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         return new FileAttributes($path, $this->files[$path]->fileSize());
     }
 
+    public function extraMetadata(string $path): FileAttributes
+    {
+        $path = $this->preparePath($path);
+
+        if (array_key_exists($path, $this->files) === false) {
+            throw UnableToRetrieveMetadata::extraMetadata($path, 'file does not exist');
+        }
+
+        return new FileAttributes($path, null, null, null, null, $this->files[$path]->extraMetadata());
+    }
+
     public function listContents(string $path, bool $deep): iterable
     {
         $prefix = rtrim($this->preparePath($path), '/') . '/';

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -377,6 +377,11 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         return new FileAttributes($path, null, null, null, $mimeType);
     }
 
+    public function extraMetadata(string $path): FileAttributes
+    {
+        throw UnableToRetrieveMetadata::extraMetadata($path, 'No extra metadata available for local files');
+    }
+
     public function lastModified(string $path): FileAttributes
     {
         $location = $this->prefixer->prefixPath($path);

--- a/src/PhpseclibV2/SftpAdapter.php
+++ b/src/PhpseclibV2/SftpAdapter.php
@@ -251,6 +251,11 @@ class SftpAdapter implements FilesystemAdapter
         return $this->fetchFileMetadata($path, FileAttributes::ATTRIBUTE_VISIBILITY);
     }
 
+    public function extraMetadata(string $path): FileAttributes
+    {
+        return $this->fetchFileMetadata($path, FileAttributes::ATTRIBUTE_EXTRA_METADATA);
+    }
+
     public function listContents(string $path, bool $deep): iterable
     {
         $connection = $this->connectionProvider->provideConnection();

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -251,6 +251,11 @@ class SftpAdapter implements FilesystemAdapter
         return $this->fetchFileMetadata($path, FileAttributes::ATTRIBUTE_VISIBILITY);
     }
 
+    public function extraMetadata(string $path): FileAttributes
+    {
+        return $this->fetchFileMetadata($path, FileAttributes::ATTRIBUTE_EXTRA_METADATA);
+    }
+
     public function listContents(string $path, bool $deep): iterable
     {
         $connection = $this->connectionProvider->provideConnection();

--- a/src/UnableToRetrieveMetadata.php
+++ b/src/UnableToRetrieveMetadata.php
@@ -44,6 +44,11 @@ final class UnableToRetrieveMetadata extends RuntimeException implements Filesys
         return static::create($location, FileAttributes::ATTRIBUTE_MIME_TYPE, $reason, $previous);
     }
 
+    public static function extraMetadata(string $location, string $reason = '', Throwable $previous = null): self
+    {
+        return static::create($location, FileAttributes::ATTRIBUTE_EXTRA_METADATA, $reason, $previous);
+    }
+
     public static function create(string $location, string $type, string $reason = '', Throwable $previous = null): self
     {
         $e = new static("Unable to retrieve the $type for file at location: $location. {$reason}", 0, $previous);


### PR DESCRIPTION
Fix #1323 

Allow fetching of extra metadata so that more customised code can be written that isn't adapter specific