### PR TITLE
Fix: Backport `UnableToCheckDirectoryExistence` to `2.x`

### DIFF
--- a/src/ExceptionInformationTest.php
+++ b/src/ExceptionInformationTest.php
@@ -69,6 +69,24 @@ class ExceptionInformationTest extends TestCase
     /**
      * @test
      */
+    public function unable_to_check_for_existence(): void
+    {
+        $exception = UnableToCheckExistence::forLocation('location');
+        $this->assertEquals(FilesystemOperationFailed::OPERATION_EXISTENCE_CHECK, $exception->operation());
+    }
+
+    /**
+     * @test
+     */
+    public function unable_to_check_for_directory_existence(): void
+    {
+        $exception = UnableToCheckDirectoryExistence::forLocation('location');
+        $this->assertEquals(FilesystemOperationFailed::OPERATION_DIRECTORY_EXISTS, $exception->operation());
+    }
+
+    /**
+     * @test
+     */
     public function move_file_exception_information(): void
     {
         $exception = UnableToMoveFile::fromLocationTo('from', 'to');

--- a/src/FilesystemOperationFailed.php
+++ b/src/FilesystemOperationFailed.php
@@ -8,6 +8,8 @@ interface FilesystemOperationFailed extends FilesystemException
 {
     public const OPERATION_WRITE = 'WRITE';
     public const OPERATION_UPDATE = 'UPDATE';
+    public const OPERATION_EXISTENCE_CHECK = 'EXISTENCE_CHECK';
+    public const OPERATION_DIRECTORY_EXISTS = 'DIRECTORY_EXISTS';
     public const OPERATION_FILE_EXISTS = 'FILE_EXISTS';
     public const OPERATION_CREATE_DIRECTORY = 'CREATE_DIRECTORY';
     public const OPERATION_DELETE = 'DELETE';

--- a/src/UnableToCheckDirectoryExistence.php
+++ b/src/UnableToCheckDirectoryExistence.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem;
+
+class UnableToCheckDirectoryExistence extends UnableToCheckExistence
+{
+    public function operation(): string
+    {
+        return FilesystemOperationFailed::OPERATION_DIRECTORY_EXISTS;
+    }
+}

--- a/src/UnableToCheckExistence.php
+++ b/src/UnableToCheckExistence.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem;
+
+use RuntimeException;
+use Throwable;
+
+class UnableToCheckExistence extends RuntimeException implements FilesystemOperationFailed
+{
+    public static function forLocation(string $path, Throwable $exception = null): static
+    {
+        return new static("Unable to check existence for: {$path}", 0, $exception);
+    }
+
+    public function operation(): string
+    {
+        return FilesystemOperationFailed::OPERATION_EXISTENCE_CHECK;
+    }
+}


### PR DESCRIPTION
This pull request

- [x] backports `UnableToCheckDirectoryExistence` to `2.x`

Fixes #1519.