### PR TITLE
Make timestamp configurable for InMemory adapter

### DIFF
--- a/src/InMemory/InMemoryFile.php
+++ b/src/InMemory/InMemoryFile.php
@@ -27,15 +27,23 @@ class InMemoryFile
      */
     private $visibility;
 
-    public function updateContents(string $contents): void
+    public function updateContents(string $contents, ?int $timestamp): void
     {
         $this->contents = $contents;
-        $this->lastModified = time();
+        $this->lastModified = $timestamp ?: time();
     }
 
     public function lastModified(): int
     {
         return $this->lastModified;
+    }
+
+    public function withLastModified(int $lastModified): self
+    {
+        $clone = clone $this;
+        $clone->lastModified = $lastModified;
+
+        return $clone;
     }
 
     public function read(): string

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -55,7 +55,7 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
     {
         $path = $this->preparePath($path);
         $file = $this->files[$path] = $this->files[$path] ?? new InMemoryFile();
-        $file->updateContents($contents);
+        $file->updateContents($contents, $config->get('timestamp'));
 
         $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
         $file->setVisibility($visibility);
@@ -249,7 +249,9 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
             throw UnableToCopyFile::fromLocationTo($source, $destination);
         }
 
-        $this->files[$destination] = clone $this->files[$source];
+        $lastModified = $config->get('timestamp', time());
+
+        $this->files[$destination] = $this->files[$source]->withLastModified($lastModified);
     }
 
     private function preparePath(string $path): string

--- a/src/InMemory/InMemoryFilesystemAdapterTest.php
+++ b/src/InMemory/InMemoryFilesystemAdapterTest.php
@@ -273,6 +273,22 @@ class InMemoryFilesystemAdapterTest extends FilesystemAdapterTestCase
         parent::fetching_unknown_mime_type_of_a_file();
     }
 
+    /**
+     * @test
+     */
+    public function using_custom_timestamp(): void
+    {
+        $adapter = $this->adapter();
+
+        $now = 100;
+        $adapter->write('file.txt', 'contents', new Config(['timestamp' => $now]));
+        $this->assertEquals($now, $adapter->lastModified('file.txt')->lastModified());
+
+        $earlier = 50;
+        $adapter->copy('file.txt', 'new_file.txt', new Config(['timestamp' => $earlier]));
+        $this->assertEquals($earlier, $adapter->lastModified('new_file.txt')->lastModified());
+    }
+
     protected static function createFilesystemAdapter(): FilesystemAdapter
     {
         return new InMemoryFilesystemAdapter();


### PR DESCRIPTION
Use an optional 'timestamp' option in the config to set the 'lastModified' attribute when writing or copying a file.
This allows using the memory adapter in testing environments for testing time-based behaviors.