### PR TITLE
Local Adapter: Lock files during read when LOCK_EX flag is set

### DIFF
--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -254,10 +254,11 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         $location = $this->prefixer->prefixPath($path);
 
         if ($this->writeFlags & LOCK_EX) {
+            error_clear_last();
             $fileHandle = fopen($location, 'rb');
 
             if ($fileHandle === false) {
-                return false;
+                throw UnableToReadFile::fromLocation($path, error_get_last()['message'] ?? '');
             }
 
             flock($fileHandle, LOCK_SH);

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Flysystem\Local;
 
-use function file_put_contents;
 use const DIRECTORY_SEPARATOR;
 use const LOCK_EX;
 use DirectoryIterator;
@@ -38,11 +37,11 @@ use function dirname;
 use function error_clear_last;
 use function error_get_last;
 use function file_exists;
+use function file_put_contents;
 use function is_dir;
 use function is_file;
 use function mkdir;
 use function rename;
-use function stream_copy_to_stream;
 
 class LocalFilesystemAdapter implements FilesystemAdapter
 {
@@ -253,11 +252,31 @@ class LocalFilesystemAdapter implements FilesystemAdapter
     public function read(string $path): string
     {
         $location = $this->prefixer->prefixPath($path);
+
+        if ($this->writeFlags & LOCK_EX) {
+            $fileHandle = fopen($location, 'rb');
+
+            if ($fileHandle === false) {
+                return false;
+            }
+
+            flock($fileHandle, LOCK_SH);
+        }
+
         error_clear_last();
         $contents = @file_get_contents($location);
 
         if ($contents === false) {
-            throw UnableToReadFile::fromLocation($path, error_get_last()['message'] ?? '');
+            $lastError = error_get_last();
+        }
+
+        if ($this->writeFlags & LOCK_EX && ($fileHandle ?? false) !== false) {
+            flock($fileHandle, LOCK_UN);
+            fclose($fileHandle);
+        }
+
+        if ($contents === false) {
+            throw UnableToReadFile::fromLocation($path, $lastError['message'] ?? '');
         }
 
         return $contents;
@@ -271,6 +290,10 @@ class LocalFilesystemAdapter implements FilesystemAdapter
 
         if ($contents === false) {
             throw UnableToReadFile::fromLocation($path, error_get_last()['message'] ?? '');
+        }
+
+        if ($this->writeFlags & LOCK_EX && $contents !== false) {
+            flock($contents, LOCK_SH);
         }
 
         return $contents;


### PR DESCRIPTION
Currently the Local Adapter will lock files with the "LOCK_EX" flag by default during write.
However, during read locks are completely ignored.

This PR will set read (shared) locks during reads.
This will fix reading corrupted data while a write is happening.

I encountered this issue (corrupted files) while using the php-cache library, which is using flystem for read and write operations ( https://github.com/php-cache/cache/blob/master/src/Adapter/Filesystem/FilesystemCachePool.php#L19 ).

Note: in readStream() the lock is obtained but never released, but this should be fine, because it will be automatically released during "fclose()". 