### PR TITLE
Allow injecting custom PathPrefixer

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -18,6 +18,7 @@ use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\Prefixer;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCheckFileExistence;
 use League\Flysystem\UnableToCopyFile;
@@ -76,7 +77,7 @@ class AsyncAwsS3Adapter implements FilesystemAdapter
     private $client;
 
     /**
-     * @var PathPrefixer
+     * @var Prefixer
      */
     private $prefixer;
 
@@ -103,10 +104,11 @@ class AsyncAwsS3Adapter implements FilesystemAdapter
         string $bucket,
         string $prefix = '',
         VisibilityConverter $visibility = null,
-        MimeTypeDetector $mimeTypeDetector = null
+        MimeTypeDetector $mimeTypeDetector = null,
+        ?Prefixer $prefixer = null
     ) {
         $this->client = $client;
-        $this->prefixer = new PathPrefixer($prefix);
+        $this->prefixer = $prefixer ?? new PathPrefixer($prefix);
         $this->bucket = $bucket;
         $this->visibility = $visibility ?: new PortableVisibilityConverter();
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -13,6 +13,7 @@ use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemOperationFailed;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\Prefixer;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCheckFileExistence;
 use League\Flysystem\UnableToCopyFile;
@@ -74,7 +75,7 @@ class AwsS3V3Adapter implements FilesystemAdapter
     private $client;
 
     /**
-     * @var PathPrefixer
+     * @var Prefixer
      */
     private $prefixer;
 
@@ -110,10 +111,11 @@ class AwsS3V3Adapter implements FilesystemAdapter
         VisibilityConverter $visibility = null,
         MimeTypeDetector $mimeTypeDetector = null,
         array $options = [],
-        bool $streamReads = true
+        bool $streamReads = true,
+        ?Prefixer $prefixer = null
     ) {
         $this->client = $client;
-        $this->prefixer = new PathPrefixer($prefix);
+        $this->prefixer = $prefixer ?? new PathPrefixer($prefix);
         $this->bucket = $bucket;
         $this->visibility = $visibility ?: new PortableVisibilityConverter();
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -12,6 +12,7 @@ use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\Prefixer;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToDeleteDirectory;
@@ -34,7 +35,7 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
     private $bucket;
 
     /**
-     * @var PathPrefixer
+     * @var Prefixer
      */
     private $prefixer;
 
@@ -58,10 +59,11 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
         string $prefix = '',
         VisibilityHandler $visibilityHandler = null,
         string $defaultVisibility = Visibility::PRIVATE,
-        MimeTypeDetector $mimeTypeDetector = null
+        MimeTypeDetector $mimeTypeDetector = null,
+        ?Prefixer $prefixer = null
     ) {
         $this->bucket = $bucket;
-        $this->prefixer = new PathPrefixer($prefix);
+        $this->prefixer = $prefixer ?? new PathPrefixer($prefix);
         $this->visibilityHandler = $visibilityHandler ?: new PortableVisibilityHandler();
         $this->defaultVisibility = $defaultVisibility;
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -15,6 +15,7 @@ use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\Prefixer;
 use League\Flysystem\SymbolicLinkEncountered;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
@@ -57,7 +58,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter
     public const DISALLOW_LINKS = 0002;
 
     /**
-     * @var PathPrefixer
+     * @var Prefixer
      */
     private $prefixer;
 
@@ -86,9 +87,10 @@ class LocalFilesystemAdapter implements FilesystemAdapter
         VisibilityConverter $visibility = null,
         int $writeFlags = LOCK_EX,
         int $linkHandling = self::DISALLOW_LINKS,
-        MimeTypeDetector $mimeTypeDetector = null
+        MimeTypeDetector $mimeTypeDetector = null,
+        ?Prefixer $prefixer = null
     ) {
-        $this->prefixer = new PathPrefixer($location, DIRECTORY_SEPARATOR);
+        $this->prefixer = $prefixer ?? new PathPrefixer($location, DIRECTORY_SEPARATOR);
         $this->writeFlags = $writeFlags;
         $this->linkHandling = $linkHandling;
         $this->visibility = $visibility ?: new PortableVisibilityConverter();

--- a/src/PathPrefixer.php
+++ b/src/PathPrefixer.php
@@ -8,7 +8,7 @@ use function rtrim;
 use function strlen;
 use function substr;
 
-final class PathPrefixer
+final class PathPrefixer implements Prefixer
 {
     /**
      * @var string

--- a/src/PhpseclibV2/SftpAdapter.php
+++ b/src/PhpseclibV2/SftpAdapter.php
@@ -10,6 +10,7 @@ use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\Prefixer;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
@@ -38,7 +39,7 @@ class SftpAdapter implements FilesystemAdapter
     private $visibilityConverter;
 
     /**
-     * @var PathPrefixer
+     * @var Prefixer
      */
     private $prefixer;
 
@@ -51,10 +52,11 @@ class SftpAdapter implements FilesystemAdapter
         ConnectionProvider $connectionProvider,
         string $root,
         VisibilityConverter $visibilityConverter = null,
-        MimeTypeDetector $mimeTypeDetector = null
+        MimeTypeDetector $mimeTypeDetector = null,
+        ?Prefixer $prefixer = null
     ) {
         $this->connectionProvider = $connectionProvider;
-        $this->prefixer = new PathPrefixer($root);
+        $this->prefixer = $prefixer ?? new PathPrefixer($root);
         $this->visibilityConverter = $visibilityConverter ?: new PortableVisibilityConverter();
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
     }

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -10,6 +10,7 @@ use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\Prefixer;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
@@ -38,7 +39,7 @@ class SftpAdapter implements FilesystemAdapter
     private $visibilityConverter;
 
     /**
-     * @var PathPrefixer
+     * @var Prefixer
      */
     private $prefixer;
 
@@ -51,10 +52,11 @@ class SftpAdapter implements FilesystemAdapter
         ConnectionProvider $connectionProvider,
         string $root,
         VisibilityConverter $visibilityConverter = null,
-        MimeTypeDetector $mimeTypeDetector = null
+        MimeTypeDetector $mimeTypeDetector = null,
+        Prefixer $prefixer = null
     ) {
         $this->connectionProvider = $connectionProvider;
-        $this->prefixer = new PathPrefixer($root);
+        $this->prefixer = $prefixer ?? new PathPrefixer($root);
         $this->visibilityConverter = $visibilityConverter ?: new PortableVisibilityConverter();
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
     }

