### PR TITLE
Verify SFTP retries when dealing with peer resets 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,3 +44,15 @@ services:
       - "2122:21"
       - "30000-30009:30000-30009"
     command: "/run.sh -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -P localhost"
+  toxiproxy:
+    container_name: toxiproxy
+    restart: unless-stopped
+    image: ghcr.io/shopify/toxiproxy
+    command: "-host 0.0.0.0 -config /opt/toxiproxy/config.json"
+    volumes:
+      - ./test_files/toxiproxy/toxiproxy.json:/opt/toxiproxy/config.json:ro
+    ports:
+      - "8474:8474" # HTTP API
+      - "8222:8222" # SFTP
+      - "8121:8121" # FTP
+      - "8122:8122" # FTPD

--- a/src/AdapterTestUtilities/ToxiproxyManagement.php
+++ b/src/AdapterTestUtilities/ToxiproxyManagement.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\AdapterTestUtilities;
+
+use GuzzleHttp\Client;
+
+/**
+ * This class provides a client for the HTTP API provided by the proxy that simulates network issues.
+ *
+ * @see https://github.com/shopify/toxiproxy#http-api
+ *
+ * @phpstan-type RegisteredProxies 'ftp'|'sftp'|'ftpd'
+ * @phpstan-type StreamDirection 'upstream'|'downstream'
+ * @phpstan-type Type 'latency'|'bandwidth'|'slow_close'|'timeout'|'reset_peer'|'slicer'|'limit_data'
+ * @phpstan-type Attributes array{latency?: int, jitter?: int, rate?: int, delay?: int}
+ * @phpstan-type Toxic array{name?: string, type: Type, stream?: StreamDirection, toxicity?: float, attributes: Attributes}
+ */
+final class ToxiproxyManagement
+{
+    /** @var Client */
+    private $apiClient;
+
+    public function __construct(Client $apiClient)
+    {
+        $this->apiClient = $apiClient;
+    }
+
+    public static function forServer(string $apiUri = 'http://localhost:8474'): self
+    {
+        return new self(
+            new Client(
+                [
+                    'base_uri' => $apiUri,
+                    'base_url' => $apiUri, // Compatibility with older versions of Guzzle
+                ]
+            )
+        );
+    }
+
+    public function removeAllToxics(): void
+    {
+        $this->apiClient->post('/reset');
+    }
+
+    /**
+     * Simulates a peer reset on the client->server direction.
+     *
+     * @param RegisteredProxies $proxyName
+     */
+    public function resetPeerOnRequest(
+        string $proxyName,
+        int $timeoutInMilliseconds
+    ): void {
+        $configuration = [
+            'type' => 'reset_peer',
+            'stream' => 'upstream',
+            'attributes' => ['timeout' => $timeoutInMilliseconds],
+        ];
+
+        $this->addToxic($proxyName, $configuration);
+    }
+
+    /**
+     * Registers a network toxic for the given proxy.
+     *
+     * @param RegisteredProxies $proxyName
+     * @param Toxic $configuration
+     */
+    private function addToxic(string $proxyName, array $configuration): void
+    {
+        $this->apiClient->post('/proxies/' . $proxyName . '/toxics', ['json' => $configuration]);
+    }
+}

--- a/src/PhpseclibV3/SftpConnectionProviderTest.php
+++ b/src/PhpseclibV3/SftpConnectionProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Flysystem\PhpseclibV3;
 
+use League\Flysystem\AdapterTestUtilities\ToxiproxyManagement;
 use phpseclib3\Net\SFTP;
 use PHPUnit\Framework\TestCase;
 
@@ -239,6 +240,52 @@ class SftpConnectionProviderTest extends TestCase
             ]
         );
         $provider->provideConnection();
+    }
+
+    /**
+     * @test
+     */
+    public function retries_several_times_until_failure(): void
+    {
+        $connectivityChecker = new class implements ConnectivityChecker {
+            /** @var int */
+            public $calls = 0;
+
+            public function isConnected(SFTP $connection): bool
+            {
+                ++$this->calls;
+
+                return $connection->isConnected();
+            }
+        };
+
+        $managesConnectionToxics = ToxiproxyManagement::forServer();
+        $managesConnectionToxics->resetPeerOnRequest('sftp', 10);
+
+        $maxTries = 5;
+
+        $provider = SftpConnectionProvider::fromArray(
+            [
+                'host' => 'localhost',
+                'username' => 'bar',
+                'privateKey' => __DIR__ . '/../../test_files/sftp/id_rsa',
+                'passphrase' => 'secret',
+                'port' => 8222,
+                'maxTries' => $maxTries,
+                'timeout' => 1,
+                'connectivityChecker' => $connectivityChecker,
+            ]
+        );
+
+        $this->expectException(UnableToConnectToSftpHost::class);
+
+        try {
+            $provider->provideConnection();
+        } finally {
+            $managesConnectionToxics->removeAllToxics();
+
+            self::assertSame($maxTries + 1, $connectivityChecker->calls);
+        }
     }
 
     private function computeFingerPrint(string $publicKey): string

--- a/test_files/toxiproxy/toxiproxy.json
+++ b/test_files/toxiproxy/toxiproxy.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "sftp",
+    "listen": "[::]:8222",
+    "upstream": "sftp:22",
+    "enabled": true
+  },
+  {
+    "name": "ftp",
+    "listen": "[::]:8121",
+    "upstream": "ftp:21",
+    "enabled": true
+  },
+  {
+    "name": "ftpd",
+    "listen": "[::]:8122",
+    "upstream": "ftpd:21",
+    "enabled": true
+  }
+]


### PR DESCRIPTION
This verifies that Flysystem SFTP adapter goes through all the configured tries before throwing an `UnableToConnectToSftpHost` exception.

Reverting the fix applied in https://github.com/thephpleague/flysystem/pull/1451 makes the test to fail due to an unexpected `RuntimeException`.

Applying this for phpseclib v2 is a bit tricky, though, due to the lack of knowledge on what has happened in the flow (e.g. `false` is returned when a connection cannot be established or when an authentication error happened). To make it work, the adapter for that version would need to verify if there's a connection or not all the time - which doesn't sound very good to me.