### PR TITLE
Set correct permissions wrt. visibility for implicitly created directories

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -99,7 +99,7 @@ class Local extends AbstractAdapter
     {
         if ( ! is_dir($root)) {
             $umask = umask(0);
-	        $visibility = $config instanceof Config ? $config->get('visibility', 'public') : 'public';
+	        $visibility = $config instanceof Config ? $config->get('directory_visibility', 'public') : 'public';
 
             if ( ! @mkdir($root, $this->permissionMap['dir'][$visibility], true)) {
                 $mkdirError = error_get_last();

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -99,7 +99,7 @@ class Local extends AbstractAdapter
     {
         if ( ! is_dir($root)) {
             $umask = umask(0);
-	        $visibility = $config === null ? 'public' : $config->get('visibility', 'public');
+	        $visibility = $config instanceof Config ? $config->get('visibility', 'public') : 'public';
 
             if ( ! @mkdir($root, $this->permissionMap['dir'][$visibility], true)) {
                 $mkdirError = error_get_last();

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -95,12 +95,13 @@ class Local extends AbstractAdapter
      *
      * @throws Exception in case the root directory can not be created
      */
-    protected function ensureDirectory($root)
+    protected function ensureDirectory($root, ?Config $config = null)
     {
         if ( ! is_dir($root)) {
             $umask = umask(0);
+	        $visibility = $config === null ? 'public' : $config->get('visibility', 'public');
 
-            if ( ! @mkdir($root, $this->permissionMap['dir']['public'], true)) {
+            if ( ! @mkdir($root, $this->permissionMap['dir'][$visibility], true)) {
                 $mkdirError = error_get_last();
             }
 
@@ -130,7 +131,7 @@ class Local extends AbstractAdapter
     public function write($path, $contents, Config $config)
     {
         $location = $this->applyPathPrefix($path);
-        $this->ensureDirectory(dirname($location));
+        $this->ensureDirectory(dirname($location), $config);
 
         if (($size = file_put_contents($location, $contents, $this->writeFlags)) === false) {
             return false;
@@ -153,7 +154,7 @@ class Local extends AbstractAdapter
     public function writeStream($path, $resource, Config $config)
     {
         $location = $this->applyPathPrefix($path);
-        $this->ensureDirectory(dirname($location));
+        $this->ensureDirectory(dirname($location), $config);
         $stream = fopen($location, 'w+b');
 
         if ( ! $stream || stream_copy_to_stream($resource, $stream) === false || ! fclose($stream)) {


### PR DESCRIPTION
`Local::ensureDirectory` should use the configured visibility if available. I discovered this problem while working on a Laravel 8 project which still uses Flysystem v1. This bug fix does probably not completely fix the problem, but only for writing file streams.
If a file is copied or moved a non-existing parent directory is sill created with `'public'` visibility, but this fix suffices for our project and fixing all possible cases seemed to be too much work.