### PR TITLE
Chunk s3 delete calls when deleting huge directories with AsyncAws

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -186,7 +186,12 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
             return;
         }
 
-        $this->client->deleteObjects(['Bucket' => $this->bucket, 'Delete' => ['Objects' => $objects]]);
+        foreach (array_chunk($objects, 1000) as $chunk) {
+            $this->client->deleteObjects([
+                'Bucket' => $this->bucket,
+                'Delete' => ['Objects' => $chunk],
+            ]);
+        }
     }
 
     public function createDirectory(string $path, Config $config): void


### PR DESCRIPTION
Fixes https://github.com/thephpleague/flysystem/issues/1615

As stated in the linked issue AsyncAws is dumb and does no chunking, in the AsyncAws Adapter we also loop over all objects in a "directory", and create one big delete request for all objects.

This may lead to issues if to many objects should be deleted in one request, as stated in the linked issue. IMHO as AsyncAws already loops through all objects in a "directory" it should also chunk the created delete commands accordingly.

I'm not sure about the exact chunk size we should use, locally trying to delete a dir with ~5.000 objects failed, using a chunk size of 1.000 worked so I used that.

We can also think about making the chunk size configurable, but i'm not sure if that is really needed.