### PR TITLE
feat: add `StaticInMemoryFilesystemAdapter`

### DIFF
--- a/src/InMemory/StaticInMemoryFilesystemAdapter.php
+++ b/src/InMemory/StaticInMemoryFilesystemAdapter.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace League\Flysystem\InMemory;
+
+use League\Flysystem\Config;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemAdapter;
+
+class StaticInMemoryFilesystemAdapter implements FilesystemAdapter
+{
+    /** @var array<string, InMemoryFilesystemAdapter> */
+    private static array $filesystems = [];
+
+    public function __construct(private string $name = 'default')
+    {
+    }
+
+    public static function reset(): void
+    {
+        self::$filesystems = [];
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return $this->inner()->fileExists($path);
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        return $this->inner()->directoryExists($path);
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        $this->inner()->write($path, $contents, $config);
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->inner()->writeStream($path, $contents, $config);
+    }
+
+    public function read(string $path): string
+    {
+        return $this->inner()->read($path);
+    }
+
+    public function readStream(string $path)
+    {
+        return $this->inner()->readStream($path);
+    }
+
+    public function delete(string $path): void
+    {
+        $this->inner()->delete($path);
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        $this->inner()->deleteDirectory($path);
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        $this->inner()->createDirectory($path, $config);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $this->inner()->setVisibility($path, $visibility);
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        return $this->inner()->visibility($path);
+    }
+
+    public function mimeType(string $path): FileAttributes
+    {
+        return $this->inner()->mimeType($path);
+    }
+
+    public function lastModified(string $path): FileAttributes
+    {
+        return $this->inner()->lastModified($path);
+    }
+
+    public function fileSize(string $path): FileAttributes
+    {
+        return $this->inner()->fileSize($path);
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return $this->inner()->listContents($path, $deep);
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        $this->inner()->move($source, $destination, $config);
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        $this->inner()->copy($source, $destination, $config);
+    }
+
+    public function deleteEverything(): void
+    {
+        $this->inner()->deleteEverything();
+    }
+
+    private function inner(): InMemoryFilesystemAdapter
+    {
+        return self::$filesystems[$this->name] ??= new InMemoryFilesystemAdapter();
+    }
+}

--- a/src/InMemory/StaticInMemoryFilesystemAdapterTest.php
+++ b/src/InMemory/StaticInMemoryFilesystemAdapterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace League\Flysystem\InMemory;
+
+use League\Flysystem\Config;
+use League\Flysystem\FilesystemAdapter;
+
+class StaticInMemoryFilesystemAdapterTest extends InMemoryFilesystemAdapterTest
+{
+    /**
+     * @test
+     */
+    public function using_different_name_to_segment_adapters(): void
+    {
+        $first = new StaticInMemoryFilesystemAdapter();
+        $second = new StaticInMemoryFilesystemAdapter('second');
+
+        $first->write('foo.txt', 'foo', new Config());
+        $second->write('bar.txt', 'bar', new Config());
+
+        $this->assertTrue($first->fileExists('foo.txt'));
+        $this->assertFalse($first->fileExists('bar.txt'));
+        $this->assertTrue($second->fileExists('bar.txt'));
+        $this->assertFalse($second->fileExists('foo.txt'));
+    }
+
+    /**
+     * @test
+     */
+    public function files_persist_between_instances(): void
+    {
+        $first = new StaticInMemoryFilesystemAdapter();
+        $second = new StaticInMemoryFilesystemAdapter('second');
+
+        $first->write('foo.txt', 'foo', new Config());
+        $second->write('bar.txt', 'bar', new Config());
+
+        $this->assertTrue($first->fileExists('foo.txt'));
+        $this->assertTrue($second->fileExists('bar.txt'));
+
+        $first = new StaticInMemoryFilesystemAdapter();
+        $second = new StaticInMemoryFilesystemAdapter('second');
+
+        $this->assertTrue($first->fileExists('foo.txt'));
+        $this->assertTrue($second->fileExists('bar.txt'));
+    }
+
+    protected function tearDown(): void
+    {
+        StaticInMemoryFilesystemAdapter::reset();
+    }
+
+    protected static function createFilesystemAdapter(): FilesystemAdapter
+    {
+        return new StaticInMemoryFilesystemAdapter();
+    }
+}


### PR DESCRIPTION
This can be useful when functionally testing requests with a `InMemoryFilesystemAdapter` that is reset between requests.

If acceptable, I can create a doc PR.