### PR TITLE
Update SftpAdapter.php

### DIFF
--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -187,7 +187,7 @@ class SftpAdapter implements FilesystemAdapter
 
     public function createDirectory(string $path, Config $config): void
     {
-        $this->makeDirectory($path, $config->get(Config::OPTION_VISIBILITY));
+        $this->makeDirectory($path, $config->get(Config::OPTION_DIRECTORY_VISIBILITY));
     }
 
     public function setVisibility(string $path, string $visibility): void


### PR DESCRIPTION
There is no reason I can find that would explain why createDirectory would call makeDirectory with Config::OPTION_VISIBILITY over Config::OPTION_DIRECTORY_VISIBILITY as in ensureParentDirectoryExists...