--- a/src/Prefixer.php
+++ b/src/Prefixer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem;
+
+interface Prefixer
+{
+    public function prefixPath(string $path): string;
+
+    public function stripPrefix(string $path): string;
+
+    public function stripDirectoryPrefix(string $path): string;
+
+    public function prefixDirectoryPath(string $path): string;
+}

--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -10,6 +10,7 @@ use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\PathPrefixer;
+use League\Flysystem\Prefixer;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
 use League\Flysystem\UnableToDeleteDirectory;
@@ -34,7 +35,7 @@ use function stream_with_contents;
 
 final class ZipArchiveAdapter implements FilesystemAdapter
 {
-    /** @var PathPrefixer */
+    /** @var Prefixer */
     private $pathPrefixer;
     /** @var MimeTypeDetector */
     private $mimeTypeDetector;
@@ -47,9 +48,10 @@ final class ZipArchiveAdapter implements FilesystemAdapter
         ZipArchiveProvider $zipArchiveProvider,
         string $root = '',
         ?MimeTypeDetector $mimeTypeDetector = null,
-        ?VisibilityConverter $visibility = null
+        ?VisibilityConverter $visibility = null,
+        ?Prefixer $prefixer = null
     ) {
-        $this->pathPrefixer = new PathPrefixer($root);
+        $this->pathPrefixer = $prefixer ?? new PathPrefixer($root);
         $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
         $this->visibility = $visibility ?? new PortableVisibilityConverter();
         $this->zipArchiveProvider = $zipArchiveProvider;


### PR DESCRIPTION
Hello.
We're trying to upgrade our Product to use Flysystem v2 (can't switch to v3 due to PHP 7.4 being still in use).
However for us a path where we store files is dynamic - determined at runtime depending on a context.

If we had the ability to inject our custom PathPrefixer, it would solve all our issues. This PR enables that. Otherwise we needed to copy 1:1 `src/Local/LocalFilesystemAdapter.php` just to use our own Path Prefixer.

## Known issues

Naming. Ideally I'd name the interface `PathPrefixer` and the implementation `NativePathPrefixer` or `PortablePathPrefixer` (trying to follow the existing convention). However due to BC (there's `PathPrefixer` class already), I called it simply `Prefixer`. Not sure if there's better name.