### PR TITLE
Fixes error reason not showing when using MountManager with ReadOnlyAdapter

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -182,7 +182,7 @@ class MountManager implements FilesystemOperator
         try {
             $filesystem->delete($path);
         } catch (UnableToDeleteFile $exception) {
-            throw UnableToDeleteFile::atLocation($location, '', $exception);
+            throw UnableToDeleteFile::atLocation($location, $exception->reason(), $exception);
         }
     }
 
@@ -194,7 +194,7 @@ class MountManager implements FilesystemOperator
         try {
             $filesystem->deleteDirectory($path);
         } catch (UnableToDeleteDirectory $exception) {
-            throw UnableToDeleteDirectory::atLocation($location, '', $exception);
+            throw UnableToDeleteDirectory::atLocation($location, $exception->reason(), $exception);
         }
     }
 

--- a/src/UnableToCreateDirectory.php
+++ b/src/UnableToCreateDirectory.php
@@ -1,3 +1,5 @@
+
+
 <?php
 
 declare(strict_types=1);
@@ -14,20 +16,27 @@ final class UnableToCreateDirectory extends RuntimeException implements Filesyst
      */
     private $location;
 
+    /**
+     * @var string
+     */
+    private $reason = '';
+
     public static function atLocation(string $dirname, string $errorMessage = '', ?Throwable $previous = null): UnableToCreateDirectory
     {
         $message = "Unable to create a directory at {$dirname}. {$errorMessage}";
         $e = new static(rtrim($message), 0, $previous);
         $e->location = $dirname;
+        $e->reason = $errorMessage;
 
         return $e;
     }
 
     public static function dueToFailure(string $dirname, Throwable $previous): UnableToCreateDirectory
     {
-        $message = "Unable to create a directory at {$dirname}";
-        $e = new static($message, 0, $previous);
+        $message = "Unable to create a directory at {$dirname}. {$previous->reason()}";
+        $e = new static(rtrim($message), 0, $previous);
         $e->location = $dirname;
+        $e->reason = $previous->reason();
 
         return $e;
     }
@@ -35,6 +44,11 @@ final class UnableToCreateDirectory extends RuntimeException implements Filesyst
     public function operation(): string
     {
         return FilesystemOperationFailed::OPERATION_CREATE_DIRECTORY;
+    }
+
+    public function reason(): string
+    {
+        return $this->reason;
     }
 
     public function location(): string

--- a/src/UnableToMoveFile.php
+++ b/src/UnableToMoveFile.php
@@ -34,7 +34,8 @@ final class UnableToMoveFile extends RuntimeException implements FilesystemOpera
         string $destinationPath,
         Throwable $previous = null
     ): UnableToMoveFile {
-        $e = new static("Unable to move file from $sourcePath to $destinationPath", 0, $previous);
+        $message = $previous->getMessage() ?? "Unable to move file from $sourcePath to $destinationPath";
+        $e = new static($message, 0, $previous);
         $e->source = $sourcePath;
         $e->destination = $destinationPath;
 

--- a/src/UnableToMoveFile.php
+++ b/src/UnableToMoveFile.php
@@ -34,7 +34,7 @@ final class UnableToMoveFile extends RuntimeException implements FilesystemOpera
         string $destinationPath,
         Throwable $previous = null
     ): UnableToMoveFile {
-        $message = $previous->getMessage() ?? "Unable to move file from $sourcePath to $destinationPath";
+        $message = $previous?->getMessage() ?? "Unable to move file from $sourcePath to $destinationPath";
         $e = new static($message, 0, $previous);
         $e->source = $sourcePath;
         $e->destination = $destinationPath;


### PR DESCRIPTION
Creating a new file and deleting items doesn't show error reasons while using MountManager.  

For example using ReadOnlyAdapter throws an exception with 'This is a readonly adapter' string. This is not showing with MountManager.

This PR solves the issue.