### PR TITLE
Update set-subsplit-default-branch.yml replacing checkout@v2 for checkout@v3

### DIFF
--- a/.github/workflows/set-subsplit-default-branch.yml
+++ b/.github/workflows/set-subsplit-default-branch.yml
@@ -8,7 +8,7 @@ jobs:
     name: Set default git branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
           persist-credentials: 'false'


### PR DESCRIPTION
This replaces the Github Actions V2 (which is deprecated) for V3

## Additional context
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/