### PR TITLE
Reenable phpstan

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -61,8 +61,5 @@ jobs:
       - run: composer require --dev --with-all-dependencies phpseclib/phpseclib:^3.0 --no-progress ${{ matrix.composer-flags }}
       - run: vendor/bin/phpunit --group phpseclib3 ${{ matrix.phpunit-flags }}
       - run: vendor/bin/phpstan analyse
-        if: ${{ matrix.php == '7.4' }}
       - run: vendor/bin/php-cs-fixer fix --diff --dry-run
         continue-on-error: true
-        if: ${{ matrix.php == '7.4' }}
-

--- a/src/AwsS3V3/AwsS3V3AdapterTest.php
+++ b/src/AwsS3V3/AwsS3V3AdapterTest.php
@@ -121,6 +121,7 @@ class AwsS3V3AdapterTest extends FilesystemAdapterTestCase
 
     /**
      * @test
+     *
      * @see https://github.com/thephpleague/flysystem-aws-s3-v3/issues/291
      */
     public function issue_291(): void

--- a/src/AzureBlobStorage/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorage/AzureBlobStorageAdapter.php
@@ -111,7 +111,7 @@ class AzureBlobStorageAdapter implements FilesystemAdapter
         return stream_get_contents($response);
     }
 
-    public function readStream($path)
+    public function readStream(string $path)
     {
         $location = $this->prefixer->prefixPath($path);
 
@@ -273,6 +273,11 @@ class AzureBlobStorageAdapter implements FilesystemAdapter
         $this->upload($path, $contents, $config);
     }
 
+    /**
+     * @param string          $destination
+     * @param string|resource $contents
+     * @param Config          $config
+     */
     private function upload(string $destination, $contents, Config $config): void
     {
         $resolved = $this->prefixer->prefixPath($destination);

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -452,7 +452,9 @@ class FtpAdapter implements FilesystemAdapter
 
         if ($isDirectory) {
             return new DirectoryAttributes(
-                $path, $this->visibilityConverter->inverseForDirectory($permissions), $lastModified
+                $path,
+                $this->visibilityConverter->inverseForDirectory($permissions),
+                $lastModified
             );
         }
 

--- a/src/GoogleCloudStorage/StubRiggedBucket.php
+++ b/src/GoogleCloudStorage/StubRiggedBucket.php
@@ -12,12 +12,12 @@ class StubRiggedBucket extends Bucket
 {
     private array $triggers = [];
 
-    public function failForObject($name, ?Throwable $throwable = null): void
+    public function failForObject(string $name, ?Throwable $throwable = null): void
     {
         $this->setupTrigger('object', $name, $throwable);
     }
 
-    public function failForUpload($name, ?Throwable $throwable = null): void
+    public function failForUpload(string $name, ?Throwable $throwable = null): void
     {
         $this->setupTrigger('upload', $name, $throwable);
     }

--- a/src/Local/FallbackMimeTypeDetector.php
+++ b/src/Local/FallbackMimeTypeDetector.php
@@ -21,7 +21,8 @@ class FallbackMimeTypeDetector implements MimeTypeDetector
     public function __construct(
         private MimeTypeDetector $detector,
         private array $inconclusiveMimetypes = self::INCONCLUSIVE_MIME_TYPES
-    ) {}
+    ) {
+    }
 
     public function detectMimeType(string $path, $contents): ?string
     {

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace League\Flysystem\Local;
 
-use League\Flysystem\FilesystemException;
-use Throwable;
 use const DIRECTORY_SEPARATOR;
 use const LOCK_EX;
 use DirectoryIterator;

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Flysystem\Local;
 
-use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use const LOCK_EX;
 use League\Flysystem\AdapterTestUtilities\FilesystemAdapterTestCase;
 use League\Flysystem\Config;
@@ -24,6 +23,7 @@ use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\Visibility;
 use League\MimeTypeDetection\EmptyExtensionToMimeTypeMap;
 use League\MimeTypeDetection\ExtensionMimeTypeDetector;
+use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use Traversable;
 use function file_get_contents;
 use function file_put_contents;
@@ -83,6 +83,7 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
 
     /**
      * @test
+     *
      * @see https://github.com/thephpleague/flysystem/issues/1442
      */
     public function falling_back_to_extension_lookup_when_finding_mime_type_of_empty_file(): void

--- a/src/PhpseclibV3/SftpConnectionProviderTest.php
+++ b/src/PhpseclibV3/SftpConnectionProviderTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace League\Flysystem\PhpseclibV3;
 
 use League\Flysystem\AdapterTestUtilities\ToxiproxyManagement;
-use phpseclib3\Exception\NoSupportedAlgorithmsException;
 use phpseclib3\Net\SFTP;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
When working on another PR, I noticed that phpstan is disabled in the current GitHub workflow. Since there were already some errors occuring on the current code state, I figured it might be useful to reenable this on the `3.x` branch with current PHP versions.