### PR TITLE
Issue #1358: Impossible to set an empty prefix for Google Cloud Storage adapter.

### DIFF
--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -233,8 +233,11 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
     public function listContents(string $path, bool $deep): iterable
     {
         $prefixedPath = $this->prefixer->prefixPath($path);
-        $options = ['prefix' => rtrim($prefixedPath, '/') . '/'];
-        $prefixes = [];
+        $prefixes = $options = [];
+
+        if (! empty($prefixedPath)) {
+            $options = ['prefix' => sprintf('%s/', rtrim($prefixedPath, '/'))];
+        }
 
         if ($deep === false) {
             $options['delimiter'] = '/';


### PR DESCRIPTION
### Context

Please have a look at issue #1358.

### Proposed solution.

Solution proposed is to not automatically set **prefix** option when listing content. This option is only set when a prefix exists.