### PR TITLE
Issue #1356: It should be possible not to use the visibility handler/visibility settings.

### DIFF
--- a/src/GoogleCloudStorage/PortableVisibilityHandler.php
+++ b/src/GoogleCloudStorage/PortableVisibilityHandler.php
@@ -11,6 +11,8 @@ use League\Flysystem\Visibility;
 
 class PortableVisibilityHandler implements VisibilityHandler
 {
+    public const NO_PREDEFINED_VISIBILITY = 'noPredefinedVisibility';
+
     public const ACL_PUBLIC_READ = 'publicRead';
     public const ACL_AUTHENTICATED_READ = 'authenticatedRead';
     public const ACL_PRIVATE = 'private';
@@ -65,10 +67,13 @@ class PortableVisibilityHandler implements VisibilityHandler
 
     public function visibilityToPredefinedAcl(string $visibility): string
     {
-        if ($visibility === Visibility::PUBLIC) {
-            return $this->predefinedPublicAcl;
+        switch ($visibility) {
+            case Visibility::PUBLIC:
+                return $this->predefinedPublicAcl;
+            case self::NO_PREDEFINED_VISIBILITY:
+                return self::NO_PREDEFINED_VISIBILITY;
+            default:
+                return $this->predefinedPrivateAcl;
         }
-
-        return $this->predefinedPrivateAcl;
     }
 }


### PR DESCRIPTION
### Context

See related issue #1356 

The [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) doesn't accept the predefinedAcl option to be set when performing actions on objects. I tried all default acl options, even null, and it ends up with following error: _Cannot insert legacy ACL for an object when uniform bucket-level access is enabled_

### Proposed solution

In order to ensure backward compatibility, it should be nice to have a new constant to bypass this settings.