### PR TITLE
[2.x] Allow utf8 connections when server is already utf8 

### DIFF
--- a/src/Ftp/FtpConnectionProvider.php
+++ b/src/Ftp/FtpConnectionProvider.php
@@ -70,7 +70,7 @@ class FtpConnectionProvider implements ConnectionProvider
 
         $response = ftp_raw($connection, "OPTS UTF8 ON");
 
-        if (substr($response[0] ?? '', 0, 3) !== '200') {
+        if (!in_array(substr($response[0], 0, 3), ['200', '202'])) {
             throw new UnableToEnableUtf8Mode(
                 'Could not set UTF-8 mode for connection: ' . $options->host() . '::' . $options->port()
             );

--- a/src/Ftp/FtpConnectionProviderTest.php
+++ b/src/Ftp/FtpConnectionProviderTest.php
@@ -21,7 +21,7 @@ class FtpConnectionProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->retryOnException(UnableToConnectToFtpHost::class);
+        //$this->retryOnException(UnableToConnectToFtpHost::class);
     }
 
     /**
@@ -80,6 +80,27 @@ class FtpConnectionProviderTest extends TestCase
         mock_function('ftp_raw', ['Error']);
 
         $this->expectException(UnableToEnableUtf8Mode::class);
+
+        $this->runScenario(function () use ($options) {
+            $this->connectionProvider->createConnection($options);
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function uft8_mode_already_active_by_server(): void
+    {
+        $options = FtpConnectionOptions::fromArray([
+            'host' => 'localhost',
+            'port' => 2121,
+            'utf8' => true,
+            'root' => '/home/foo/upload',
+            'username' => 'foo',
+            'password' => 'pass',
+       ]);
+
+        mock_function('ftp_raw', ['202 UTF8 mode is always enabled. No need to send this command.']);
 
         $this->runScenario(function () use ($options) {
             $this->connectionProvider->createConnection($options);

--- a/src/Ftp/FtpConnectionProviderTest.php
+++ b/src/Ftp/FtpConnectionProviderTest.php
@@ -21,7 +21,7 @@ class FtpConnectionProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        //$this->retryOnException(UnableToConnectToFtpHost::class);
+        $this->retryOnException(UnableToConnectToFtpHost::class);
     }
 
     /**


### PR DESCRIPTION
* Allow 202 response code as valid UTF-8 activation
* Add tests to match this new configuration
