### PR TITLE
Adding `ContentMD5` option to `AVAILABLE_OPTIONS` array

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -44,6 +44,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
         'ContentEncoding',
         'ContentLength',
         'ContentType',
+        'ContentMD5',
         'Expires',
         'GrantFullControl',
         'GrantRead',


### PR DESCRIPTION
This proposed change is adding `ContentMD5` option to `AVAILABLE_OPTIONS` array. Without this option in the array it is impossible to upload file on file lock enabled S3.