### PR TITLE
support custom metadata for objects for google cloud adapter

### DIFF
--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -132,6 +132,10 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
             $options['predefinedAcl'] = $predefinedAcl;
         }
 
+        if ($config->get('metadata')) {
+            $options['metadata'] = $config->get('metadata');
+        }
+
         try {
             $this->bucket->upload($contents, $options);
         } catch (Throwable $exception) {


### PR DESCRIPTION
You can specify metadata for Google Cloud objects to e.g. change the `Cache-Control` header or set completely custom meta tags. Currently, all custom parameters in the config object are removed. The code has been extended to pass them to the Google Storage driver if they are existent.

This is an alternative implementation to #1299 which is achieving the same result but is changing the code much less. The other pull request is additionally adding some automatic behavior to guess the mime-type which is inserted in the metadata. As automatic guessing can be wrong, this has not been implemented by me. With this minimalistic implementation, the mime-type (which is by the way also automatically detected by Google Cloud Storage) can be added manually by using the `['metadata' => ['contentType' => 'image/jpeg']]` config option.