### PR TITLE
Allow configuring `Filesystem` with a `PublicUrlGenerator` instance

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -183,7 +183,7 @@ class Filesystem implements FilesystemOperator
     private function resolvePublicUrlGenerator(): ?PublicUrlGenerator
     {
         if ($publicUrl = $this->config->get('public_url')) {
-            return new PrefixPublicUrlGenerator($publicUrl);
+            return $publicUrl instanceof PublicUrlGenerator ? $publicUrl : new PrefixPublicUrlGenerator($publicUrl);
         }
 
         if ($this->adapter instanceof PublicUrlGenerator) {

--- a/src/FilesystemTest.php
+++ b/src/FilesystemTest.php
@@ -440,6 +440,24 @@ class FilesystemTest extends TestCase
     /**
      * @test
      */
+    public function custom_public_url_generator(): void
+    {
+        $filesystem = new Filesystem(
+            new InMemoryFilesystemAdapter(),
+            ['public_url' => new class() implements PublicUrlGenerator {
+                public function publicUrl(string $path, Config $config): string
+                {
+                    return 'custom/' . $path;
+                }
+            }],
+        );
+
+        self::assertSame('custom/file.txt', $filesystem->publicUrl('file.txt'));
+    }
+
+    /**
+     * @test
+     */
     public function get_checksum_for_adapter_that_supports(): void
     {
         $this->filesystem->write('path.txt', 'foobar');


### PR DESCRIPTION
Currently, it's only possible to configure with a string prefix.