### PR TITLE
Fixes #1370 create PrefixedFilesystem

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -18,6 +18,7 @@ use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\PrefixedFilesystem;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCheckFileExistence;
 use League\Flysystem\UnableToCopyFile;
@@ -30,6 +31,11 @@ use League\Flysystem\Visibility;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use League\MimeTypeDetection\MimeTypeDetector;
 use Throwable;
+
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class AsyncAwsS3Adapter implements FilesystemAdapter
 {
@@ -110,6 +116,13 @@ class AsyncAwsS3Adapter implements FilesystemAdapter
         $this->bucket = $bucket;
         $this->visibility = $visibility ?: new PortableVisibilityConverter();
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
+
+        if ($prefix !== '') {
+            trigger_error(
+                sprintf('Passing $prefix on %s is deprecated. Use %s.', self::class, PrefixedFilesystem::class),
+                E_USER_DEPRECATED
+            );
+        }
     }
 
     public function fileExists(string $path): bool

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -13,6 +13,7 @@ use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemOperationFailed;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\PrefixedFilesystem;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCheckFileExistence;
 use League\Flysystem\UnableToCopyFile;
@@ -27,6 +28,11 @@ use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use League\MimeTypeDetection\MimeTypeDetector;
 use Psr\Http\Message\StreamInterface;
 use Throwable;
+
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class AwsS3V3Adapter implements FilesystemAdapter
 {
@@ -119,6 +125,13 @@ class AwsS3V3Adapter implements FilesystemAdapter
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
         $this->options = $options;
         $this->streamReads = $streamReads;
+
+        if ($prefix !== '') {
+            trigger_error(
+                sprintf('Passing $prefix on %s is deprecated. Use %s.', self::class, PrefixedFilesystem::class),
+                E_USER_DEPRECATED
+            );
+        }
     }
 
     public function fileExists(string $path): bool

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -12,6 +12,7 @@ use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\PrefixedFilesystem;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToDeleteDirectory;
@@ -23,6 +24,11 @@ use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\Visibility;
 use Throwable;
+
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class GoogleCloudStorageAdapter implements FilesystemAdapter
 {
@@ -52,6 +58,13 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
         $this->prefixer = new PathPrefixer($prefix);
         $this->visibilityHandler = $visibilityHandler ?: new PortableVisibilityHandler();
         $this->defaultVisibility = $defaultVisibility;
+
+        if ($prefix !== '') {
+            trigger_error(
+                sprintf('Passing $prefix on %s is deprecated. Use %s.', self::class, PrefixedFilesystem::class),
+                E_USER_DEPRECATED
+            );
+        }
     }
 
     public function fileExists(string $path): bool

--- a/src/PrefixedFilesystem.php
+++ b/src/PrefixedFilesystem.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem;
+
+final class PrefixedFilesystem implements FilesystemOperator
+{
+    private $filesystem;
+    private $prefixer;
+
+    public function __construct(FilesystemOperator $filesystem, string $prefix)
+    {
+        $this->filesystem = $filesystem;
+        $this->prefixer = new PathPrefixer($prefix);
+    }
+
+    public function fileExists(string $location): bool
+    {
+        return $this->filesystem->fileExists($this->prefixer->prefixPath($location));
+    }
+
+    public function read(string $location): string
+    {
+        return $this->filesystem->read($this->prefixer->prefixPath($location));
+    }
+
+    public function readStream(string $location)
+    {
+        return $this->filesystem->readStream($this->prefixer->prefixPath($location));
+    }
+
+    public function listContents(string $location, bool $deep = self::LIST_SHALLOW): DirectoryListing
+    {
+        return $this->filesystem->listContents($this->prefixer->prefixPath($location), $deep);
+    }
+
+    public function lastModified(string $path): int
+    {
+        return $this->filesystem->lastModified($this->prefixer->prefixPath($path));
+    }
+
+    public function fileSize(string $path): int
+    {
+        return $this->filesystem->fileSize($this->prefixer->prefixPath($path));
+    }
+
+    public function mimeType(string $path): string
+    {
+        return $this->filesystem->mimeType($this->prefixer->prefixPath($path));
+    }
+
+    public function visibility(string $path): string
+    {
+        return $this->filesystem->visibility($this->prefixer->prefixPath($path));
+    }
+
+    public function write(string $location, string $contents, array $config = []): void
+    {
+        $this->filesystem->write($this->prefixer->prefixPath($location), $contents, $config);
+    }
+
+    public function writeStream(string $location, $contents, array $config = []): void
+    {
+        $this->filesystem->writeStream($this->prefixer->prefixPath($location), $contents, $config);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $this->filesystem->setVisibility($this->prefixer->prefixPath($path), $visibility);
+    }
+
+    public function delete(string $location): void
+    {
+        $this->filesystem->delete($this->prefixer->prefixPath($location));
+    }
+
+    public function deleteDirectory(string $location): void
+    {
+        $this->filesystem->deleteDirectory($this->prefixer->prefixPath($location));
+    }
+
+    public function createDirectory(string $location, array $config = []): void
+    {
+        $this->filesystem->createDirectory($this->prefixer->prefixPath($location), $config);
+    }
+
+    public function move(string $source, string $destination, array $config = []): void
+    {
+        $this->filesystem->move(
+            $this->prefixer->prefixPath($source),
+            $this->prefixer->prefixPath($destination),
+            $config
+        );
+    }
+
+    public function copy(string $source, string $destination, array $config = []): void
+    {
+        $this->filesystem->copy(
+            $this->prefixer->prefixPath($source),
+            $this->prefixer->prefixPath($destination),
+            $config
+        );
+    }
+}

