### PR TITLE
Run phpstan and php-cs-fixer in PHP 8.0

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -62,8 +62,8 @@ jobs:
       - run: php test_files/wait_for_ftp.php 2122
       - run: COMPOSER_OPTS='${{ matrix.composer-flags }}' vendor/bin/phpunit ${{ matrix.phpunit-flags }}
       - run: vendor/bin/phpstan analyse
-        if: ${{ matrix.php == '7.4' }}
+        if: ${{ matrix.php == '8.0' }}
       - run: vendor/bin/php-cs-fixer fix --diff --dry-run
         continue-on-error: true
-        if: ${{ matrix.php == '7.4' }}
+        if: ${{ matrix.php == '8.0' }}
 


### PR DESCRIPTION
In branch `3.x` the quality assurance steps related to `phpstan` and `php-cs-fixer` must run in PHP 8.0

Currently, these steps are being skipped.