### PR TITLE
Fix fails to get ACL header from config

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -170,7 +170,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
     {
         $key = $this->prefixer->prefixPath($path);
         $options = $this->createOptionsFromConfig($config);
-        $acl = $options['ACL'] ?? $this->determineAcl($config);
+        $acl = $options['params']['ACL'] ?? $this->determineAcl($config);
         $shouldDetermineMimetype = $body !== '' && ! array_key_exists('ContentType', $options['params']);
 
         if ($shouldDetermineMimetype && $mimeType = $this->mimeTypeDetector->detectMimeType($key, $body)) {


### PR DESCRIPTION
Fix ACL not being applied from config.

`createOptionsFromConfig()` stores configuration values under the `params` key.  
The adapter was attempting to read the ACL from `$options['ACL']`, which caused the value to be ignored.

This change retrieves the ACL from `$options['params']['ACL']`, ensuring it is correctly applied during S3 uploads.