### PR TITLE
feat: add `ChainPublicUrlGenerator`

### DIFF
--- a/src/UrlGeneration/ChainPublicUrlGenerator.php
+++ b/src/UrlGeneration/ChainPublicUrlGenerator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\UrlGeneration;
+
+use League\Flysystem\Config;
+use League\Flysystem\UnableToGeneratePublicUrl;
+
+final class ChainPublicUrlGenerator implements PublicUrlGenerator
+{
+    /**
+     * @param PublicUrlGenerator[] $generators
+     */
+    public function __construct(private iterable $generators)
+    {
+    }
+
+    public function publicUrl(string $path, Config $config): string
+    {
+        foreach ($this->generators as $generator) {
+            try {
+                return $generator->publicUrl($path, $config);
+            } catch (UnableToGeneratePublicUrl) {
+            }
+        }
+
+        throw new UnableToGeneratePublicUrl('No supported public url generator found.', $path);
+    }
+}

--- a/src/UrlGeneration/ChainPublicUrlGeneratorTest.php
+++ b/src/UrlGeneration/ChainPublicUrlGeneratorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace League\Flysystem\UrlGeneration;
+
+use League\Flysystem\Config;
+use League\Flysystem\UnableToGeneratePublicUrl;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ChainPublicUrlGeneratorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_generate_url_for_supported_generator(): void
+    {
+        $generator = new ChainPublicUrlGenerator([
+            new class() implements PublicUrlGenerator
+            {
+                public function publicUrl(string $path, Config $config): string
+                {
+                    throw new UnableToGeneratePublicUrl('not supported', $path);
+                }
+            },
+            new PrefixPublicUrlGenerator('/prefix'),
+        ]);
+
+        $this->assertSame('/prefix/some/path', $generator->publicUrl('some/path', new Config()));
+    }
+
+    /**
+     * @test
+     */
+    public function no_supported_generator_found_throws_exception(): void
+    {
+        $generator = new ChainPublicUrlGenerator([
+            new class() implements PublicUrlGenerator
+            {
+                public function publicUrl(string $path, Config $config): string
+                {
+                    throw new UnableToGeneratePublicUrl('not supported', $path);
+                }
+            },
+        ]);
+
+        $this->expectException(UnableToGeneratePublicUrl::class);
+        $this->expectExceptionMessage('Unable to generate public url for some/path: No supported public url generator found.');
+
+        $generator->publicUrl('some/path', new Config());
+    }
+}


### PR DESCRIPTION
This allows having a url generator that supports multiple url generation schemes. Consider the following example:

```php
$filesystem = new Filesystem($adapter, publicUrlGenerator: new ChainPublicUrlGenerator([
    new SomeImageFilterPublicUrlGenerator(...), // only works if "filter" key is passed to config
    new PrefixPublicUrlGenerator(...),
]));

$filesystem->publicUrl('some/path.png', ['filter' => 'square300']);
$filesystem->publicUrl('some/path.png'); // uses PrefixPublicUrlGenerator
```