### PR TITLE
use storage visibility to prevent acl legacy error while copying

### DIFF
--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -278,8 +278,7 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
     public function copy(string $source, string $destination, Config $config): void
     {
         try {
-            /** @var string $visibility */
-            $visibility = $this->visibility($source)->visibility();
+            $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
             $prefixedSource = $this->prefixer->prefixPath($source);
             $options = ['name' => $this->prefixer->prefixPath($destination)];
             $predefinedAcl = $this->visibilityHandler->visibilityToPredefinedAcl($visibility);


### PR DESCRIPTION
Related to #1356 
The error still exists in "copy" method. The main point is that the visibility is accessed from the copied object which creates the same error:

```
{"error":{"code":400,"message":"Cannot get legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access","err  
  ors":[{"message":"Cannot get legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access","domain":"global",  
  "reason":"invalid"}]}}
```