### PR TITLE
`ZipArchiveAdapter` fixes

### DIFF
--- a/src/ZipArchive/EmptyRootPrefixZipArchiveAdapterTest.php
+++ b/src/ZipArchive/EmptyRootPrefixZipArchiveAdapterTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\ZipArchive;
+
+final class EmptyRootPrefixZipArchiveAdapterTest extends ZipArchiveAdapterTest
+{
+    protected static function getRoot(): string
+    {
+        return '';
+    }
+}

--- a/src/ZipArchive/NoRootPrefixZipArchiveAdapterTest.php
+++ b/src/ZipArchive/NoRootPrefixZipArchiveAdapterTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\ZipArchive;
+
+final class NoRootPrefixZipArchiveAdapterTest extends ZipArchiveAdapterTest
+{
+    protected static function getRoot(): string
+    {
+        return '/';
+    }
+}

--- a/src/ZipArchive/NonAbsolutePrefixedRootZipArchiveAdapterTest.php
+++ b/src/ZipArchive/NonAbsolutePrefixedRootZipArchiveAdapterTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\ZipArchive;
+
+final class NonAbsolutePrefixedRootZipArchiveAdapterTest extends ZipArchiveAdapterTest
+{
+    protected static function getRoot(): string
+    {
+        return 'prefixed-path';
+    }
+}

--- a/src/ZipArchive/PrefixedRootZipArchiveAdapterTest.php
+++ b/src/ZipArchive/PrefixedRootZipArchiveAdapterTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\ZipArchive;
+
+final class PrefixedRootZipArchiveAdapterTest extends ZipArchiveAdapterTest
+{
+    protected static function getRoot(): string
+    {
+        return '/prefixed-path';
+    }
+}

--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -171,6 +171,8 @@ final class ZipArchiveAdapter implements FilesystemAdapter
             }
         }
 
+        $archive->deleteName($prefixedPath);
+
         $archive->close();
     }
 

--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -48,7 +48,7 @@ final class ZipArchiveAdapter implements FilesystemAdapter
         ?MimeTypeDetector $mimeTypeDetector = null,
         ?VisibilityConverter $visibility = null
     ) {
-        $this->pathPrefixer = new PathPrefixer($root);
+        $this->pathPrefixer = new PathPrefixer('/' . ltrim($root, '/'));
         $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
         $this->visibility = $visibility ?? new PortableVisibilityConverter();
         $this->zipArchiveProvider = $zipArchiveProvider;

--- a/src/ZipArchive/ZipArchiveAdapterTest.php
+++ b/src/ZipArchive/ZipArchiveAdapterTest.php
@@ -22,7 +22,7 @@ use function iterator_to_array;
 /**
  * @group zip
  */
-final class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
+abstract class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
 {
     private const ARCHIVE = __DIR__ . '/test.zip';
 
@@ -52,8 +52,10 @@ final class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
     {
         static::$archiveProvider = new StubZipArchiveProvider(self::ARCHIVE);
 
-        return new ZipArchiveAdapter(self::$archiveProvider, '/path-prefix');
+        return new ZipArchiveAdapter(self::$archiveProvider, static::getRoot());
     }
+
+    abstract protected static function getRoot(): string;
 
     /**
      * @test


### PR DESCRIPTION
I discovered when deleting a directory that's at the root of the archive, just the inner files are deleted, not the actual directory. The first commit provides a fix for this.

I also would like to propose that all root paths be made absolute as you can't list directories otherwise. My second commit adds this.