### PR TITLE
[PHP 8.2] Fix deprecated `${var}` string interpolation patterns

### DIFF
--- a/src/UnableToCheckExistence.php
+++ b/src/UnableToCheckExistence.php
@@ -11,7 +11,7 @@ class UnableToCheckExistence extends RuntimeException implements FilesystemOpera
 {
     public static function forLocation(string $path, Throwable $exception = null): static
     {
-        return new static("Unable to check existence for: ${path}", 0, $exception);
+        return new static("Unable to check existence for: {$path}", 0, $exception);
     }
 
     public function operation(): string

--- a/src/UnableToCreateDirectory.php
+++ b/src/UnableToCreateDirectory.php
@@ -16,7 +16,7 @@ final class UnableToCreateDirectory extends RuntimeException implements Filesyst
 
     public static function atLocation(string $dirname, string $errorMessage = ''): UnableToCreateDirectory
     {
-        $message = "Unable to create a directory at {$dirname}. ${errorMessage}";
+        $message = "Unable to create a directory at {$dirname}. {$errorMessage}";
         $e = new static(rtrim($message));
         $e->location = $dirname;
 


### PR DESCRIPTION
PHP 8.2 deprecates string interpolation patterns that place the dollar sign outside the curly braces. This fixes such patterns by replacing them with proper curly braced patterns.

Reference:
 - [PHP.Watch: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated)
 - [wiki.php.net RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)