### PR TITLE
Fix InMemory not overwriting on move

### DIFF
--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -226,12 +226,20 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         $source = $this->preparePath($source);
         $destination = $this->preparePath($destination);
 
-        if ( ! $this->fileExists($source) || $this->fileExists($destination)) {
-            throw UnableToMoveFile::fromLocationTo($source, $destination);
+        if ($this->fileExists($source)) {
+            $this->files[$destination] = $this->files[$source];
+            unset($this->files[$source]);
+            return;
         }
 
-        $this->files[$destination] = $this->files[$source];
-        unset($this->files[$source]);
+        if ($this->directoryExists($source)) {
+            $this->deleteDirectory($destination);
+            $this->copy($source, $destination, $config);
+            $this->deleteDirectory($source);
+            return;
+        }
+
+        throw UnableToMoveFile::fromLocationTo($source, $destination);
     }
 
     public function copy(string $source, string $destination, Config $config): void

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -19,9 +19,7 @@ use League\MimeTypeDetection\MimeTypeDetector;
 
 use function array_keys;
 use function rtrim;
-use function strlen;
 use function strpos;
-use function substr;
 
 class InMemoryFilesystemAdapter implements FilesystemAdapter
 {
@@ -232,13 +230,6 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
             return;
         }
 
-        if ($this->directoryExists($source)) {
-            $this->deleteDirectory($destination);
-            $this->copy($source, $destination, $config);
-            $this->deleteDirectory($source);
-            return;
-        }
-
         throw UnableToMoveFile::fromLocationTo($source, $destination);
     }
 
@@ -247,28 +238,13 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         $source = $this->preparePath($source);
         $destination = $this->preparePath($destination);
 
+        if ( ! $this->fileExists($source)) {
+            throw UnableToCopyFile::fromLocationTo($source, $destination);
+        }
+
         $lastModified = $config->get('timestamp', time());
 
-        if ($this->fileExists($source)) {
-            $this->files[$destination] = $this->files[$source]->withLastModified($lastModified);
-            return;
-        }
-
-        if ($this->directoryExists($source)) {
-            $sourcePrefix = rtrim($source, '/') . '/';
-            $destinationPrefix = rtrim($destination, '/') . '/';
-
-            foreach (array_keys($this->files) as $path) {
-                if (strpos($path, $sourcePrefix) === 0) {
-                    $newPath = $destinationPrefix . substr($path, strlen($sourcePrefix));
-                    $this->files[$newPath] = $this->files[$path]->withLastModified($lastModified);
-                }
-            }
-
-            return;
-        }
-
-        throw UnableToCopyFile::fromLocationTo($source, $destination);
+        $this->files[$destination] = $this->files[$source]->withLastModified($lastModified);
     }
 
     private function preparePath(string $path): string

--- a/src/InMemory/InMemoryFilesystemAdapterTest.php
+++ b/src/InMemory/InMemoryFilesystemAdapterTest.php
@@ -226,6 +226,19 @@ class InMemoryFilesystemAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function copying_a_directory(): void
+    {
+        $adapter = $this->adapter();
+        $adapter->createDirectory('/source_directory', new Config());
+        $adapter->write('/source_directory/a', 'contents', new Config());
+        $adapter->copy('/source_directory', '/target_directory', new Config());
+        $this->assertTrue($adapter->fileExists('/target_directory/a'));
+        $this->assertTrue($adapter->fileExists('/source_directory/a'));
+    }
+
+    /**
+     * @test
+     */
     public function trying_to_copy_a_non_existing_file(): void
     {
         $this->expectException(UnableToCopyFile::class);

--- a/src/InMemory/InMemoryFilesystemAdapterTest.php
+++ b/src/InMemory/InMemoryFilesystemAdapterTest.php
@@ -214,19 +214,6 @@ class InMemoryFilesystemAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
-    public function copying_a_directory(): void
-    {
-        $adapter = $this->adapter();
-        $adapter->createDirectory('/source_directory', new Config());
-        $adapter->write('/source_directory/a', 'contents', new Config());
-        $adapter->copy('/source_directory', '/target_directory', new Config());
-        $this->assertTrue($adapter->fileExists('/target_directory/a'));
-        $this->assertTrue($adapter->fileExists('/source_directory/a'));
-    }
-
-    /**
-     * @test
-     */
     public function trying_to_copy_a_non_existing_file(): void
     {
         $this->expectException(UnableToCopyFile::class);
@@ -318,43 +305,6 @@ class InMemoryFilesystemAdapterTest extends FilesystemAdapterTestCase
             );
             $this->assertEquals(Visibility::PUBLIC, $adapter->visibility('destination.txt')->visibility());
             $this->assertEquals('contents to be moved', $adapter->read('destination.txt'));
-        });
-    }
-
-    /**
-     * @test
-     * @fixme Move to FilesystemAdapterTestCase once all adapters pass
-     */
-    public function moving_a_directory_and_overwriting(): void
-    {
-        $this->runScenario(function() {
-            $adapter = $this->adapter();
-            $config = new Config();
-
-            $adapter->createDirectory('move_and_overwrite_source', $config);
-            $adapter->write('move_and_overwrite_source/a', 'a', $config);
-
-            $adapter->createDirectory('move_and_overwrite_target', $config);
-            $adapter->write('move_and_overwrite_target/b', 'b', $config);
-
-            $adapter->move('move_and_overwrite_source', 'move_and_overwrite_target', $config);
-
-            $this->assertFalse(
-                $adapter->directoryExists('move_and_overwrite_source'),
-                'Source directory should not exist'
-            );
-            $this->assertTrue(
-                $adapter->directoryExists('move_and_overwrite_target'),
-                'Target directory should exist'
-            );
-            $this->assertTrue(
-                $adapter->fileExists('move_and_overwrite_target/a'),
-                'Source files not moved'
-            );
-            $this->assertFalse(
-                $adapter->fileExists('move_and_overwrite_target/b'),
-                'Target files not deleted'
-            );
         });
     }
 


### PR DESCRIPTION
This fixes the `InMemoryFilesystemAdapter` not copying or moving directories