### PR TITLE
Fix SFTP retry mechanism

### DIFF
--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Flysystem\PhpseclibV3;
 
+use League\Flysystem\FilesystemException;
 use phpseclib3\Crypt\Common\AsymmetricKey;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Exception\NoKeyLoadedException;
@@ -137,7 +138,10 @@ class SftpConnectionProvider implements ConnectionProvider
             $this->authenticate($connection);
         } catch (Throwable $exception) {
             $connection->disconnect();
-            throw $exception;
+
+            if ($exception instanceof FilesystemException) {
+                throw $exception;
+            }
         }
 
         return $connection;

--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -9,7 +9,6 @@ use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Exception\NoKeyLoadedException;
 use phpseclib3\Net\SFTP;
 use phpseclib3\System\SSH\Agent;
-use RuntimeException;
 use Throwable;
 
 use function base64_decode;
@@ -229,8 +228,6 @@ class SftpConnectionProvider implements ConnectionProvider
         } catch (NoKeyLoadedException $exception) {
             throw new UnableToLoadPrivateKey();
         }
-
-        throw new RuntimeException();
     }
 
     private function authenticateWithAgent(SFTP $connection): void


### PR DESCRIPTION
As of phpseclib v3 `RuntimeException` objects are thrown, causing the whole retry logic to be bypassed.

This makes sure to re-attempt to connect when timeout or connection issues happen.

FIxes #1450 