### PR TITLE
Use arrow functions

### DIFF
--- a/src/DirectoryListing.php
+++ b/src/DirectoryListing.php
@@ -55,9 +55,7 @@ class DirectoryListing implements IteratorAggregate
     {
         $listing = $this->toArray();
 
-        usort($listing, function (StorageAttributes $a, StorageAttributes $b) {
-            return $a->path() <=> $b->path();
-        });
+        usort($listing, fn (StorageAttributes $a, StorageAttributes $b) => $a->path() <=> $b->path());
 
         return new DirectoryListing($listing);
     }

--- a/src/DirectoryListingTest.php
+++ b/src/DirectoryListingTest.php
@@ -22,9 +22,7 @@ class DirectoryListingTest extends TestCase
         $numbers = $this->generateIntegers(1, 10);
         $listing = new DirectoryListing($numbers);
 
-        $mappedListing = $listing->map(function (int $i) {
-            return $i * 2;
-        });
+        $mappedListing = $listing->map(fn (int $i) => $i * 2);
         $mappedNumbers = $mappedListing->toArray();
 
         $expectedNumbers = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
@@ -39,12 +37,8 @@ class DirectoryListingTest extends TestCase
         $numbers = $this->generateIntegers(1, 10);
         $listing = new DirectoryListing($numbers);
 
-        $mappedListing = $listing->map(function (int $i) {
-            return $i * 2;
-        });
-        $mappedListing = $mappedListing->map(function (int $i) {
-            return $i / 2;
-        });
+        $mappedListing = $listing->map(fn (int $i) => $i * 2);
+        $mappedListing = $mappedListing->map(fn (int $i) => $i / 2);
         $mappedNumbers = $mappedListing->toArray();
 
         $expectedNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -59,9 +53,7 @@ class DirectoryListingTest extends TestCase
         $numbers = $this->generateIntegers(1, 20);
         $listing = new DirectoryListing($numbers);
 
-        $fileredListing = $listing->filter(function (int $i) {
-            return $i % 2 === 0;
-        });
+        $fileredListing = $listing->filter(fn (int $i) => $i % 2 === 0);
         $mappedNumbers = $fileredListing->toArray();
 
         $expectedNumbers = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
@@ -76,12 +68,8 @@ class DirectoryListingTest extends TestCase
         $numbers = $this->generateIntegers(1, 20);
         $listing = new DirectoryListing($numbers);
 
-        $filteredListing = $listing->filter(function (int $i) {
-            return $i % 2 === 0;
-        });
-        $filteredListing = $filteredListing->filter(function (int $i) {
-            return $i > 10;
-        });
+        $filteredListing = $listing->filter(fn (int $i) => $i % 2 === 0);
+        $filteredListing = $filteredListing->filter(fn (int $i) => $i > 10);
         $mappedNumbers = $filteredListing->toArray();
 
         $expectedNumbers = [12, 14, 16, 18, 20];
@@ -102,9 +90,7 @@ class DirectoryListingTest extends TestCase
         ]);
 
         $actual = $listing->sortByPath()
-            ->map(function ($i) {
-                return $i->path();
-            })
+            ->map(fn ($i) => $i->path())
             ->toArray();
 
         self::assertEquals($expected, $actual);

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -497,9 +497,7 @@ class FtpAdapter implements FilesystemAdapter
         $parts = str_split($permissions, 3);
 
         // convert the groups
-        $mapper = function ($part) {
-            return array_sum(str_split($part));
-        };
+        $mapper = fn ($part) => array_sum(str_split($part));
 
         // converts to decimal number
         return octdec(implode('', array_map($mapper, $parts)));

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -328,9 +328,7 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         /** @var Traversable<StorageAttributes> $contentListing */
         $contentListing = $adapter->listContents('/', true);
         $listing = iterator_to_array($contentListing);
-        usort($listing, function (StorageAttributes $a, StorageAttributes $b) {
-            return strnatcasecmp($a->path(), $b->path());
-        });
+        usort($listing, fn (StorageAttributes $a, StorageAttributes $b) => strnatcasecmp($a->path(), $b->path()));
         /**
          * @var StorageAttributes $publicDirectoryAttributes
          * @var StorageAttributes $privateFileAttributes

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -94,9 +94,7 @@ class MountManager implements FilesystemOperator
             $filesystem
                 ->listContents($path, $deep)
                 ->map(
-                    function (StorageAttributes $attributes) use ($mountIdentifier) {
-                        return $attributes->withPath(sprintf('%s://%s', $mountIdentifier, $attributes->path()));
-                    }
+                    fn (StorageAttributes $attributes) => $attributes->withPath(sprintf('%s://%s', $mountIdentifier, $attributes->path()))
                 );
     }
 


### PR DESCRIPTION
Anonymous functions with one-liner return statement must use arrow functions.