### PR TITLE
Void return

### DIFF
--- a/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
+++ b/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
@@ -99,7 +99,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
             return;
         }
 
-        $this->runSetup(function () use ($adapter) {
+        $this->runSetup(function () use ($adapter): void {
             /** @var StorageAttributes $item */
             foreach ($adapter->listContents('', false) as $item) {
                 if ($item->isDir()) {
@@ -124,7 +124,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function writing_and_reading_with_string(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
 
             $adapter->write('path.txt', 'contents', new Config());
@@ -141,7 +141,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function writing_a_file_with_a_stream(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $writeStream = stream_with_contents('contents');
 
@@ -163,7 +163,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function writing_and_reading_files_with_special_path(string $path): void
     {
-        $this->runScenario(function () use ($path) {
+        $this->runScenario(function () use ($path): void {
             $adapter = $this->adapter();
 
             $adapter->write($path, 'contents', new Config());
@@ -196,7 +196,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function writing_a_file_with_an_empty_stream(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $writeStream = stream_with_contents('');
 
@@ -222,7 +222,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->givenWeHaveAnExistingFile('path.txt', 'contents');
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $contents = $this->adapter()->read('path.txt');
 
             $this->assertEquals('contents', $contents);
@@ -236,7 +236,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->givenWeHaveAnExistingFile('path.txt', 'contents');
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $readStream = $this->adapter()->readStream('path.txt');
             $contents = stream_get_contents($readStream);
 
@@ -251,7 +251,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function overwriting_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->givenWeHaveAnExistingFile('path.txt', 'contents', ['visibility' => Visibility::PUBLIC]);
             $adapter = $this->adapter();
 
@@ -269,7 +269,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function deleting_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $this->givenWeHaveAnExistingFile('path.txt', 'contents');
 
@@ -285,7 +285,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function listing_contents_shallow(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->givenWeHaveAnExistingFile('some/0-path.txt', 'contents');
             $this->givenWeHaveAnExistingFile('some/1-nested/path.txt', 'contents');
 
@@ -313,7 +313,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function checking_if_a_non_existing_directory_exists(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             self::assertFalse($adapter->directoryExists('this-does-not-exist.php'));
         });
@@ -324,7 +324,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function checking_if_a_directory_exists_after_writing_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $this->givenWeHaveAnExistingFile('existing-directory/file.txt');
             self::assertTrue($adapter->directoryExists('existing-directory'));
@@ -336,7 +336,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function checking_if_a_directory_exists_after_creating_it(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->createDirectory('explicitly-created-directory', new Config());
             self::assertTrue($adapter->directoryExists('explicitly-created-directory'));
@@ -352,7 +352,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function listing_contents_recursive(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->createDirectory('path', new Config());
             $adapter->write('path/file.txt', 'string', new Config());
@@ -378,7 +378,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
 
     protected function givenWeHaveAnExistingFile(string $path, string $contents = 'contents', array $config = []): void
     {
-        $this->runSetup(function () use ($path, $contents, $config) {
+        $this->runSetup(function () use ($path, $contents, $config): void {
             $this->adapter()->write($path, $contents, new Config($config));
         });
     }
@@ -391,7 +391,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
         $adapter = $this->adapter();
         $this->givenWeHaveAnExistingFile('path.txt', 'contents');
 
-        $this->runScenario(function () use ($adapter) {
+        $this->runScenario(function () use ($adapter): void {
             $attributes = $adapter->fileSize('path.txt');
             $this->assertInstanceOf(FileAttributes::class, $attributes);
             $this->assertEquals(8, $attributes->fileSize());
@@ -403,7 +403,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function setting_visibility(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $this->givenWeHaveAnExistingFile('path.txt', 'contents', [Config::OPTION_VISIBILITY => Visibility::PUBLIC]);
 
@@ -428,7 +428,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
 
         $adapter = $this->adapter();
 
-        $this->runScenario(function () use ($adapter) {
+        $this->runScenario(function () use ($adapter): void {
             $adapter->createDirectory('path', new Config());
             $adapter->fileSize('path/');
         });
@@ -441,7 +441,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->expectException(UnableToRetrieveMetadata::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->fileSize('non-existing-file.txt');
         });
     }
@@ -453,7 +453,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->expectException(UnableToRetrieveMetadata::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->lastModified('non-existing-file.txt');
         });
     }
@@ -465,7 +465,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->expectException(UnableToRetrieveMetadata::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->visibility('non-existing-file.txt');
         });
     }
@@ -475,7 +475,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function fetching_the_mime_type_of_an_svg_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->givenWeHaveAnExistingFile('file.svg', file_get_contents(__DIR__ . '/test_files/flysystem.svg'));
 
             $mimetype = $this->adapter()->mimeType('file.svg')->mimeType();
@@ -491,7 +491,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->expectException(UnableToRetrieveMetadata::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->mimeType('non-existing-file.txt');
         });
     }
@@ -508,7 +508,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
 
         $this->expectException(UnableToRetrieveMetadata::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->mimeType('unknown-mime-type.md5');
         });
     }
@@ -521,7 +521,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
         $this->givenWeHaveAnExistingFile('path1.txt');
         $this->givenWeHaveAnExistingFile('path2.txt');
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $contents = iterator_to_array($this->adapter()->listContents('', true));
 
             $this->assertCount(2, $contents);
@@ -533,7 +533,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function writing_and_reading_with_streams(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $writeStream = stream_with_contents('contents');
             $adapter = $this->adapter();
 
@@ -557,7 +557,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->expectException(UnableToSetVisibility::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->setVisibility('this-path-does-not-exists.txt', Visibility::PRIVATE);
         });
     }
@@ -567,7 +567,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function copying_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',
@@ -589,7 +589,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function copying_a_file_again(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',
@@ -611,7 +611,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function moving_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',
@@ -639,7 +639,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->expectException(UnableToReadFile::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->read('path.txt');
         });
     }
@@ -651,7 +651,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
     {
         $this->expectException(UnableToMoveFile::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->move('source.txt', 'destination.txt', new Config());
         });
     }
@@ -674,7 +674,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function checking_if_files_exist(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $fileExistsBefore = $adapter->fileExists('some/path.txt');
             $adapter->write('some/path.txt', 'contents', new Config());
@@ -690,7 +690,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function fetching_last_modified(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write('path.txt', 'contents', new Config());
 
@@ -728,7 +728,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function creating_a_directory(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
 
             $adapter->createDirectory('creating_a_directory/path', new Config());
@@ -751,7 +751,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
      */
     public function copying_a_file_with_collision(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write('path.txt', 'new contents', new Config());
             $adapter->write('new-path.txt', 'contents', new Config());
@@ -765,7 +765,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
 
     protected function assertFileExistsAtPath(string $path): void
     {
-        $this->runScenario(function () use ($path) {
+        $this->runScenario(function () use ($path): void {
             $fileExists = $this->adapter()->fileExists($path);
             $this->assertTrue($fileExists);
         });

--- a/src/AdapterTestUtilities/test-functions.php
+++ b/src/AdapterTestUtilities/test-functions.php
@@ -7,7 +7,7 @@ function return_mocked_value(string $name)
     return array_shift($_ENV['__FM:RETURNS:' . $name]);
 }
 
-function reset_function_mocks()
+function reset_function_mocks(): void
 {
     foreach (array_keys($_ENV) as $name) {
         if (is_string($name) && substr($name, 0, 5) === '__FM:') {
@@ -16,7 +16,7 @@ function reset_function_mocks()
     }
 }
 
-function mock_function(string $name, ...$returns)
+function mock_function(string $name, ...$returns): void
 {
     $_ENV['__FM:FUNC_IS_MOCKED:' . $name] = 'yes';
     $_ENV['__FM:RETURNS:' . $name] = $returns;

--- a/src/AwsS3V3/S3ClientStub.php
+++ b/src/AwsS3V3/S3ClientStub.php
@@ -162,7 +162,7 @@ class S3ClientStub implements S3ClientInterface
         return $this->actualClient->getPaginator($name, $args);
     }
 
-    public function waitUntil($name, array $args = [])
+    public function waitUntil($name, array $args = []): void
     {
         $this->actualClient->waitUntil($name, $args);
     }

--- a/src/AzureBlobStorage/AzureBlobStorageTest.php
+++ b/src/AzureBlobStorage/AzureBlobStorageTest.php
@@ -38,7 +38,7 @@ class AzureBlobStorageTest extends TestCase
     public function overwriting_a_file(): void
     {
         $this->runScenario(
-            function () {
+            function (): void {
                 $this->givenWeHaveAnExistingFile('path.txt', 'contents');
                 $adapter = $this->adapter();
 
@@ -89,7 +89,7 @@ class AzureBlobStorageTest extends TestCase
      */
     public function copying_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',
@@ -110,7 +110,7 @@ class AzureBlobStorageTest extends TestCase
      */
     public function moving_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',
@@ -135,7 +135,7 @@ class AzureBlobStorageTest extends TestCase
      */
     public function copying_a_file_again(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',

--- a/src/FilesystemTest.php
+++ b/src/FilesystemTest.php
@@ -302,25 +302,25 @@ class FilesystemTest extends TestCase
 
     public function scenariosCausingPathTraversal(): Generator
     {
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->delete('../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->deleteDirectory('../path');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->createDirectory('../path');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->read('../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->readStream('../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->write('../path.txt', 'contents');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $stream = stream_with_contents('contents');
             try {
                 $filesystem->writeStream('../path.txt', $stream);
@@ -328,37 +328,37 @@ class FilesystemTest extends TestCase
                 fclose($stream);
             }
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->listContents('../path');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->fileExists('../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->mimeType('../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->fileSize('../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->lastModified('../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->visibility('../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->setVisibility('../path.txt', Visibility::PUBLIC);
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->copy('../path.txt', 'path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->copy('path.txt', '../path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->move('../path.txt', 'path.txt');
         }];
-        yield [function (FilesystemOperator $filesystem) {
+        yield [function (FilesystemOperator $filesystem): void {
             $filesystem->move('path.txt', '../path.txt');
         }];
     }

--- a/src/Ftp/FtpAdapterTestCase.php
+++ b/src/Ftp/FtpAdapterTestCase.php
@@ -55,7 +55,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
             'password' => 'pass',
         ]);
 
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $adapter = new FtpAdapter($options);
 
             $adapter->write('dirname1/dirname2/path.txt', 'contents', new Config());
@@ -71,7 +71,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
      */
     public function reconnecting_after_failure(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             static::$connectivityChecker->failNextCall();
 
@@ -86,13 +86,13 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
      */
     public function failing_to_write_a_file(callable $scenario): void
     {
-        $this->runScenario(function () use ($scenario) {
+        $this->runScenario(function () use ($scenario): void {
             $scenario();
         });
 
         $this->expectException(UnableToWriteFile::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->write('some/path.txt', 'contents', new Config([
                 Config::OPTION_VISIBILITY => Visibility::PUBLIC,
                 Config::OPTION_DIRECTORY_VISIBILITY => Visibility::PUBLIC
@@ -102,19 +102,19 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
 
     public function scenariosCausingWriteFailure(): Generator
     {
-        yield "Not being able to create the parent directory" => [function () {
+        yield "Not being able to create the parent directory" => [function (): void {
             mock_function('ftp_mkdir', false);
         }];
 
-        yield "Not being able to set the parent directory visibility" => [function () {
+        yield "Not being able to set the parent directory visibility" => [function (): void {
             mock_function('ftp_chmod', false);
         }];
 
-        yield "Not being able to write the file" => [function () {
+        yield "Not being able to write the file" => [function (): void {
             mock_function('ftp_fput', false);
         }];
 
-        yield "Not being able to set the visibility" => [function () {
+        yield "Not being able to set the visibility" => [function (): void {
             mock_function('ftp_chmod', true, false);
         }];
     }
@@ -130,18 +130,18 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
 
         $this->expectException(UnableToDeleteDirectory::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->deleteDirectory('some');
         });
     }
 
     public function scenariosCausingDirectoryDeleteFailure(): Generator
     {
-        yield "ftp_delete failure" => [function () {
+        yield "ftp_delete failure" => [function (): void {
             mock_function('ftp_delete', false);
         }];
 
-        yield "ftp_rmdir failure" => [function () {
+        yield "ftp_rmdir failure" => [function (): void {
             mock_function('ftp_rmdir', false);
         }];
     }
@@ -157,7 +157,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
 
         $this->expectException(UnableToCopyFile::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->copy('path.txt', 'new/path.txt', new Config());
         });
     }
@@ -172,18 +172,18 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
 
         $this->expectException(UnableToMoveFile::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->move('path.txt', 'new/path.txt', new Config());
         });
     }
 
     public function scenariosCausingCopyFailure(): Generator
     {
-        yield "failing to read" => [function () {
+        yield "failing to read" => [function (): void {
             mock_function('ftp_fget', false);
         }];
 
-        yield "failing to write" => [function () {
+        yield "failing to write" => [function (): void {
             mock_function('ftp_fput', false);
         }];
     }
@@ -198,7 +198,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
 
         $this->expectException(UnableToDeleteFile::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->delete('path.txt');
         });
     }
@@ -214,7 +214,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
         ];
         mock_function('ftp_rawlist', $response);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $contents = iterator_to_array($adapter->listContents('/', false), false);
 
@@ -235,7 +235,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
         ];
         mock_function('ftp_rawlist', $response);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $contents = iterator_to_array($adapter->listContents('/', false), false);
 
@@ -256,7 +256,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
 
         $this->expectException(InvalidListResponseReceived::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             iterator_to_array($adapter->listContents('/', false), false);
         });
@@ -275,7 +275,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
 
         $this->expectException(InvalidListResponseReceived::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             iterator_to_array($adapter->listContents('/', false), false);
         });
@@ -288,13 +288,13 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
     {
         $adapter = $this->adapter();
 
-        $this->runScenario(function () use ($adapter) {
+        $this->runScenario(function () use ($adapter): void {
             $adapter->createDirectory('directory_name', new Config());
         });
 
         $this->expectException(UnableToRetrieveMetadata::class);
 
-        $this->runScenario(function () use ($adapter) {
+        $this->runScenario(function () use ($adapter): void {
             $adapter->fileSize('directory_name');
         });
     }
@@ -333,7 +333,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
            'password' => 'pass',
        ]);
 
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $adapter = new FtpAdapter($options);
 
             $contents = iterator_to_array($adapter->listContents('somewhere', true), false);
@@ -350,7 +350,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
     {
         $this->givenWeHaveAnExistingFile('some dirname/file name.txt');
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
 
             $this->assertTrue($adapter->fileExists('some dirname/file name.txt'));

--- a/src/Ftp/FtpConnectionProviderTest.php
+++ b/src/Ftp/FtpConnectionProviderTest.php
@@ -58,7 +58,7 @@ class FtpConnectionProviderTest extends TestCase
             'password' => 'pass',
         ]);
 
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $connection = $this->connectionProvider->createConnection($options);
             $this->assertTrue(ftp_close($connection));
         });
@@ -82,7 +82,7 @@ class FtpConnectionProviderTest extends TestCase
 
         $this->expectException(UnableToEnableUtf8Mode::class);
 
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $this->connectionProvider->createConnection($options);
         });
     }
@@ -104,7 +104,7 @@ class FtpConnectionProviderTest extends TestCase
         mock_function('ftp_raw', ['202 UTF8 mode is always enabled. No need to send this command.']);
         $this->expectNotToPerformAssertions();
 
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $this->connectionProvider->createConnection($options);
         });
     }
@@ -127,7 +127,7 @@ class FtpConnectionProviderTest extends TestCase
 
         $this->expectException(UnableToSetFtpOption::class);
 
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $this->connectionProvider->createConnection($options);
         });
     }
@@ -150,7 +150,7 @@ class FtpConnectionProviderTest extends TestCase
 
         $this->expectException(UnableToMakeConnectionPassive::class);
 
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $this->connectionProvider->createConnection($options);
         });
     }
@@ -211,7 +211,7 @@ class FtpConnectionProviderTest extends TestCase
 
         $this->expectException(UnableToAuthenticate::class);
         $this->retryOnException(UnableToConnectToFtpHost::class);
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $this->connectionProvider->createConnection($options);
         });
     }

--- a/src/Ftp/NoopCommandConnectivityCheckerTest.php
+++ b/src/Ftp/NoopCommandConnectivityCheckerTest.php
@@ -50,7 +50,7 @@ class NoopCommandConnectivityCheckerTest extends TestCase
             'password' => 'pass',
         ]);
 
-        $this->runScenario(function () use ($options) {
+        $this->runScenario(function () use ($options): void {
             $connection = (new FtpConnectionProvider())->createConnection($options);
             ftp_close($connection);
 

--- a/src/Ftp/RawListFtpConnectivityCheckerTest.php
+++ b/src/Ftp/RawListFtpConnectivityCheckerTest.php
@@ -17,7 +17,7 @@ class RawListFtpConnectivityCheckerTest extends TestCase
     public function detecting_if_a_connection_is_connected(): void
     {
         $this->retryOnException(UnableToConnectToFtpHost::class);
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $options = FtpConnectionOptions::fromArray([
                'host' => 'localhost',
                'port' => 2121,

--- a/src/WebDAV/WebDAVAdapterTestCase.php
+++ b/src/WebDAV/WebDAVAdapterTestCase.php
@@ -30,7 +30,7 @@ abstract class WebDAVAdapterTestCase extends FilesystemAdapterTestCase
      */
     public function overwriting_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->givenWeHaveAnExistingFile('path.txt', 'contents');
             $adapter = $this->adapter();
 
@@ -46,7 +46,7 @@ abstract class WebDAVAdapterTestCase extends FilesystemAdapterTestCase
      */
     public function copying_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',
@@ -67,7 +67,7 @@ abstract class WebDAVAdapterTestCase extends FilesystemAdapterTestCase
      */
     public function copying_a_file_again(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',
@@ -88,7 +88,7 @@ abstract class WebDAVAdapterTestCase extends FilesystemAdapterTestCase
      */
     public function moving_a_file(): void
     {
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $adapter = $this->adapter();
             $adapter->write(
                 'source.txt',
@@ -115,7 +115,7 @@ abstract class WebDAVAdapterTestCase extends FilesystemAdapterTestCase
     {
         $this->expectException(UnableToMoveFile::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $this->adapter()->move('source.txt', 'destination.txt', new Config());
         });
     }

--- a/src/ZipArchive/ZipArchiveAdapterTest.php
+++ b/src/ZipArchive/ZipArchiveAdapterTest.php
@@ -88,7 +88,7 @@ final class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
 
         $this->expectException(UnableToWriteFile::class);
 
-        $this->runScenario(function () {
+        $this->runScenario(function (): void {
             $handle = stream_with_contents('contents');
             $this->adapter()->writeStream('some/path.txt', $handle, new Config([Config::OPTION_VISIBILITY => Visibility::PUBLIC]));
             is_resource($handle) && @fclose($handle);
@@ -97,15 +97,15 @@ final class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
 
     public function scenariosThatCauseWritesToFail(): Generator
     {
-        yield "writing a file fails when writing" => [function () {
+        yield "writing a file fails when writing" => [function (): void {
             static::$archiveProvider->stubbedZipArchive()->failNextWrite();
         }];
 
-        yield "writing a file fails when setting visibility" => [function () {
+        yield "writing a file fails when setting visibility" => [function (): void {
             static::$archiveProvider->stubbedZipArchive()->failWhenSettingVisibility();
         }];
 
-        yield "writing a file fails to get the stream contents" => [function () {
+        yield "writing a file fails to get the stream contents" => [function (): void {
             mock_function('stream_get_contents', false);
         }];
     }


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.