### PR TITLE
[feature] allow `PrefixPublicUrlGenerator` to have multiple prefixes

### DIFF
--- a/src/FilesystemTest.php
+++ b/src/FilesystemTest.php
@@ -420,7 +420,7 @@ class FilesystemTest extends TestCase
     /**
      * @test
      */
-    public function creating_a_public_url(): void
+    public function creating_a_public_url_with_single_prefix(): void
     {
         $filesystem = new Filesystem(
             new InMemoryFilesystemAdapter(),
@@ -430,5 +430,28 @@ class FilesystemTest extends TestCase
         $url = $filesystem->publicUrl('path.txt');
 
         self::assertEquals('https://example.org/public/path.txt', $url);
+    }
+
+    /**
+     * @test
+     */
+    public function creating_a_public_url_with_multiple_prefixes(): void
+    {
+        $filesystem = new Filesystem(
+            new InMemoryFilesystemAdapter(),
+            ['public_url' => ['https://cdn1', 'https://cdn2']],
+        );
+
+        $url1 = $filesystem->publicUrl('path1.txt');
+        $url2 = $filesystem->publicUrl('path2.txt');
+        $url3 = $filesystem->publicUrl('path1.txt'); // deterministic
+        $url4 = $filesystem->publicUrl('/some/path.txt');
+        $url5 = $filesystem->publicUrl('some/path.txt'); // deterministic even with leading "/"
+
+        self::assertEquals('https://cdn1/path1.txt', $url1);
+        self::assertEquals('https://cdn2/path2.txt', $url2);
+        self::assertEquals('https://cdn1/path1.txt', $url3);
+        self::assertEquals('https://cdn2/some/path.txt', $url4);
+        self::assertEquals('https://cdn2/some/path.txt', $url5);
     }
 }

--- a/src/UrlGeneration/PrefixPublicUrlGenerator.php
+++ b/src/UrlGeneration/PrefixPublicUrlGenerator.php
@@ -7,17 +7,42 @@ namespace League\Flysystem\UrlGeneration;
 use League\Flysystem\Config;
 use League\Flysystem\PathPrefixer;
 
+use function array_map;
+use function array_values;
+use function count;
+use function fmod;
+use function hash;
+use function hexdec;
+use function ltrim;
+use function mb_substr;
+
 class PrefixPublicUrlGenerator implements PublicUrlGenerator
 {
-    private PathPrefixer $prefixer;
+    /** @var PathPrefixer[] */
+    private array $prefixers;
 
-    public function __construct(string $urlPrefix)
+    /**
+     * @param string|string[] $urlPrefix
+     */
+    public function __construct(string|array $urlPrefix)
     {
-        $this->prefixer = new PathPrefixer($urlPrefix, '/');
+        $this->prefixers = array_map(
+            static fn (string $prefix) => new PathPrefixer($prefix),
+            array_values((array) $urlPrefix)
+        );
     }
 
     public function publicUrl(string $path, Config $config): string
     {
-        return $this->prefixer->prefixPath($path);
+        if (1 === count($this->prefixers)) {
+            return $this->prefixers[0]->prefixPath($path);
+        }
+
+        /**
+         * @source https://github.com/symfony/symfony/blob/294195157c3690b869ff6295713a69ff38b3039c/src/Symfony/Component/Asset/UrlPackage.php#L115
+         */
+        $index = (int) fmod(hexdec(mb_substr(hash('sha256', ltrim($path, '/')), 0, 10)), count($this->prefixers));
+
+        return $this->prefixers[$index]->prefixPath($path);
     }
 }


### PR DESCRIPTION
When multiple prefixes are used, the generated URL's prefix is deterministic (the same path used multiple times will always have the same prefix).