### PR TITLE
Compatibility with PHP 8.1

### DIFF
--- a/src/ProxyArrayAccessToProperties.php
+++ b/src/ProxyArrayAccessToProperties.php
@@ -33,6 +33,7 @@ trait ProxyArrayAccessToProperties
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $property = $this->formatPropertyName((string) $offset);

--- a/src/ZipArchive/StubZipArchive.php
+++ b/src/ZipArchive/StubZipArchive.php
@@ -44,7 +44,7 @@ class StubZipArchive extends ZipArchive
      *
      * @return bool
      */
-    public function addEmptyDir($dirname, $flags = 0)
+    public function addEmptyDir($dirname, $flags = 0): bool
     {
         if ($this->failNextDirectoryCreation) {
             $this->failNextDirectoryCreation = false;
@@ -67,7 +67,7 @@ class StubZipArchive extends ZipArchive
      *
      * @return bool
      */
-    public function addFromString($localname, $contents, $flags = 0)
+    public function addFromString($localname, $contents, $flags = 0): bool
     {
         if ($this->failNextWrite) {
             $this->failNextWrite = false;
@@ -84,9 +84,9 @@ class StubZipArchive extends ZipArchive
     }
 
     /**
-     * @return bool|resource
+     * @return bool
      */
-    public function deleteName($name)
+    public function deleteName($name): bool
     {
         if ($this->failNextDeleteName) {
             $this->failNextDeleteName = false;
@@ -118,7 +118,7 @@ class StubZipArchive extends ZipArchive
         $this->failWhenDeletingAnIndex = true;
     }
 
-    public function deleteIndex($index)
+    public function deleteIndex($index): bool
     {
         if ($this->failWhenDeletingAnIndex) {
             $this->failWhenDeletingAnIndex = false;


### PR DESCRIPTION
See https://www.php.net/manual/tr/migration81.incompatible.php

> Most non-final internal methods now require overriding methods to declare a compatible return type, otherwise a deprecated notice is emitted during inheritance validation. In case the return type cannot be declared for an overriding method due to PHP cross-version compatibility concerns, a `#[ReturnTypeWillChange]` attribute can be added to silence the deprecation notice. 

This PR adds return types where they are compatible with PHP 7, and the attribute where they are not.