### PR TITLE
Add explanation for missing `basename` metadata to v2 upgrade guide

### DIFF
--- a/v2/advanced/upgrade-to-2.0.0.md
+++ b/v2/advanced/upgrade-to-2.0.0.md
@@ -40,6 +40,15 @@ Plugin | Alternative
 `ListPaths` | Transform over the contents listing instead.
 `ListWith` | This operation is very unpredictable and has bad performance, don't use it.
 
+### `basename` is no longer precomputed
+
+These values are often part of a rename that can just as well incorporate functions like `basename()`.
+
+```diff
+- $name = $item['basename'];
++ $name = basename($item->path());
+```
+
 ## Changes
 
 ### Rename is now move, specific for files.


### PR DESCRIPTION
I've been looking for this information and found it by looking through the issues in this specific issue:
https://github.com/thephpleague/flysystem/issues/1251#issuecomment-776248022

I think this would be helpful to other people as well to find this more quickly in the future.

If this belongs somewhere else or the information needs to be worded differently, I'm more than happy to oblige. :slightly_smiling_face: 