### PR TITLE
use absolute uri as destination header for webdav

### DIFF
--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -336,7 +336,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
         try {
             $response = $this->client->request('MOVE', '/' . ltrim($location, '/'), null, [
-                'Destination' => '/' . ltrim($newLocation, '/'),
+                'Destination' => $this->client->getAbsoluteUrl('/' . ltrim($newLocation, '/')),
             ]);
 
             if ($response['statusCode'] < 200 || $response['statusCode'] >= 300) {
@@ -372,7 +372,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
         try {
             $response = $this->client->request('COPY', '/' . ltrim($location, '/'), null, [
-                'Destination' => '/' . ltrim($newLocation, '/'),
+                'Destination' => $this->client->getAbsoluteUrl('/' . ltrim($newLocation, '/')),
             ]);
 
             if ($response['statusCode'] < 200 || $response['statusCode'] >= 300) {


### PR DESCRIPTION
Apache mod_dav expects an absolute uri for destination header for methods like `MOVE` and `COPY`.
Related issue: https://github.com/thephpleague/flysystem-webdav/issues/40