### PR TITLE
Call ensureParentDirectoryExists() with valid parameter when moving file

### DIFF
--- a/src/PhpseclibV2/SftpAdapter.php
+++ b/src/PhpseclibV2/SftpAdapter.php
@@ -308,7 +308,7 @@ class SftpAdapter implements FilesystemAdapter
         $connection = $this->connectionProvider->provideConnection();
 
         try {
-            $this->ensureParentDirectoryExists($destinationLocation, $config);
+            $this->ensureParentDirectoryExists($destination, $config);
         } catch (Throwable $exception) {
             throw UnableToMoveFile::fromLocationTo($source, $destination, $exception);
         }

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -304,7 +304,7 @@ class SftpAdapter implements FilesystemAdapter
         $connection = $this->connectionProvider->provideConnection();
 
         try {
-            $this->ensureParentDirectoryExists($destinationLocation, $config);
+            $this->ensureParentDirectoryExists($destination, $config);
         } catch (Throwable $exception) {
             throw UnableToMoveFile::fromLocationTo($source, $destination, $exception);
         }


### PR DESCRIPTION
The method ensureParentDirectoryExists() expects an unprefixed path.

Fixes: thephpleague/flysystem-sftp#118