### PR TITLE
fix for createDirectory when prefix is used

### DIFF
--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -209,7 +209,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
     public function createDirectory(string $path, Config $config): void
     {
-        $parts = explode('/', $this->prefixer->prefixDirectoryPath($path));
+        $parts = explode('/', ltrim($path, '/'));
         $directoryParts = [];
 
         foreach ($parts as $directory) {
@@ -219,7 +219,7 @@ class WebDAVAdapter implements FilesystemAdapter
 
             $directoryParts[] = $directory;
             $directoryPath = implode('/', $directoryParts);
-            $location = $this->encodePath($directoryPath);
+            $location = $this->encodePath($this->prefixer->prefixDirectoryPath($directoryPath));
 
             if ($this->directoryExists($directoryPath)) {
                 continue;


### PR DESCRIPTION
When a prefix is used the createDirectory is incorrect. What is going wrong: 
line 212: The parts are first retrieved including the prefix
line 224: The $directoryPath included the prefix. But the function 'directoryExists' will also put the prefix in front. So check is performed with 2 times the prefix in the path