### PR TITLE
Handle checksum errors without message

### DIFF
--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -421,7 +421,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
         $checksum = @hash_file($algo, $location);
 
         if ($checksum === false) {
-            throw new UnableToProvideChecksum(error_get_last()['message'], $path);
+            throw new UnableToProvideChecksum(error_get_last()['message'] ?? '', $path);
         }
 
         return $checksum;


### PR DESCRIPTION
I encountered the following error today, while using the checksum functionality on a local disk:

```
ErrorException Trying to access array offset on value of type null 
    vendor/league/flysystem/src/Local/LocalFilesystemAdapter.php:453 Illuminate\Foundation\Bootstrap\HandleExceptions::handleError
    vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php:259 Illuminate\Foundation\Bootstrap\HandleExceptions::Illuminate\Foundation\Bootstrap\{closure}
    vendor/league/flysystem/src/Local/LocalFilesystemAdapter.php:453 League\Flysystem\Local\LocalFilesystemAdapter::checksum
    vendor/league/flysystem/src/Filesystem.php:198 League\Flysystem\Filesystem::checksum
    vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemAdapter.php:568 Illuminate\Filesystem\FilesystemAdapter::checksum
```

The `error_get_last()` method does not always return a message, so it's better to provide an empty string as a fallback, like the other methods on the local adapter do.
