### PR TITLE
FilesystemAdapterTestCase: always close stream handlers after use

### DIFF
--- a/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
+++ b/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
@@ -142,6 +142,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
             $writeStream = stream_with_contents('contents');
 
             $adapter->writeStream('path.txt', $writeStream, new Config());
+            fclose($writeStream);
             $fileExists = $adapter->fileExists('path.txt');
 
             $this->assertTrue($fileExists);
@@ -192,6 +193,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
             $writeStream = stream_with_contents('');
 
             $adapter->writeStream('path.txt', $writeStream, new Config());
+            fclose($writeStream);
             $fileExists = $adapter->fileExists('path.txt');
 
             $this->assertTrue($fileExists);


### PR DESCRIPTION
I had some issues with this two dandling streams left opened within the tests.