### PR TITLE
Update SftpConnectionProvider.php

### DIFF
--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -228,20 +228,25 @@ class SftpConnectionProvider implements ConnectionProvider
 
     private function loadPrivateKey(): AsymmetricKey
     {
-        if ("---" !== substr($this->privateKey, 0, 3) && is_file($this->privateKey)) {
+        if (is_file($this->privateKey)) {
             $this->privateKey = file_get_contents($this->privateKey);
-        }
-
-        try {
-            if ($this->passphrase !== null) {
-                return PublicKeyLoader::load($this->privateKey, $this->passphrase);
-            }
-
-            return PublicKeyLoader::load($this->privateKey);
-        } catch (NoKeyLoadedException $exception) {
+        } else
             throw new UnableToLoadPrivateKey();
-        }
+
+        if (str_starts_with($this->privateKey, "---")) {
+            try {
+                if ($this->passphrase !== null) {
+                    return PublicKeyLoader::load($this->privateKey, $this->passphrase);
+                }
+
+                return PublicKeyLoader::load($this->privateKey);
+            } catch (NoKeyLoadedException $exception) {
+                throw new UnableToLoadPrivateKey();
+            }
+        } else
+            throw new UnableToLoadPrivateKey();
     }
+
 
     private function authenticateWithAgent(SFTP $connection): void
     {


### PR DESCRIPTION
6a19b50c(Fix a logic error on private key file), closes #1495 

Since 3.x, SFTP private key must be stored as files. Checking for file starting with proper comment is not well managed.

Thus I propose theses changes to cope with this new requirement

HTH