### PR TITLE
Fix: get the correct visibilities when listing the contents of the filesystem

### DIFF
--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -104,7 +104,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         );
         error_clear_last();
 
-        if (($size = @file_put_contents($prefixedLocation, $contents, $this->writeFlags)) === false) {
+        if (@file_put_contents($prefixedLocation, $contents, $this->writeFlags) === false) {
             throw UnableToWriteFile::atLocation($path, error_get_last()['message'] ?? '');
         }
 
@@ -217,7 +217,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter
             $path = $this->prefixer->stripPrefix($fileInfo->getPathname());
             $lastModified = $fileInfo->getMTime();
             $isDirectory = $fileInfo->isDir();
-            $permissions = $fileInfo->getPerms();
+            $permissions = octdec(substr(sprintf('%o', $fileInfo->getPerms()), -4));
             $visibility = $isDirectory ? $this->visibility->inverseForDirectory($permissions) : $this->visibility->inverseForFile($permissions);
 
             yield $isDirectory ? new DirectoryAttributes($path, $visibility, $lastModified) : new FileAttributes(

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -292,6 +292,33 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function retrieving_visibility_while_listing_directory_contents(): void
+    {
+        $adapter = new LocalFilesystemAdapter(static::ROOT);
+        $adapter->createDirectory('public', new Config(['visibility' => 'public']));
+        $adapter->createDirectory('private', new Config(['visibility' => 'private']));
+        $adapter->write('public/private.txt', 'private', new Config(['visibility' => 'private']));
+        $adapter->write('private/public.txt', 'public', new Config(['visibility' => 'public']));
+
+        /** @var Traversable<StorageAttributes> $contentListing */
+        $contentListing = $adapter->listContents('/', true);
+        /**
+         * @var StorageAttributes $publicDirectoryAttributes
+         * @var StorageAttributes $privateFileAttributes
+         * @var StorageAttributes $privateDirectoryAttributes
+         * @var StorageAttributes $publicFileAttributes
+         */
+        [$publicDirectoryAttributes, $privateFileAttributes, $privateDirectoryAttributes, $publicFileAttributes] = iterator_to_array($contentListing);
+
+        $this->assertEquals('public', $publicDirectoryAttributes->visibility());
+        $this->assertEquals('private', $privateFileAttributes->visibility());
+        $this->assertEquals('private', $privateDirectoryAttributes->visibility());
+        $this->assertEquals('public', $publicFileAttributes->visibility());
+    }
+
+    /**
+     * @test
+     */
     public function deleting_a_directory(): void
     {
         $adapter = new LocalFilesystemAdapter(static::ROOT);


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/splfileinfo.getperms#example-3683) of `SplFileInfo::getPerms()`, the permissions were not parsed correctly.
This resulted in incorrect visibilities when listing the contents of the filesystem.