### PR TITLE
Local Adapter: Lock files during read when LOCK_EX flag is set

### DIFF
--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -254,10 +254,11 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         $location = $this->prefixer->prefixPath($path);
 
         if ($this->writeFlags & LOCK_EX) {
+            error_clear_last();
             $fileHandle = fopen($location, 'rb');
 
             if ($fileHandle === false) {
-                return false;
+                throw UnableToReadFile::fromLocation($path, error_get_last()['message'] ?? '');
             }
 
             flock($fileHandle, LOCK_SH);


### PR DESCRIPTION
Currently the Local Adapter will lock files with the "LOCK_EX" flag by default during write.
However, during read locks are completely ignored.

This PR will set read (shared) locks during reads.
This will fix reading corrupted data while a write is happening.

I encountered this issue (corrupted files) while using the php-cache library, which is using flystem for read and write operations ( https://github.com/php-cache/cache/blob/master/src/Adapter/Filesystem/FilesystemCachePool.php#L19 ).

Note: in readStream() the lock is obtained but never released, but this should be fine, because it will be automatically released during "fclose()". 