### PR TITLE
Fix mistake in UnableToCopyFile exception message

### DIFF
--- a/src/UnableToCopyFile.php
+++ b/src/UnableToCopyFile.php
@@ -34,7 +34,7 @@ final class UnableToCopyFile extends RuntimeException implements FilesystemOpera
         string $destinationPath,
         Throwable $previous = null
     ): UnableToCopyFile {
-        $e = new static("Unable to move file from $sourcePath to $destinationPath", 0 , $previous);
+        $e = new static("Unable to copy file from $sourcePath to $destinationPath", 0 , $previous);
         $e->source = $sourcePath;
         $e->destination = $destinationPath;
 


### PR DESCRIPTION
The UnableToCopyFile exception is probably a copy of UnableToMoveFile exception and thus by mistake the message was probably left untouched and still says 'move' instead of 'copy'.