### PR TITLE
Insert 1.1.5 changelog that has gone missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - [FTP] Listing contents required escaping for special characters (caused missing contents and failure of directory deletes)
 
+## 1.1.5 - 2021-08-17
+
+### Fixed
+
+* [FTP] Do not fail when setting a connection to UTF-8 when it is already on UTF-8.
+
 ## 1.1.4 - 2021-05-22
 
 ### Fixed


### PR DESCRIPTION
https://github.com/thephpleague/flysystem/compare/1.1.4...1.1.5 has this changelog for 1.1.5 but somehow it went missing from the 1.x branch.