### PR TITLE
made flags configurable for file_put_contents

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -10,6 +10,7 @@ class Config
 {
     public const OPTION_VISIBILITY = 'visibility';
     public const OPTION_DIRECTORY_VISIBILITY = 'directory_visibility';
+    public const WRITE_FLAG = 'write_flag';
 
     /**
      * @var array

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -117,9 +117,16 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         );
         error_clear_last();
 
-        if (@file_put_contents($prefixedLocation, $contents, $this->writeFlags) === false) {
+        if (!is_null($writeFlag = $config->get(Config::WRITE_FLAG))) {
+            $this->setWriteFlag($writeFlag);
+        }
+        $writeFlag = $this->writeFlag;
+
+
+        if (@file_put_contents($prefixedLocation, $contents, $writeFlag) === false) {
             throw UnableToWriteFile::atLocation($path, error_get_last()['message'] ?? '');
         }
+
 
         if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
             $this->setVisibility($path, (string) $visibility);
@@ -327,6 +334,11 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         if ( ! @mkdir($location, $permissions, true)) {
             throw UnableToCreateDirectory::atLocation($path, error_get_last()['message'] ?? '');
         }
+    }
+
+    public function setWriteFlag(int $writeFlag): void
+    {
+        $this->writeFlag = $writeFlag;
     }
 
     public function setVisibility(string $path, string $visibility): void


### PR DESCRIPTION
Hello,

in the new version you guys are trying to lock files before writing.

The NFS (Versions 2 and 3) protocol does not support file locking, but the NFS environment supports an ancillary protocol called NLM, which originally stood for "Network Lock Manager." When an NFS filesystem on an NFS client gets a request to lock a file, instead of an NFS remote procedure call, it generates an NLM remote procedure call.

To fix this our purpose is to allow clients to choose if use lock flag or not.

This requires a change also in /Illuminate/Filesystem/FilesystemManager.php adding the 'write_flag' to the allowed configurations.

Hope this helps, regards