### PR TITLE
Added prefixed paths onto checksum and temporary url methods

### DIFF
--- a/src/PathPrefixing/PathPrefixedAdapter.php
+++ b/src/PathPrefixing/PathPrefixedAdapter.php
@@ -208,7 +208,7 @@ class PathPrefixedAdapter implements FilesystemAdapter, PublicUrlGenerator, Chec
             return $this->adapter->checksum($path, $config);
         }
 
-        return $this->calculateChecksumFromStream($path, $config);
+        return $this->calculateChecksumFromStream($this->prefix->prefixPath($path), $config);
     }
 
     public function temporaryUrl(string $path, DateTimeInterface $expiresAt, Config $config): string
@@ -217,6 +217,6 @@ class PathPrefixedAdapter implements FilesystemAdapter, PublicUrlGenerator, Chec
             throw UnableToGenerateTemporaryUrl::noGeneratorConfigured($path);
         }
 
-        return $this->adapter->temporaryUrl($path, $expiresAt, $config);
+        return $this->adapter->temporaryUrl($this->prefix->prefixPath($path), $expiresAt, $config);
     }
 }


### PR DESCRIPTION
Essentially `checksum` and `temporaryUrl` we're left off the path prefix'ing, and are included here.

This fixes a bug that got caught when passing a `PathPrefixedAdapter` through `FilesystemAdapterTestCase`.