### PR TITLE
fix gcloud bucket storage copy when acl not available

### DIFF
--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -348,8 +348,12 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter, PublicUrlGenerator
     public function copy(string $source, string $destination, Config $config): void
     {
         try {
-            /** @var string $visibility */
-            $visibility = $this->visibility($source)->visibility();
+            try {
+                /** @var string $visibility */
+                $visibility = $this->visibility($source)->visibility();
+            } catch (UnableToRetrieveMetadata $e) {
+                $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
+            }
             $prefixedSource = $this->prefixer->prefixPath($source);
             $options = ['name' => $this->prefixer->prefixPath($destination)];
             $predefinedAcl = $this->visibilityHandler->visibilityToPredefinedAcl($visibility);


### PR DESCRIPTION
fix: https://github.com/thephpleague/flysystem/issues/1593
fix: https://github.com/thephpleague/flysystem-google-cloud-storage/issues/4

This will allow the copy function to work when using uniform IAM access control as recommended by google