### PR TITLE
[1.x] Allow utf8 connections when server is already utf8

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -160,7 +160,7 @@ class Ftp extends AbstractFtpAdapter
     {
         if ($this->utf8) {
             $response = ftp_raw($this->connection, "OPTS UTF8 ON");
-            if (substr($response[0], 0, 3) !== '200') {
+            if (!in_array(substr($response[0], 0, 3), ['200', '202'])) {
                 throw new ConnectionRuntimeException(
                     'Could not set UTF-8 mode for connection: ' . $this->getHost() . '::' . $this->getPort()
                 );

--- a/tests/FtpTests.php
+++ b/tests/FtpTests.php
@@ -125,6 +125,10 @@ function ftp_raw($connection, $command)
     }
 
     if ($command === 'OPTS UTF8 ON') {
+        if ($connection === 'utf8.alreadyActive') {
+            return [0 => '202 UTF8 mode is always enabled. No need to send this command.'];
+        }
+    
         return [0 => '200 UTF8 set to on'];
     }
 
@@ -922,6 +926,16 @@ class FtpTests extends TestCase
     public function testItSetUtf8Mode()
     {
         $adapter = new Ftp($this->options + ['utf8' => true]);
+        $adapter->setUtf8(true);
+        $this->assertNull($adapter->connect());
+    }
+
+        /**
+     * @depends testInstantiable
+     */
+    public function testItSetUtf8ModeWhenAlreadySetByServer()
+    {
+        $adapter = new Ftp(['host' => 'utf8.alreadyActive', 'utf8' => true]);
         $adapter->setUtf8(true);
         $this->assertNull($adapter->connect());
     }


### PR DESCRIPTION
* Allow 202 response code as valid UTF-8 activation
* Add tests to match this new configuration