### PR TITLE
`ZipArchiveAdapter` changes for dealing with root dir ('')

### DIFF
--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -28,8 +28,10 @@ use ZipArchive;
 
 use function fclose;
 use function fopen;
+use function is_file;
 use function rewind;
 use function stream_copy_to_stream;
+use function unlink;
 
 final class ZipArchiveAdapter implements FilesystemAdapter
 {
@@ -173,7 +175,13 @@ final class ZipArchiveAdapter implements FilesystemAdapter
 
         $archive->deleteName($prefixedPath);
 
+        $filename = $archive->filename;
+
         $archive->close();
+
+        if ('' === $path) {
+            unlink($filename);
+        }
     }
 
     public function createDirectory(string $path, Config $config): void
@@ -189,6 +197,10 @@ final class ZipArchiveAdapter implements FilesystemAdapter
     {
         $archive = $this->zipArchiveProvider->createZipArchive();
         $location = $this->pathPrefixer->prefixDirectoryPath($path);
+
+        if ('' === $path) {
+            return is_file($archive->filename);
+        }
 
         return $archive->statName($location) !== false;
     }

--- a/src/ZipArchive/ZipArchiveAdapterTest.php
+++ b/src/ZipArchive/ZipArchiveAdapterTest.php
@@ -258,6 +258,35 @@ abstract class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
         $this->adapter()->setVisibility('path.txt', Visibility::PUBLIC);
     }
 
+    /**
+     * @test
+     */
+    public function checking_if_root_exists_checks_if_file_exists(): void
+    {
+        $adapter = $this->adapter();
+
+        $this->assertFalse($adapter->directoryExists(''));
+
+        $adapter->write('foo.txt', 'content', new Config());
+
+        $this->assertTrue($adapter->directoryExists(''));
+    }
+
+    /**
+     * @test
+     */
+    public function deleting_root_deletes_file(): void
+    {
+        $adapter = $this->adapter();
+        $adapter->write('foo.txt', 'content', new Config());
+
+        $this->assertFileExists(self::ARCHIVE);
+
+        $adapter->deleteDirectory('');
+
+        $this->assertFileDoesNotExist(self::ARCHIVE);
+    }
+
     protected static function removeZipArchive(): void
     {
         if ( ! file_exists(self::ARCHIVE)) {


### PR DESCRIPTION
This PR proposes the following changes for `ZipArchiveAdapter`:
- When checking existence of root dir, check if file exists
- When deleting root dir, delete file