### PR TITLE
Add prefix filesystem

### DIFF
--- a/src/PrefixFilesystem.php
+++ b/src/PrefixFilesystem.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace League\Flysystem;
+
+class PrefixFilesystem implements FilesystemOperator
+{
+    protected FilesystemOperator $filesystem;
+    private string $prefix;
+
+    /**
+     * @internal
+     */
+    public function __construct(FilesystemOperator $filesystem, string $prefix)
+    {
+        if (empty($prefix)) {
+            throw new \InvalidArgumentException('The prefix must not be empty.');
+        }
+
+        $this->filesystem = $filesystem;
+        $this->prefix = trim($prefix, '/') . '/';
+    }
+
+    public function has(string $location): bool
+    {
+        $location = $this->preparePath($location);
+
+        return $this->filesystem->has($location);
+    }
+
+    public function read(string $location): string
+    {
+        $location = $this->preparePath($location);
+
+        return $this->filesystem->read($location);
+    }
+
+    public function readStream(string $location)
+    {
+        $location = $this->preparePath($location);
+
+        return $this->filesystem->readStream($location);
+    }
+
+    public function listContents(string $location, bool $deep = self::LIST_SHALLOW): DirectoryListing
+    {
+        $location = $this->preparePath($location);
+
+        return new DirectoryListing(array_map(
+            function (StorageAttributes $info) {
+                if ($info instanceof DirectoryAttributes) {
+                    return new DirectoryAttributes(
+                        $this->stripPath($info->path()),
+                        $info->visibility(),
+                        $info->lastModified(),
+                        $info->extraMetadata()
+                    );
+                }
+
+                if ($info instanceof FileAttributes) {
+                    return new FileAttributes(
+                        $this->stripPath($info->path()),
+                        $info->fileSize(),
+                        $info->visibility(),
+                        $info->lastModified(),
+                        $info->mimeType(),
+                        $info->extraMetadata()
+                    );
+                }
+
+                return $info;
+            },
+            $this->filesystem->listContents($location, $deep)->toArray()
+        ));
+    }
+
+    public function fileExists(string $location): bool
+    {
+        $location = $this->preparePath($location);
+
+        return $this->filesystem->fileExists($location);
+    }
+
+    public function directoryExists(string $location): bool
+    {
+        $location = $this->preparePath($location);
+
+        return $this->filesystem->directoryExists($location);
+    }
+
+    public function lastModified(string $path): int
+    {
+        $path = $this->preparePath($path);
+
+        return $this->filesystem->lastModified($path);
+    }
+
+    public function fileSize(string $path): int
+    {
+        $path = $this->preparePath($path);
+
+        return $this->filesystem->fileSize($path);
+    }
+
+    public function mimeType(string $path): string
+    {
+        $path = $this->preparePath($path);
+
+        return $this->filesystem->mimeType($path);
+    }
+
+    public function visibility(string $path): string
+    {
+        $path = $this->preparePath($path);
+
+        return $this->filesystem->visibility($path);
+    }
+
+    public function write(string $location, string $contents, array $config = []): void
+    {
+        $location = $this->preparePath($location);
+
+        $this->filesystem->write($location, $contents, $config);
+    }
+
+    public function writeStream(string $location, $contents, array $config = []): void
+    {
+        $location = $this->preparePath($location);
+
+        $this->filesystem->writeStream($location, $contents, $config);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $path = $this->preparePath($path);
+
+        $this->filesystem->setVisibility($path, $visibility);
+    }
+
+    public function delete(string $location): void
+    {
+        $location = $this->preparePath($location);
+
+        $this->filesystem->delete($location);
+    }
+
+    public function deleteDirectory(string $location): void
+    {
+        $location = $this->preparePath($location);
+
+        $this->filesystem->deleteDirectory($location);
+    }
+
+    public function createDirectory(string $location, array $config = []): void
+    {
+        $location = $this->preparePath($location);
+
+        $this->filesystem->createDirectory($location, $config);
+    }
+
+    public function move(string $source, string $destination, array $config = []): void
+    {
+        $source = $this->preparePath($source);
+        $destination = $this->preparePath($destination);
+
+        $this->filesystem->move($source, $destination, $config);
+    }
+
+    public function copy(string $source, string $destination, array $config = []): void
+    {
+        $source = $this->preparePath($source);
+        $destination = $this->preparePath($destination);
+
+        $this->filesystem->copy($source, $destination, $config);
+    }
+
+    private function stripPath(string $path): string
+    {
+        $prefix = rtrim($this->prefix, '/');
+        $path = preg_replace('#^' . preg_quote($prefix, '#') . '#', '', $path);
+
+        return ltrim($path, '/');
+    }
+
+    private function preparePath(string $path): string
+    {
+        return $this->prefix . $path;
+    }
+}

