### PR TITLE
Visibility required

### DIFF
--- a/src/AzureBlobStorage/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorage/AzureBlobStorageAdapter.php
@@ -41,8 +41,8 @@ class AzureBlobStorageAdapter implements FilesystemAdapter
         'ContentLanguage',
         'ContentEncoding',
     ];
-    const ON_VISIBILITY_THROW_ERROR = 'throw';
-    const ON_VISIBILITY_IGNORE = 'ignore';
+    public const ON_VISIBILITY_THROW_ERROR = 'throw';
+    public const ON_VISIBILITY_IGNORE = 'ignore';
 
     private BlobRestProxy $client;
 

--- a/src/AzureBlobStorage/AzureBlobStorageTest.php
+++ b/src/AzureBlobStorage/AzureBlobStorageTest.php
@@ -17,7 +17,7 @@ use function getenv;
  */
 class AzureBlobStorageTest extends TestCase
 {
-    const CONTAINER_NAME = 'flysystem';
+    public const CONTAINER_NAME = 'flysystem';
 
     protected static function createFilesystemAdapter(): FilesystemAdapter
     {

--- a/src/FilesystemTest.php
+++ b/src/FilesystemTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FilesystemTest extends TestCase
 {
-    const ROOT = __DIR__ . '/../test_files/test-root';
+    public const ROOT = __DIR__ . '/../test_files/test-root';
 
     /**
      * @var Filesystem

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -23,7 +23,7 @@ use function strpos;
 
 class InMemoryFilesystemAdapter implements FilesystemAdapter
 {
-    const DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST = '______DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST';
+    public const DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST = '______DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST';
 
     /**
      * @var InMemoryFile[]

--- a/src/InMemory/InMemoryFilesystemAdapterTest.php
+++ b/src/InMemory/InMemoryFilesystemAdapterTest.php
@@ -21,7 +21,7 @@ use League\MimeTypeDetection\ExtensionMimeTypeDetector;
  */
 class InMemoryFilesystemAdapterTest extends FilesystemAdapterTestCase
 {
-    const PATH = 'path.txt';
+    public const PATH = 'path.txt';
 
     /**
      * @before

--- a/src/PhpseclibV3/SftpConnectionProviderTest.php
+++ b/src/PhpseclibV3/SftpConnectionProviderTest.php
@@ -23,7 +23,7 @@ use function str_split;
  */
 class SftpConnectionProviderTest extends TestCase
 {
-    const KEX_ACCEPTED_BY_DEFAULT_OPENSSH_BUT_DISABLED_IN_EDDSA_ONLY = 'diffie-hellman-group14-sha256';
+    public const KEX_ACCEPTED_BY_DEFAULT_OPENSSH_BUT_DISABLED_IN_EDDSA_ONLY = 'diffie-hellman-group14-sha256';
 
     public static function setUpBeforeClass(): void
     {


### PR DESCRIPTION
Visibility MUST be declared on all properties and methods; abstract and final MUST be declared before the visibility; static MUST be declared after the visibility.