### PR TITLE
Fix ZipArchiveAdapter not overwriting on move

### DIFF
--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -338,11 +338,18 @@ final class ZipArchiveAdapter implements FilesystemAdapter
         }
 
         $archive = $this->zipArchiveProvider->createZipArchive();
+
+        if ($archive->locateName($this->pathPrefixer->prefixPath($destination)) !== false) {
+            $this->delete($destination);
+            $this->copy($source, $destination, $config);
+            $this->delete($source);
+            return;
+        }
+
         $renamed = $archive->renameName(
             $this->pathPrefixer->prefixPath($source),
             $this->pathPrefixer->prefixPath($destination)
         );
-
         if ($renamed === false) {
             throw UnableToMoveFile::fromLocationTo($source, $destination);
         }

--- a/src/ZipArchive/ZipArchiveAdapterTest.php
+++ b/src/ZipArchive/ZipArchiveAdapterTest.php
@@ -291,6 +291,38 @@ abstract class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
         $this->adapter()->setVisibility('path.txt', Visibility::PUBLIC);
     }
 
+    /**
+     * @test
+     * @fixme Move to FilesystemAdapterTestCase once all adapters pass
+     */
+    public function moving_a_file_and_overwriting(): void
+    {
+        $this->runScenario(function() {
+            $adapter = $this->adapter();
+            $adapter->write(
+                'source.txt',
+                'contents to be moved',
+                new Config([Config::OPTION_VISIBILITY => Visibility::PUBLIC])
+            );
+            $adapter->write(
+                'destination.txt',
+                'contents to be overwritten',
+                new Config([Config::OPTION_VISIBILITY => Visibility::PUBLIC])
+            );
+            $adapter->move('source.txt', 'destination.txt', new Config());
+            $this->assertFalse(
+                $adapter->fileExists('source.txt'),
+                'After moving a file should no longer exist in the original location.'
+            );
+            $this->assertTrue(
+                $adapter->fileExists('destination.txt'),
+                'After moving, a file should be present at the new location.'
+            );
+            $this->assertEquals(Visibility::PUBLIC, $adapter->visibility('destination.txt')->visibility());
+            $this->assertEquals('contents to be moved', $adapter->read('destination.txt'));
+        });
+    }
+
     protected static function removeZipArchive(): void
     {
         if ( ! file_exists(self::ARCHIVE)) {


### PR DESCRIPTION
As with #1682 and #1684 this fixes the adapter not overwriting when moving files.