### PR TITLE
fix(AsyncAwsS3): Ensure top-level directory is not returned in directory listing

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -285,7 +285,13 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
         $listing = $this->retrievePaginatedListing($options);
 
         foreach ($listing as $item) {
-            yield $this->mapS3ObjectMetadata($item);
+            $item = $this->mapS3ObjectMetadata($item);
+
+            if ("{$item->path()}/" === $prefix) {
+                continue;
+            }
+
+            yield $item;
         }
     }
 


### PR DESCRIPTION
Same fix as #1437 but for `AsyncAwsS3Adapter`.