### PR TITLE
Fix prefix-related issues in WebDAV adapter

### DIFF
--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -213,6 +213,10 @@ class WebDAVAdapter implements FilesystemAdapter
         $directoryParts = [];
 
         foreach ($parts as $directory) {
+            if ($directory === '.' || $directory === '') {
+                return;
+            }
+
             $directoryParts[] = $directory;
             $directoryPath = implode('/', $directoryParts);
             $location = $this->encodePath($directoryPath);
@@ -409,10 +413,6 @@ class WebDAVAdapter implements FilesystemAdapter
     private function createParentDirFor(string $path): void
     {
         $dirname = dirname($path);
-
-        if ($dirname === '.' || $dirname === '') {
-            return;
-        }
 
         if ($this->directoryExists($dirname)) {
             return;

--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -62,7 +62,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function fileExists(string $path): bool
     {
-        $location = $this->prefixer->prefixPath($this->encodePath($path));
+        $location = $this->encodePath($this->prefixer->prefixPath($path));
 
         try {
             $properties = $this->client->propFind($location, ['{DAV:}resourcetype', '{DAV:}iscollection']);
@@ -90,7 +90,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function directoryExists(string $path): bool
     {
-        $location = $this->prefixer->prefixPath($this->encodePath($path));
+        $location = $this->encodePath($this->prefixer->prefixPath($path));
 
         try {
             $properties = $this->client->propFind($location, ['{DAV:}resourcetype', '{DAV:}iscollection']);
@@ -121,7 +121,7 @@ class WebDAVAdapter implements FilesystemAdapter
     private function upload(string $path, mixed $contents): void
     {
         $this->createParentDirFor($path);
-        $location = $this->prefixer->prefixPath($this->encodePath($path));
+        $location = $this->encodePath($this->prefixer->prefixPath($path));
 
         try {
             $response = $this->client->request('PUT', $location, $contents);
@@ -137,7 +137,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function read(string $path): string
     {
-        $location = $this->prefixer->prefixPath($this->encodePath($path));
+        $location = $this->encodePath($this->prefixer->prefixPath($path));
 
         try {
             $response = $this->client->request('GET', $location);
@@ -154,7 +154,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function readStream(string $path)
     {
-        $location = $this->prefixer->prefixPath($this->encodePath($path));
+        $location = $this->encodePath($this->prefixer->prefixPath($path));
 
         try {
             $url = $this->client->getAbsoluteUrl($location);
@@ -174,7 +174,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function delete(string $path): void
     {
-        $location = $this->prefixer->prefixPath($this->encodePath($path));
+        $location = $this->encodePath($this->prefixer->prefixPath($path));
 
         try {
             $response = $this->client->request('DELETE', $location);
@@ -192,7 +192,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function deleteDirectory(string $path): void
     {
-        $location = $this->prefixer->prefixDirectoryPath($this->encodePath($path));
+        $location = $this->encodePath($this->prefixer->prefixDirectoryPath($path));
 
         try {
             $statusCode = $this->client->request('DELETE', $location)['statusCode'];
@@ -209,13 +209,13 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function createDirectory(string $path, Config $config): void
     {
-        $parts = explode('/', $path);
+        $parts = explode('/', $this->prefixer->prefixDirectoryPath($path));
         $directoryParts = [];
 
         foreach ($parts as $directory) {
             $directoryParts[] = $directory;
             $directoryPath = implode('/', $directoryParts);
-            $location = $this->prefixer->prefixDirectoryPath($this->encodePath($directoryPath));
+            $location = $this->encodePath($directoryPath);
 
             if ($this->directoryExists($directoryPath)) {
                 continue;
@@ -268,7 +268,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function listContents(string $path, bool $deep): iterable
     {
-        $location = $this->prefixer->prefixDirectoryPath($this->encodePath($path));
+        $location = $this->encodePath($this->prefixer->prefixDirectoryPath($path));
         $response = $this->client->propFind($location, self::FIND_PROPERTIES, 1);
         array_shift($response);
 
@@ -330,8 +330,8 @@ class WebDAVAdapter implements FilesystemAdapter
         }
 
         $this->createParentDirFor($destination);
-        $location = $this->prefixer->prefixPath($this->encodePath($source));
-        $newLocation = $this->prefixer->prefixPath($this->encodePath($destination));
+        $location = $this->encodePath($this->prefixer->prefixPath($source));
+        $newLocation = $this->encodePath($this->prefixer->prefixPath($destination));
 
         try {
             $response = $this->client->request('MOVE', '/' . ltrim($location, '/'), null, [
@@ -367,8 +367,8 @@ class WebDAVAdapter implements FilesystemAdapter
         }
 
         $this->createParentDirFor($destination);
-        $location = $this->prefixer->prefixPath($this->encodePath($source));
-        $newLocation = $this->prefixer->prefixPath($this->encodePath($destination));
+        $location = $this->encodePath($this->prefixer->prefixPath($source));
+        $newLocation = $this->encodePath($this->prefixer->prefixPath($destination));
 
         try {
             $response = $this->client->request('COPY', '/' . ltrim($location, '/'), null, [


### PR DESCRIPTION
Hi,
using the prefix option with the WebDAV adapter currently has multiple issues and works only for simple ascii prefixes in paths that already exist on the destination server.

Basically, all paths are encoded BEFORE adding the prefix. This means that the prefix is never encoded, and a simple space character in the prefix is enough to generate errors for any operation.

The second issue is that the functionality for auto-creating the directories on the server does not add the prefix before iterating over its split components, and so it fails to create the directory tree when the prefix itself does not exist on the server.

Thanks