### PR TITLE
Fixes #1313: Add a sorting function to the directory listing.

### DIFF
--- a/src/DirectoryListing.php
+++ b/src/DirectoryListing.php
@@ -55,7 +55,7 @@ class DirectoryListing implements IteratorAggregate
         $listing = $this->toArray();
 
         usort($listing, function (StorageAttributes $a, StorageAttributes $b) {
-            return strcasecmp($a->path(), $b->path());
+            return $a->path() <=> $b->path();
         });
 
         return new DirectoryListing($listing);

--- a/src/DirectoryListing.php
+++ b/src/DirectoryListing.php
@@ -50,6 +50,17 @@ class DirectoryListing implements IteratorAggregate
         return new DirectoryListing($generator);
     }
 
+    public function sortByPath(): DirectoryListing
+    {
+        $listing = $this->toArray();
+
+        usort($listing, function (StorageAttributes $a, StorageAttributes $b) {
+            return strcasecmp($a->path(), $b->path());
+        });
+
+        return new DirectoryListing($listing);
+    }
+
     /**
      * @return iterable<T>
      */

--- a/src/DirectoryListingTest.php
+++ b/src/DirectoryListingTest.php
@@ -87,6 +87,26 @@ class DirectoryListingTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function sorting_a_directory_listing(): void
+    {
+        $expected = ['/a/a/a.txt', '/b/c/a.txt', '/c/b/a.txt', '/c/c/a.txt'];
+        $listing = new DirectoryListing([
+            new FileAttributes('/b/c/a.txt'),
+            new FileAttributes('/c/c/a.txt'),
+            new FileAttributes('/c/b/a.txt'),
+            new FileAttributes('/a/a/a.txt'),
+        ]);
+
+        $actual = $listing->sortByPath()
+            ->map(function($i) { return $i->path(); })
+            ->toArray();
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
      * @return Generator<int>
      */
     private function generateIntegers(int $min, int $max): Generator


### PR DESCRIPTION
Directory iterators and other PHP local filesystem methods do not return sorted responses. In v1 we would always sort the output. Sorting is not compatible with generators, so it cannot be the default. This PR introduces a sortByPath method to the directory listing to sort it, which also turns the directory listing into a fully accumulated array response, which takes up more memory. This is the trade-off that people will have to make.

This will fix #1313