### PR TITLE
Fopen flags

### DIFF
--- a/src/PhpseclibV2/SftpAdapter.php
+++ b/src/PhpseclibV2/SftpAdapter.php
@@ -178,7 +178,7 @@ class SftpAdapter implements FilesystemAdapter
         $location = $this->prefixer->prefixPath($path);
         $connection = $this->connectionProvider->provideConnection();
         /** @var resource $readStream */
-        $readStream = fopen('php://temp', 'w+');
+        $readStream = fopen('php://temp', 'w+b');
 
         if ( ! $connection->get($location, $readStream)) {
             fclose($readStream);

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -178,7 +178,7 @@ class SftpAdapter implements FilesystemAdapter
         $location = $this->prefixer->prefixPath($path);
         $connection = $this->connectionProvider->provideConnection();
         /** @var resource $readStream */
-        $readStream = fopen('php://temp', 'w+');
+        $readStream = fopen('php://temp', 'w+b');
 
         if ( ! $connection->get($location, $readStream)) {
             fclose($readStream);


### PR DESCRIPTION
The flags in fopen calls must omit t, and b must be omitted or included consistently.