### PR TITLE
Add `@method` annotations to `FilesystemReader`

### DIFF
--- a/src/FilesystemReader.php
+++ b/src/FilesystemReader.php
@@ -7,6 +7,9 @@ namespace League\Flysystem;
 /**
  * This interface contains everything to read from and inspect
  * a filesystem. All methods containing are non-destructive.
+ *
+ * @method string publicUrl(string $path, array $config = []) Will be added in 4.0
+ * @method string checksum(string $path, array $config = []) Will be added in 4.0
  */
 interface FilesystemReader
 {


### PR DESCRIPTION
This is a common practice in Symfony to denote how interfaces will look in the future.