### PR TITLE
SftpAdapter fix - check if the listing is not an array

### DIFF
--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -274,6 +274,10 @@ class SftpAdapter implements FilesystemAdapter
         $location = $this->prefixer->prefixPath(rtrim($path, '/')) . '/';
         $listing = $connection->rawlist($location, false);
 
+        if (false === $listing) {
+            return [];
+        }
+
         foreach ($listing as $filename => $attributes) {
             if ($filename === '.' || $filename === '..') {
                 continue;

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -275,7 +275,7 @@ class SftpAdapter implements FilesystemAdapter
         $listing = $connection->rawlist($location, false);
 
         if (false === $listing) {
-            return [];
+            return;
         }
 
         foreach ($listing as $filename => $attributes) {

--- a/src/PhpseclibV3/SftpAdapterTest.php
+++ b/src/PhpseclibV3/SftpAdapterTest.php
@@ -205,6 +205,15 @@ class SftpAdapterTest extends FilesystemAdapterTestCase
         }
     }
 
+    /**
+     * @test
+     */
+    public function list_contents_directory_does_not_exist(): void
+    {
+        $contents = $this->adapter()->listContents('/does_not_exist', false);
+        $this->assertCount(0, iterator_to_array($contents));
+    }
+
     private static function connectionProvider(): ConnectionProvider
     {
         if ( ! static::$connectionProvider instanceof ConnectionProvider) {


### PR DESCRIPTION
`$connection->rawlist` returns `array|false`. There was a check missing before trying to foreach `$listing` which resulted in 
 
`foreach() argument must be of type array|object, bool given` error.

The same check is already present in the PhpseclibV2 sftp adapter.