### PR TITLE
Add more specific return types to DirectoryAttributes and FileAttributes methods

### DIFF
--- a/src/DirectoryAttributes.php
+++ b/src/DirectoryAttributes.php
@@ -76,7 +76,7 @@ class DirectoryAttributes implements StorageAttributes
         return true;
     }
 
-    public function withPath(string $path): StorageAttributes
+    public function withPath(string $path): self
     {
         $clone = clone $this;
         $clone->path = $path;
@@ -84,7 +84,7 @@ class DirectoryAttributes implements StorageAttributes
         return $clone;
     }
 
-    public static function fromArray(array $attributes): StorageAttributes
+    public static function fromArray(array $attributes): self
     {
         return new DirectoryAttributes(
             $attributes[StorageAttributes::ATTRIBUTE_PATH],

--- a/src/FileAttributes.php
+++ b/src/FileAttributes.php
@@ -104,7 +104,7 @@ class FileAttributes implements StorageAttributes
         return false;
     }
 
-    public function withPath(string $path): StorageAttributes
+    public function withPath(string $path): self
     {
         $clone = clone $this;
         $clone->path = $path;
@@ -112,7 +112,7 @@ class FileAttributes implements StorageAttributes
         return $clone;
     }
 
-    public static function fromArray(array $attributes): StorageAttributes
+    public static function fromArray(array $attributes): self
     {
         return new FileAttributes(
             $attributes[StorageAttributes::ATTRIBUTE_PATH],


### PR DESCRIPTION
Currently the return types of `withPath` and `fromArray` in the `FileAttributes` and `StorageAttributes` classes are marked as `StorageAttributes`. However, the return type could be more specific, as they will always return an instance of `self`.

This makes it easier to do static analysis on code using these methods. I have an implementation of `League\Flysystem\FilesystemAdapter` that uses the `FileAttributes::fromArray` method within e.g. the `mimeType` method, which yields a static analysis error as the return type is `StorageAttributes` and not `FileAttributes` with the current return type.