--- a/src/PrefixedFilesystemTest.php
+++ b/src/PrefixedFilesystemTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function fopen;
+
+/**
+ * @group core
+ */
+class PrefixedFilesystemTest extends TestCase
+{
+    /**
+     * @var FilesystemOperator & MockObject
+     */
+    private $decorated;
+
+    /**
+     * @var PrefixedFilesystem
+     */
+    private $filesystem;
+
+    /**
+     * @before
+     */
+    public function setupFilesystem(): void
+    {
+        $this->decorated = $this->createMock(FilesystemOperator::class);
+        $this->filesystem = new PrefixedFilesystem($this->decorated, 'this_is_a_prefix');
+    }
+
+    public function testFileExists(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('fileExists')
+            ->with('this_is_a_prefix/file.txt')
+            ->willReturn(true);
+
+        self::assertTrue($this->filesystem->fileExists('file.txt'));
+    }
+
+    public function testRead(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('read')
+            ->with('this_is_a_prefix/file.txt')
+            ->willReturn('content');
+
+        self::assertSame('content', $this->filesystem->read('file.txt'));
+    }
+
+    public function testReadStream(): void
+    {
+        $stream = fopen('php://temp', 'r');
+        $this->decorated
+            ->expects(self::once())
+            ->method('readStream')
+            ->with('this_is_a_prefix/file.txt')
+            ->willReturn($stream);
+
+        self::assertSame($stream, $this->filesystem->readStream('file.txt'));
+    }
+
+    public function testListContents(): void
+    {
+        $directoryListing = new DirectoryListing([]);
+        $this->decorated
+            ->expects(self::once())
+            ->method('listContents')
+            ->with('this_is_a_prefix/dir', FilesystemReader::LIST_DEEP)
+            ->willReturn($directoryListing);
+
+        self::assertSame($directoryListing, $this->filesystem->listContents('dir', FilesystemReader::LIST_DEEP));
+    }
+
+    public function testLastModified(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('lastModified')
+            ->with('this_is_a_prefix/file.txt')
+            ->willReturn(1234);
+
+        self::assertSame(1234, $this->filesystem->lastModified('file.txt'));
+    }
+
+    public function testFileSize(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('fileSize')
+            ->with('this_is_a_prefix/file.txt')
+            ->willReturn(1234);
+
+        self::assertSame(1234, $this->filesystem->fileSize('file.txt'));
+    }
+
+    public function testMimeType(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('mimeType')
+            ->with('this_is_a_prefix/file.txt')
+            ->willReturn('text');
+
+        self::assertSame('text', $this->filesystem->mimeType('file.txt'));
+    }
+
+    public function testVisibility(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('visibility')
+            ->with('this_is_a_prefix/file.txt')
+            ->willReturn(Visibility::PRIVATE);
+
+        self::assertSame(Visibility::PRIVATE, $this->filesystem->visibility('file.txt'));
+    }
+
+    public function testWrite(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('write')
+            ->with('this_is_a_prefix/file.txt', 'lorem ipsum', ['config' => true]);
+
+        $this->filesystem->write('file.txt', 'lorem ipsum', ['config' => true]);
+    }
+
+    public function testWriteStream(): void
+    {
+        $stream = fopen('php://temp', 'r');
+        $this->decorated
+            ->expects(self::once())
+            ->method('writeStream')
+            ->with('this_is_a_prefix/file.txt', $stream, ['config' => true]);
+
+        $this->filesystem->writeStream('file.txt', $stream, ['config' => true]);
+    }
+
+    public function testSetVisibility(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('setVisibility')
+            ->with('this_is_a_prefix/file.txt', Visibility::PRIVATE);
+
+        $this->filesystem->setVisibility('file.txt', Visibility::PRIVATE);
+    }
+
+    public function testDelete(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('delete')
+            ->with('this_is_a_prefix/file.txt');
+
+        $this->filesystem->delete('file.txt');
+    }
+
+    public function testDeleteDirectory(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('deleteDirectory')
+            ->with('this_is_a_prefix/dir');
+
+        $this->filesystem->deleteDirectory('dir');
+    }
+
+    public function testCreateDirectory(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('createDirectory')
+            ->with('this_is_a_prefix/dir', ['config' => true]);
+
+        $this->filesystem->createDirectory('dir', ['config' => true]);
+    }
+
+    public function testMove(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('move')
+            ->with('this_is_a_prefix/file1.txt', 'this_is_a_prefix/file2.txt', ['config' => true]);
+
+        $this->filesystem->move('file1.txt', 'file2.txt', ['config' => true]);
+    }
+
+    public function testCopy(): void
+    {
+        $this->decorated
+            ->expects(self::once())
+            ->method('copy')
+            ->with('this_is_a_prefix/file1.txt', 'this_is_a_prefix/file2.txt', ['config' => true]);
+
+        $this->filesystem->copy('file1.txt', 'file2.txt', ['config' => true]);
+    }
+}


### PR DESCRIPTION
TODOs:
- Rework the bundle to add consistent behaviour to add prefix.

For LocalFilesystemAdapter and FtpAdapter I think it's fine to have internally prefixer.