### PR TITLE
Adding `ChecksumAlgorithm` option to `AVAILABLE_OPTIONS` array

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -60,6 +60,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
         'StorageClass',
         'Tagging',
         'WebsiteRedirectLocation',
+        'ChecksumAlgorithm',
     ];
     /**
      * @var string[]


### PR DESCRIPTION
This options enables S3 to compute the desired checksum when uploading a file. We can later retrieve the Checksum without the need to download the file. Here is some doc links:
https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#putobject
https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums
https://aws.amazon.com/fr/blogs/aws/new-additional-checksum-algorithms-for-amazon-s3/