### PR TITLE
Fix duplicate test implementation

### DIFF
--- a/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
+++ b/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
@@ -666,7 +666,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->expectException(UnableToReadFile::class);
 
-        $this->adapter()->readStream('something.txt');
+        $this->adapter()->read('something.txt');
     }
 
     /**


### PR DESCRIPTION
Currently `failing_to_read_a_non_existing_file_into_a_stream` and `failing_to_read_a_non_existing_file` are identical, I guess the second one is a bug and the intention was to refer to `read` method