### PR TITLE
[feature] add `Filesystem::checksum()`

### DIFF
--- a/src/AsyncAwsS3/composer.json
+++ b/src/AsyncAwsS3/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": "^8.0.2",
-        "league/flysystem": "^3.6.0",
+        "league/flysystem": "^3.7.0",
         "league/mime-type-detection": "^1.0.0",
         "async-aws/s3": "^1.5"
     },

--- a/src/AwsS3V3/composer.json
+++ b/src/AwsS3V3/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": "^8.0.2",
-        "league/flysystem": "^3.6.0",
+        "league/flysystem": "^3.7.0",
         "league/mime-type-detection": "^1.0.0",
         "aws/aws-sdk-php": "^3.132.4"
     },

--- a/src/ChecksumProvider.php
+++ b/src/ChecksumProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace League\Flysystem;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface ChecksumProvider
+{
+    /**
+     * @return string MD5 hash of the file contents
+     *
+     * @throws UnableToGetChecksum
+     */
+    public function checksum(string $path, Config $config): string;
+}

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -9,6 +9,8 @@ use League\Flysystem\UrlGeneration\PrefixPublicUrlGenerator;
 use League\Flysystem\UrlGeneration\PublicUrlGenerator;
 use Throwable;
 
+use function md5;
+
 class Filesystem implements FilesystemOperator
 {
     private FilesystemAdapter $adapter;
@@ -161,6 +163,19 @@ class Filesystem implements FilesystemOperator
         $config = $this->config->extend($config);
 
         return $this->publicUrlGenerator->publicUrl($path, $config);
+    }
+
+    public function checksum(string $path, array $config = []): string
+    {
+        if ($this->adapter instanceof ChecksumProvider) {
+            return $this->adapter->checksum($path, $this->config->extend($config));
+        }
+
+        try {
+            return md5($this->read($path));
+        } catch (FilesystemException $exception) {
+            throw new UnableToGetChecksum($exception->getMessage(), $path, $exception);
+        }
     }
 
     private function resolvePublicUrlGenerator(): ?PublicUrlGenerator

--- a/src/FilesystemTest.php
+++ b/src/FilesystemTest.php
@@ -431,4 +431,51 @@ class FilesystemTest extends TestCase
 
         self::assertEquals('https://example.org/public/path.txt', $url);
     }
+
+    /**
+     * @test
+     */
+    public function get_checksum_for_adapter_that_supports(): void
+    {
+        $this->filesystem->write('path.txt', 'foobar');
+
+        $this->assertSame('3858f62230ac3c915f300c664312c63f', $this->filesystem->checksum('path.txt'));
+    }
+
+    /**
+     * @test
+     */
+    public function get_checksum_for_adapter_that_does_not_support(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+
+        $filesystem->write('path.txt', 'foobar');
+
+        $this->assertSame('3858f62230ac3c915f300c664312c63f', $filesystem->checksum('path.txt'));
+    }
+
+    /**
+     * @test
+     */
+    public function unable_to_get_checksum_for_for_file_that_does_not_exist(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+
+        $this->expectException(UnableToGetChecksum::class);
+
+        $filesystem->checksum('path.txt');
+    }
+
+    /**
+     * @test
+     */
+    public function unable_to_get_checksum_directory(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->createDirectory('foo');
+
+        $this->expectException(UnableToGetChecksum::class);
+
+        $filesystem->checksum('foo');
+    }
 }

--- a/src/UnableToGetChecksum.php
+++ b/src/UnableToGetChecksum.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem;
+
+use RuntimeException;
+use Throwable;
+
+final class UnableToGetChecksum extends RuntimeException implements FilesystemException
+{
+    public function __construct(string $reason, string $path, ?Throwable $previous = null)
+    {
+        parent::__construct("Unable to get checksum for $path: $reason", 0, $previous);
+    }
+}


### PR DESCRIPTION
If an adapter implements `ChecksumProvider`, this method returns the checksum. If not, the checksum is calculated (md5) based on the file contents.

The following adapters support checksums natively:
- Local (uses `md5_file`)
- AsyncAwsS3 (uses `ETag` header value)
- AwsS3V3Adapter (uses `ETag` header value)

Fixes #1283.