### PR TITLE
[ZipArchive] fix listing contents at root when not using root prefix

### DIFF
--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -407,7 +407,13 @@ final class ZipArchiveAdapter implements FilesystemAdapter
 
     private function isAtRootDirectory(string $directoryRoot, string $path): bool
     {
-        return $directoryRoot === (rtrim(dirname($path), '/') . '/');
+        $dirname = dirname($path);
+
+        if ('' === $directoryRoot && '.' === $dirname) {
+            return true;
+        }
+
+        return $directoryRoot === (rtrim($dirname, '/') . '/');
     }
 
     private function setVisibilityAttribute(string $statsName, string $visibility, ZipArchive $archive): bool

--- a/src/ZipArchive/ZipArchiveAdapterTest.php
+++ b/src/ZipArchive/ZipArchiveAdapterTest.php
@@ -165,6 +165,20 @@ abstract class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function list_root_directory(): void
+    {
+        $this->givenWeHaveAnExistingFile('a.txt');
+        $this->givenWeHaveAnExistingFile('one/a.txt');
+        $this->givenWeHaveAnExistingFile('one/b.txt');
+        $this->givenWeHaveAnExistingFile('two/a.txt');
+
+        $this->assertCount(6, $this->adapter()->listContents('', true));
+        $this->assertCount(3, $this->adapter()->listContents('', false));
+    }
+
+    /**
+     * @test
+     */
     public function failing_to_create_a_directory(): void
     {
         static::$archiveProvider->stubbedZipArchive()->failNextDirectoryCreation();


### PR DESCRIPTION
Currently, `$zipAdapter->listContents('', false)` always returns an empty iterator if the root is `''`.