### PR TITLE
Avoid type errors when public key is not retrieved

### DIFF
--- a/src/PhpseclibV2/SftpConnectionProvider.php
+++ b/src/PhpseclibV2/SftpConnectionProvider.php
@@ -143,7 +143,12 @@ class SftpConnectionProvider implements ConnectionProvider
             return;
         }
 
-        $publicKey = $connection->getServerPublicHostKey() ?: 'no-public-key';
+        $publicKey = $connection->getServerPublicHostKey();
+
+        if ($publicKey === false) {
+            throw UnableToEstablishAuthenticityOfHost::becauseTheAuthenticityCantBeEstablished($this->host);
+        }
+
         $fingerprint = $this->getFingerprintFromPublicKey($publicKey);
 
         if (0 !== strcasecmp($this->hostFingerprint, $fingerprint)) {

--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -150,7 +150,12 @@ class SftpConnectionProvider implements ConnectionProvider
             return;
         }
 
-        $publicKey = $connection->getServerPublicHostKey() ?: 'no-public-key';
+        $publicKey = $connection->getServerPublicHostKey();
+
+        if ($publicKey === false) {
+            throw UnableToEstablishAuthenticityOfHost::becauseTheAuthenticityCantBeEstablished($this->host);
+        }
+
         $fingerprint = $this->getFingerprintFromPublicKey($publicKey);
 
         if (0 !== strcasecmp($this->hostFingerprint, $fingerprint)) {


### PR DESCRIPTION
When dealing with unstable connections, phpseclib may return `false` when retrieving the public key.  That causes `null` to be passed down to `base64_decode()` and triggers a TypeError due to strict types.

This exits early, preventing triggering the problem.
However, testing is a bit tricky since we need an unstable connection (or stub things).