### PR TITLE
drop unnecessary ext-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         }
     },
     "require": {
-        "php": "^8.0.2",
-        "ext-json": "*",
+        "php": "^8.0.2"
         "league/mime-type-detection": "^1.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Because PHP8 has ext-json included, it's no longer necessary to have this line.

https://php.watch/versions/8.0/ext-json