### PR TITLE
Bugfix: IIS WebDAV responses with domain prefixes.

### DIFF
--- a/src/WebDAV/.gitattributes
+++ b/src/WebDAV/.gitattributes
@@ -5,4 +5,5 @@
 .gitignore export-ignore
 **/*Test.php export-ignore
 **/*TestCase.php export-ignore
+**/*Stub.php export-ignore
 resources export-ignore

--- a/src/WebDAV/ByteMarkWebDAVServerTest.php
+++ b/src/WebDAV/ByteMarkWebDAVServerTest.php
@@ -11,7 +11,7 @@ class ByteMarkWebDAVServerTest extends WebDAVAdapterTestCase
 {
     protected static function createFilesystemAdapter(): FilesystemAdapter
     {
-        $client = new Client(['baseUri' => 'http://localhost:4080/', 'userName' => 'alice', 'password' => 'secret1234']);
+        $client = new UrlPrefixingClientStub(['baseUri' => 'http://localhost:4080/', 'userName' => 'alice', 'password' => 'secret1234']);
 
         return new WebDAVAdapter($client, manualCopy: true, manualMove: true);
     }

--- a/src/WebDAV/UrlPrefixingClientStub.php
+++ b/src/WebDAV/UrlPrefixingClientStub.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace League\Flysystem\WebDAV;
+
+use Sabre\DAV\Client;
+
+class UrlPrefixingClientStub extends Client
+{
+    public function propFind($url, array $properties, $depth = 0)
+    {
+        $response = parent::propFind($url, $properties, $depth);
+
+        if ($depth === 0) {
+            return $response;
+        }
+
+        $formatted = [];
+
+        foreach ($response as $path => $object) {
+            $formatted['https://domain.tld/' . ltrim($path, '/')] = $object;
+        }
+
+        return $formatted;
+    }
+}

--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -34,6 +34,8 @@ use function dirname;
 use function explode;
 use function fclose;
 use function implode;
+use function parse_url;
+use function rawurldecode;
 use function var_dump;
 
 class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
@@ -280,7 +282,8 @@ class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
         array_shift($response);
 
         foreach ($response as $path => $object) {
-            $path = $this->prefixer->stripPrefix(rawurldecode($path));
+            $path = (string) parse_url(rawurldecode($path), PHP_URL_PATH);
+            $path = $this->prefixer->stripPrefix($path);
             $object = $this->normalizeObject($object);
 
             if ($this->propsIsDirectory($object)) {

--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -34,6 +34,7 @@ use function dirname;
 use function explode;
 use function fclose;
 use function implode;
+use function var_dump;
 
 class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
 {
@@ -274,6 +275,8 @@ class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
     {
         $location = $this->encodePath($this->prefixer->prefixDirectoryPath($path));
         $response = $this->client->propFind($location, self::FIND_PROPERTIES, 1);
+
+        // This is the directory itself, the files are subsequent entries.
         array_shift($response);
 
         foreach ($response as $path => $object) {

--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -36,7 +36,6 @@ use function fclose;
 use function implode;
 use function parse_url;
 use function rawurldecode;
-use function var_dump;
 
 class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
 {


### PR DESCRIPTION
In #1607 a scenario was described where the WebDAV keys are full URL paths. Because of this, the normal prefixing strategy breaks, as it expects the path only to be prefixed with known input. This PR parses out the path from the full key, this strips out the schema, domain, port, and only leaves the path.