### PR TITLE
[ZipArchive] Do not prefix directories when creating/reading an archive

### DIFF
--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -48,7 +48,7 @@ final class ZipArchiveAdapter implements FilesystemAdapter
         ?MimeTypeDetector $mimeTypeDetector = null,
         ?VisibilityConverter $visibility = null
     ) {
-        $this->pathPrefixer = new PathPrefixer($root);
+        $this->pathPrefixer = new PathPrefixer(ltrim($root, '/'));
         $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
         $this->visibility = $visibility ?? new PortableVisibilityConverter();
         $this->zipArchiveProvider = $zipArchiveProvider;
@@ -383,7 +383,7 @@ final class ZipArchiveAdapter implements FilesystemAdapter
         $archive = $this->zipArchiveProvider->createZipArchive();
         $prefixedDirname = $this->pathPrefixer->prefixDirectoryPath($dirname);
         $parts = array_filter(explode('/', trim($prefixedDirname, '/')));
-        $dirPath = '/';
+        $dirPath = '';
 
         foreach ($parts as $part) {
             $dirPath .= $part . '/';

--- a/src/ZipArchive/ZipArchiveAdapterTest.php
+++ b/src/ZipArchive/ZipArchiveAdapterTest.php
@@ -146,6 +146,25 @@ abstract class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function deleting_a_prefixed_directory(): void
+    {
+        $this->givenWeHaveAnExistingFile('a.txt');
+        $this->givenWeHaveAnExistingFile('/one/a.txt');
+        $this->givenWeHaveAnExistingFile('one/b.txt');
+        $this->givenWeHaveAnExistingFile('two/a.txt');
+
+        $items = iterator_to_array($this->adapter()->listContents('', true));
+        $this->assertCount(6, $items);
+
+        $this->adapter()->deleteDirectory('one');
+
+        $items = iterator_to_array($this->adapter()->listContents('', true));
+        $this->assertCount(3, $items);
+    }
+
+    /**
+     * @test
+     */
     public function failing_to_create_a_directory(): void
     {
         static::$archiveProvider->stubbedZipArchive()->failNextDirectoryCreation();


### PR DESCRIPTION
The unit tests only  tested scenarios where archives where created and folder had leading slashes. This is not according to zip spec. This PR trims leading slashes in folder names when creating the folder and tries to read files without a prefixed slash after opening an archive.