--- a/src/PrefixFilesystemTest.php
+++ b/src/PrefixFilesystemTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace League\Flysystem;
+
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+
+class PrefixFilesystemTest extends TestCase
+{
+    public function testPrefix(): void
+    {
+        $fs = new Filesystem(new InMemoryFilesystemAdapter());
+        $prefix = new PrefixFilesystem($fs, 'foo');
+
+        $prefix->write('foo.txt', 'bla');
+        static::assertTrue($prefix->fileExists('foo.txt'));
+        static::assertTrue($prefix->has('foo.txt'));
+        static::assertFalse($prefix->directoryExists('foo.txt'));
+        static::assertTrue($fs->has('foo/foo.txt'));
+        static::assertFalse($fs->directoryExists('foo/foo.txt'));
+
+        static::assertSame('bla', $prefix->read('foo.txt'));
+        static::assertSame('bla', stream_get_contents($prefix->readStream('foo.txt')));
+        static::assertSame('text/plain', $prefix->mimeType('foo.txt'));
+        static::assertSame(3, $prefix->fileSize('foo.txt'));
+        static::assertSame(Visibility::PUBLIC, $prefix->visibility('foo.txt'));
+        $prefix->setVisibility('foo.txt', Visibility::PRIVATE);
+        static::assertSame(Visibility::PRIVATE, $prefix->visibility('foo.txt'));
+        static::assertEqualsWithDelta($prefix->lastModified('foo.txt'), time(), 2);
+
+        $prefix->copy('foo.txt', 'bla.txt');
+        static::assertTrue($prefix->has('bla.txt'));
+
+        $prefix->createDirectory('dir');
+        static::assertTrue($prefix->directoryExists('dir'));
+        static::assertFalse($prefix->directoryExists('dir2'));
+        $prefix->deleteDirectory('dir');
+        static::assertFalse($prefix->directoryExists('dir'));
+
+        $prefix->move('bla.txt', 'bla2.txt');
+        static::assertFalse($prefix->has('bla.txt'));
+        static::assertTrue($prefix->has('bla2.txt'));
+
+        $prefix->delete('bla2.txt');
+        static::assertFalse($prefix->has('bla2.txt'));
+
+        $prefix->createDirectory('test');
+
+        $files = $prefix->listContents('', true)->toArray();
+        static::assertCount(2, $files);
+    }
+
+    public function testWriteStream(): void
+    {
+        $fs = new Filesystem(new InMemoryFilesystemAdapter());
+        $prefix = new PrefixFilesystem($fs, 'foo');
+        $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
+        file_put_contents($tmpFile, 'test');
+
+        $prefix->writeStream('a.txt', fopen($tmpFile, 'rb'));
+
+        static::assertTrue($prefix->fileExists('a.txt'));
+        static::assertSame('test', $prefix->read('a.txt'));
+        static::assertSame('test', stream_get_contents($prefix->readStream('a.txt')));
+
+        unlink($tmpFile);
+    }
+
+    public function testEmptyPrefix(): void
+    {
+        static::expectException(\InvalidArgumentException::class);
+        new PrefixFilesystem(new Filesystem(new InMemoryFilesystemAdapter()), '');
+    }
+}


### PR DESCRIPTION
I am currently upgrading to Flysystem v3 and saw the issue #1458, so I wanted to contribute our own implementation of prefixing.

We have in our application a global public filesystem and each extension gets an own prefixed filesystem inside this. So we can enforce extensions, that they write into an own folder.