### PR TITLE
docs: add s3 IAM permissions

### DIFF
--- a/docs/adapter/async-aws-s3.md
+++ b/docs/adapter/async-aws-s3.md
@@ -75,3 +75,5 @@ $client = new AsyncAws\SimpleS3\SimpleS3Client();
 $adapter = new League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter($client, 'bucket-name');
 $filesystem = new League\Flysystem\Filesystem($adapter);
 ```
+
+You can read about required IAM permissions in [docs about AWS S3 adapter](/docs/adapter/aws-s3-v3/).

--- a/docs/adapter/aws-s3-v3.md
+++ b/docs/adapter/aws-s3-v3.md
@@ -59,3 +59,29 @@ $adapter = new League\Flysystem\AwsS3V3\AwsS3V3Adapter(
 $filesystem = new League\Flysystem\Filesystem($adapter);
 ```
 
+## IAM Permissions
+
+The required IAM permissions are as followed:
+
+~~~ json
+ {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:GetObjectAcl",
+                "s3:PutObjectAcl",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-bucket-name",
+                "arn:aws:s3:::your-bucket-name/*"
+            ]
+        }
+    ]
+}
+~~~


### PR DESCRIPTION
This PR adds S3 required IAM permissions in order to use flysystem.

It is basically an updated port of https://github.com/thephpleague/flysystem/commit/810ff30369779b4b289f2ceb237047db70db78e1.