### PR TITLE
Fix PathPrefixedAdapter checksum

### DIFF
--- a/src/PathPrefixing/PathPrefixedAdapter.php
+++ b/src/PathPrefixing/PathPrefixedAdapter.php
@@ -205,10 +205,10 @@ class PathPrefixedAdapter implements FilesystemAdapter, PublicUrlGenerator, Chec
     public function checksum(string $path, Config $config): string
     {
         if ($this->adapter instanceof ChecksumProvider) {
-            return $this->adapter->checksum($path, $config);
+            return $this->adapter->checksum($this->prefix->prefixPath($path), $config);
         }
 
-        return $this->calculateChecksumFromStream($this->prefix->prefixPath($path), $config);
+        return $this->calculateChecksumFromStream($path, $config);
     }
 
     public function temporaryUrl(string $path, DateTimeInterface $expiresAt, Config $config): string


### PR DESCRIPTION
* Add the missing prefix path in the first case (instanceof ChecksumProvider)
* Remove unwanted double prefix in the second case (`prefixPath` method already called in `readStream`, itself called by `calculateChecksumFromStream`)

(Fixes: https://github.com/thephpleague/flysystem/issues/1686)