### PR TITLE
image/svg to image/svg+xml

### DIFF
--- a/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
+++ b/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
@@ -491,7 +491,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
 
             $mimetype = $this->adapter()->mimeType('file.svg')->mimeType();
 
-            $this->assertStringStartsWith('image/svg', $mimetype);
+            $this->assertStringStartsWith('image/svg+xml', $mimetype);
         });
     }
 

--- a/src/InMemory/InMemoryFilesystemAdapterTest.php
+++ b/src/InMemory/InMemoryFilesystemAdapterTest.php
@@ -261,7 +261,7 @@ class InMemoryFilesystemAdapterTest extends FilesystemAdapterTestCase
         $this->assertTrue($adapter->fileExists(self::PATH));
         $this->assertEquals(754, $adapter->fileSize(self::PATH)->fileSize());
         $this->assertEquals(1234, $adapter->lastModified(self::PATH)->lastModified());
-        $this->assertStringStartsWith('image/svg', $adapter->mimeType(self::PATH)->mimeType());
+        $this->assertStringStartsWith('image/svg+xml', $adapter->mimeType(self::PATH)->mimeType());
     }
 
     /**

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -530,7 +530,7 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
             (string) file_get_contents(__DIR__ . '/../AdapterTestUtilities/test_files/flysystem.svg'),
             new Config()
         );
-        $this->assertStringStartsWith('image/svg', $adapter->mimeType('flysystem.svg')->mimeType());
+        $this->assertStringStartsWith('image/svg+xml', $adapter->mimeType('flysystem.svg')->mimeType());
     }
 
     /**

--- a/src/PhpseclibV2/SftpAdapterTest.php
+++ b/src/PhpseclibV2/SftpAdapterTest.php
@@ -132,7 +132,7 @@ class SftpAdapterTest extends FilesystemAdapterTestCase
 
         $mimeType = $adapter->mimeType('file.svg');
 
-        $this->assertStringStartsWith('image/svg', $mimeType->mimeType());
+        $this->assertStringStartsWith('image/svg+xml', $mimeType->mimeType());
     }
 
     /**

--- a/src/PhpseclibV3/SftpAdapterTest.php
+++ b/src/PhpseclibV3/SftpAdapterTest.php
@@ -133,7 +133,7 @@ class SftpAdapterTest extends FilesystemAdapterTestCase
 
         $mimeType = $adapter->mimeType('file.svg');
 
-        $this->assertStringStartsWith('image/svg', $mimeType->mimeType());
+        $this->assertStringStartsWith('image/svg+xml', $mimeType->mimeType());
     }
 
     /**

--- a/src/WebDAV/resources/server.php
+++ b/src/WebDAV/resources/server.php
@@ -19,7 +19,7 @@ $server->addPlugin(new Sabre\DAV\Browser\Plugin());
 
 if (strpos($_SERVER['REQUEST_URI'], 'unknown-mime-type.md5') === false) {
     $guesser = new Sabre\DAV\Browser\GuessContentType();
-    $guesser->extensionMap['svg'] = 'image/svg';
+    $guesser->extensionMap['svg'] = 'image/svg+xml';
     $server->addPlugin($guesser);
 }
 


### PR DESCRIPTION
There is no a mimeType called image/svg but image/svg+xml.
https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#svg_scalable_vector_graphics

If you guess that mimeType as image/svg the saved file will not be previewed in s3, at least in DO spaces. File will be downloaded instead of view in browser which means my svg logo which was uploaded to DO space won't be visible unless i fix the mimeType.