### PR TITLE
Add support for PuTTY ppk files to sftp v3

### DIFF
--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -163,7 +163,7 @@ class SftpConnectionProvider implements ConnectionProvider
 
     private function loadPrivateKey(): AsymmetricKey
     {
-        if ("---" !== substr($this->privateKey, 0, 3) && is_file($this->privateKey)) {
+        if (("---" !== substr($this->privateKey, 0, 3) || "PuTTY" !== substr($this->privateKey, 0, 5)) && is_file($this->privateKey)) {
             $this->privateKey = file_get_contents($this->privateKey);
         }
 


### PR DESCRIPTION
phpseclib v3 supports loading PuTTY ppk files, but the sftp v3 provider assumes the provided private key is always a file, if it does not start with 3 dashes.