### PR TITLE
Use local adapter as new package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,18 +50,5 @@
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ],
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "league/flysystem-local",
-                "version": "3.0.0",
-                "dist": {
-                    "type": "path",
-                    "url": "src/Local"
-                }
-            }
-        }
     ]
 }


### PR DESCRIPTION
Hi, with this config composer does not install new package `league/flysystem-local` 