### PR TITLE
WebDAV: MKCOL requires a trailing slash

### DIFF
--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -219,7 +219,7 @@ class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
 
             $directoryParts[] = $directory;
             $directoryPath = implode('/', $directoryParts);
-            $location = $this->encodePath($directoryPath);
+            $location = $this->encodePath($directoryPath) . '/';
 
             if ($this->directoryExists($this->prefixer->stripDirectoryPrefix($directoryPath))) {
                 continue;


### PR DESCRIPTION
When creating a collection WebDAV can only create it with a trailing slash, otherwise generates an error

RFC https://tools.ietf.org/html/rfc4918#section-9.3