### PR TITLE
feat: add `ReadonlyFilesystemAdapter`

### DIFF
--- a/src/ReadonlyFilesystemAdapter.php
+++ b/src/ReadonlyFilesystemAdapter.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace League\Flysystem;
+
+class ReadonlyFilesystemAdapter implements FilesystemAdapter
+{
+    public function __construct(private FilesystemAdapter $inner)
+    {
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return $this->inner->fileExists($path);
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        return $this->inner->directoryExists($path);
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        throw UnableToWriteFile::atLocation($path, 'This is a readonly adapter.');
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        throw UnableToWriteFile::atLocation($path, 'This is a readonly adapter.');
+    }
+
+    public function read(string $path): string
+    {
+        return $this->inner->read($path);
+    }
+
+    public function readStream(string $path)
+    {
+        return $this->inner->readStream($path);
+    }
+
+    public function delete(string $path): void
+    {
+        throw UnableToDeleteFile::atLocation($path, 'This is a readonly adapter.');
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        throw UnableToDeleteDirectory::atLocation($path, 'This is a readonly adapter.');
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        throw UnableToCreateDirectory::atLocation($path, 'This is a readonly adapter.');
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        throw UnableToSetVisibility::atLocation($path, 'This is a readonly adapter.');
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        return $this->inner->visibility($path);
+    }
+
+    public function mimeType(string $path): FileAttributes
+    {
+        return $this->inner->mimeType($path);
+    }
+
+    public function lastModified(string $path): FileAttributes
+    {
+        return $this->inner->lastModified($path);
+    }
+
+    public function fileSize(string $path): FileAttributes
+    {
+        return $this->inner->fileSize($path);
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return $this->inner->listContents($path, $deep);
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        throw new UnableToMoveFile("Unable to move file from $source to $destination as this is a readonly adapter.");
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        throw new UnableToCopyFile("Unable to copy file from $source to $destination as this is a readonly adapter.");
+    }
+}

--- a/src/ReadonlyFilesystemAdapterTest.php
+++ b/src/ReadonlyFilesystemAdapterTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace League\Flysystem;
+
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+
+class ReadonlyFilesystemAdapterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_perform_read_operations(): void
+    {
+        $adapter = $this->realAdapter();
+        $adapter->write('foo/bar.txt', 'content', new Config());
+
+        $adapter = new ReadonlyFilesystemAdapter($adapter);
+
+        $this->assertTrue($adapter->fileExists('foo/bar.txt'));
+        $this->assertTrue($adapter->directoryExists('foo'));
+        $this->assertSame('content', $adapter->read('foo/bar.txt'));
+        $this->assertSame('content', \stream_get_contents($adapter->readStream('foo/bar.txt')));
+        $this->assertInstanceOf(FileAttributes::class, $adapter->visibility('foo/bar.txt'));
+        $this->assertInstanceOf(FileAttributes::class, $adapter->mimeType('foo/bar.txt'));
+        $this->assertInstanceOf(FileAttributes::class, $adapter->lastModified('foo/bar.txt'));
+        $this->assertInstanceOf(FileAttributes::class, $adapter->fileSize('foo/bar.txt'));
+        $this->assertCount(1, $adapter->listContents('foo', true));
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_write_stream(): void
+    {
+        $adapter = new ReadonlyFilesystemAdapter($this->realAdapter());
+
+        $this->expectException(UnableToWriteFile::class);
+
+        $adapter->writeStream('foo', 'content', new Config());
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_write(): void
+    {
+        $adapter = new ReadonlyFilesystemAdapter($this->realAdapter());
+
+        $this->expectException(UnableToWriteFile::class);
+
+        $adapter->write('foo', 'content', new Config());
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_delete_file(): void
+    {
+        $adapter = $this->realAdapter();
+        $adapter->write('foo', 'content', new Config());
+
+        $adapter = new ReadonlyFilesystemAdapter($adapter);
+
+        $this->expectException(UnableToDeleteFile::class);
+
+        $adapter->delete('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_delete_directory(): void
+    {
+        $adapter = $this->realAdapter();
+        $adapter->createDirectory('foo', new Config());
+
+        $adapter = new ReadonlyFilesystemAdapter($adapter);
+
+        $this->expectException(UnableToDeleteDirectory::class);
+
+        $adapter->deleteDirectory('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_create_directory(): void
+    {
+        $adapter = new ReadonlyFilesystemAdapter($this->realAdapter());
+
+        $this->expectException(UnableToCreateDirectory::class);
+
+        $adapter->createDirectory('foo', new Config());
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_set_visibility(): void
+    {
+        $adapter = $this->realAdapter();
+        $adapter->write('foo', 'content', new Config());
+
+        $adapter = new ReadonlyFilesystemAdapter($adapter);
+
+        $this->expectException(UnableToSetVisibility::class);
+
+        $adapter->setVisibility('foo', 'private');
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_move(): void
+    {
+        $adapter = $this->realAdapter();
+        $adapter->write('foo', 'content', new Config());
+
+        $adapter = new ReadonlyFilesystemAdapter($adapter);
+
+        $this->expectException(UnableToMoveFile::class);
+
+        $adapter->move('foo', 'bar', new Config());
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_copy(): void
+    {
+        $adapter = $this->realAdapter();
+        $adapter->write('foo', 'content', new Config());
+
+        $adapter = new ReadonlyFilesystemAdapter($adapter);
+
+        $this->expectException(UnableToCopyFile::class);
+
+        $adapter->copy('foo', 'bar', new Config());
+    }
+
+    private function realAdapter(): InMemoryFilesystemAdapter
+    {
+        return new InMemoryFilesystemAdapter();
+    }
+}


### PR DESCRIPTION
Allows wrapping an adapter to disallow any _write_ operations. Throws appropriate `FilesystemOperationFailed` if write operation attempted.

If acceptable, I can create a doc PR.