### PR TITLE
[2.x] Encrypted Filesystem Adapter

### DIFF
--- a/src/EncryptedFilesystemAdapter.php
+++ b/src/EncryptedFilesystemAdapter.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace League\Flysystem;
+
+
+interface EncryptedFilesystemAdapter
+{
+    /**
+     * @throws FilesystemException
+     */
+    public function encryptedFileExists(string $path, string $encryptionKey): bool;
+
+    /**
+     * @throws UnableToWriteFile
+     * @throws FilesystemException
+     */
+    public function encryptedWrite(string $path, string $contents, Config $config, string $encryptionKey): void;
+
+    /**
+     * @param resource $contents
+     *
+     * @throws UnableToWriteFile
+     * @throws FilesystemException
+     */
+    public function encryptedWriteStream(string $path, $contents, Config $config, string $encryptionKey): void;
+
+    /**
+     * @throws UnableToReadFile
+     * @throws FilesystemException
+     */
+    public function encryptedRead(string $path, string $encryptionKey): string;
+
+    /**
+     * @return resource
+     *
+     * @throws UnableToReadFile
+     * @throws FilesystemException
+     */
+    public function encryptedReadStream(string $path, string $encryptionKey);
+
+    /**
+     * @throws UnableToRetrieveMetadata
+     * @throws FilesystemException
+     */
+    public function encryptedMimeType(string $path, string $encryptionKey): FileAttributes;
+
+    /**
+     * @throws UnableToRetrieveMetadata
+     * @throws FilesystemException
+     */
+    public function encryptedLastModified(string $path, string $encryptionKey): FileAttributes;
+
+    /**
+     * @throws UnableToRetrieveMetadata
+     * @throws FilesystemException
+     */
+    public function encryptedFileSize(string $path, string $encryptionKey): FileAttributes;
+
+    /**
+     * @throws UnableToMoveFile
+     * @throws FilesystemException
+     */
+    public function encryptedMove(string $source, string $destination, Config $config, string $sourceKey, ?string $destinationKey = null): void;
+
+    /**
+     * @throws UnableToCopyFile
+     * @throws FilesystemException
+     */
+    public function encryptedCopy(string $source, string $destination, Config $config, string $sourceKey, ?string $destinationKey = null): void;
+}


### PR DESCRIPTION
An alternative solution to #1319 (#1318)which would not break BC by introducing a new `EncryptedFilesystemAdapter` interface which allows operation on encrypted files on filesystems that support it.

Depending on which solution you think is better I'll close this or the other PR and focus on that one.