### PR TITLE
Add phpunit v10.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-fileinfo": "*",
         "ext-ftp": "*",
         "microsoft/azure-storage-blob": "^1.1",
-        "phpunit/phpunit": "^9.5.11",
+        "phpunit/phpunit": "^9.5.11|^10.0",
         "phpstan/phpstan": "^0.12.26",
         "phpseclib/phpseclib": "^3.0.14",
         "aws/aws-sdk-php": "^3.220.0",
@@ -40,7 +40,7 @@
     "conflict": {
         "async-aws/core": "<1.19.0",
         "async-aws/s3": "<1.14.0",
-        "symfony/http-client": "<6.3.1",
+        "symfony/http-client": "<5.2",
         "guzzlehttp/ringphp": "<1.1.1",
         "guzzlehttp/guzzle": "<7.0",
         "aws/aws-sdk-php": "3.209.31 || 3.210.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,17 +8,14 @@
     <php>
         <env name="FLYSYSTEM_TEST_SFTP" value="yes" />
     </php>
-    <filter>
-        <whitelist>
-            <directory>src/</directory>
-            <exclude>
-                <directory suffix="Test.php">src/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
     <groups>
         <exclude>
             <group>legacy</group>
         </exclude>
     </groups>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
+++ b/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
@@ -179,7 +179,7 @@ abstract class FilesystemAdapterTestCase extends TestCase
         });
     }
 
-    public function filenameProvider(): Generator
+    public static function filenameProvider(): Generator
     {
         yield "a path with square brackets in filename 1" => ["some/file[name].txt"];
         yield "a path with square brackets in filename 2" => ["some/file[0].txt"];

--- a/src/AsyncAwsS3/AsyncAwsS3AdapterTest.php
+++ b/src/AsyncAwsS3/AsyncAwsS3AdapterTest.php
@@ -232,7 +232,7 @@ class AsyncAwsS3AdapterTest extends FilesystemAdapterTestCase
         $adapter->{$getterName}('filename.txt');
     }
 
-    public function dpFailingMetadataGetters(): iterable
+    public static function dpFailingMetadataGetters(): iterable
     {
         yield "mimeType" => [UnableToRetrieveMetadata::mimeType('filename.txt'), 'mimeType'];
         yield "lastModified" => [UnableToRetrieveMetadata::lastModified('filename.txt'), 'lastModified'];

--- a/src/AwsS3V3/AwsS3V3AdapterTest.php
+++ b/src/AwsS3V3/AwsS3V3AdapterTest.php
@@ -241,7 +241,7 @@ class AwsS3V3AdapterTest extends FilesystemAdapterTestCase
         $adapter->{$getterName}('filename.txt');
     }
 
-    public function dpFailingMetadataGetters(): iterable
+    public static function dpFailingMetadataGetters(): iterable
     {
         yield "mimeType" => [UnableToRetrieveMetadata::mimeType('filename.txt'), 'mimeType'];
         yield "lastModified" => [UnableToRetrieveMetadata::lastModified('filename.txt'), 'lastModified'];
@@ -282,7 +282,7 @@ class AwsS3V3AdapterTest extends FilesystemAdapterTestCase
         $this->assertEquals($seekable, $metadata['seekable']);
     }
 
-    public function casesWhereHttpStreamingInfluencesSeekability(): Generator
+    public static function casesWhereHttpStreamingInfluencesSeekability(): Generator
     {
         yield "not streaming reads have seekable stream" => [false, true];
         yield "streaming reads have non-seekable stream" => [true, false];

--- a/src/FileAttributesTest.php
+++ b/src/FileAttributesTest.php
@@ -94,7 +94,7 @@ class FileAttributesTest extends TestCase
         $this->assertEquals($attributes, $newAttributes);
     }
 
-    public function data_provider_for_json_transformation(): Generator
+    public static function data_provider_for_json_transformation(): Generator
     {
         yield [new FileAttributes('path.txt', 1234, Visibility::PRIVATE, $now = time(), 'plain/text', ['key' => 'value'])];
         yield [new FileAttributes('another.txt')];

--- a/src/FilesystemTest.php
+++ b/src/FilesystemTest.php
@@ -71,7 +71,7 @@ class FilesystemTest extends TestCase
         $this->filesystem->writeStream('path.txt', $input);
     }
 
-    public function invalidStreamInput(): Generator
+    public static function invalidStreamInput(): Generator
     {
         $handle = tmpfile();
         fclose($handle);
@@ -308,7 +308,7 @@ class FilesystemTest extends TestCase
         $scenario($this->filesystem);
     }
 
-    public function scenariosCausingPathTraversal(): Generator
+    public static function scenariosCausingPathTraversal(): Generator
     {
         yield [function (FilesystemOperator $filesystem) {
             $filesystem->delete('../path.txt');

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -260,7 +260,7 @@ class FtpAdapter implements FilesystemAdapter
         $mode = $this->visibilityConverter->forFile($visibility);
 
         if ( ! @ftp_chmod($this->connection(), $mode, $location)) {
-            $message = error_get_last()['message'];
+            $message = error_get_last()['message'] ?? '';
             throw UnableToSetVisibility::atLocation($path, $message);
         }
     }

--- a/src/Ftp/FtpAdapterTestCase.php
+++ b/src/Ftp/FtpAdapterTestCase.php
@@ -118,7 +118,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
         });
     }
 
-    public function scenariosCausingWriteFailure(): Generator
+    public static function scenariosCausingWriteFailure(): Generator
     {
         yield "Not being able to create the parent directory" => [function () {
             mock_function('ftp_mkdir', false);
@@ -153,7 +153,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
         });
     }
 
-    public function scenariosCausingDirectoryDeleteFailure(): Generator
+    public static function scenariosCausingDirectoryDeleteFailure(): Generator
     {
         yield "ftp_delete failure" => [function () {
             mock_function('ftp_delete', false);
@@ -195,7 +195,7 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
         });
     }
 
-    public function scenariosCausingCopyFailure(): Generator
+    public static function scenariosCausingCopyFailure(): Generator
     {
         yield "failing to read" => [function () {
             mock_function('ftp_fget', false);

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -724,16 +724,6 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         return new LocalFilesystemAdapter(static::ROOT);
     }
 
-    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
-    {
-        if (is_callable('parent::assertFileDoesNotExist')) {
-            // PHPUnit 9+
-            parent::assertFileDoesNotExist($filename, $message);
-        } else {
-            self::assertFileNotExists($filename, $message);
-        }
-    }
-
     /**
      * @test
      */
@@ -746,15 +736,5 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         $checksum = $adapter->checksum('path.txt', new Config(['checksum_algo' => 'crc32c']));
 
         $this->assertSame('0d5f5c7f', $checksum);
-    }
-
-    public static function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
-    {
-        if (is_callable('parent::assertDirectoryDoesNotExist')) {
-            // PHPUnit 9+
-            parent::assertDirectoryDoesNotExist($directory, $message);
-        } else {
-            self::assertDirectoryNotExists($directory, $message);
-        }
     }
 }

--- a/src/MountManagerTest.php
+++ b/src/MountManagerTest.php
@@ -124,7 +124,7 @@ class MountManagerTest extends TestCase
         $this->mountManager->{$method}('first://location.txt');
     }
 
-    public function dpMetadataRetrieverMethods(): iterable
+    public static function dpMetadataRetrieverMethods(): iterable
     {
         yield 'mimeType' => ['mimeType', UnableToRetrieveMetadata::mimeType('location.txt')];
         yield 'fileSize' => ['fileSize', UnableToRetrieveMetadata::fileSize('location.txt')];

--- a/src/PathPrefixerTest.php
+++ b/src/PathPrefixerTest.php
@@ -39,7 +39,7 @@ class PathPrefixerTest extends TestCase
         $this->assertEquals($expectedPath, $prefixedPath);
     }
 
-    public function dpRootPaths(): iterable
+    public static function dpRootPaths(): iterable
     {
         yield "unix-style root path" => ['/', '/', 'path.txt', '/path.txt'];
         yield "windows-style root path" => ['\\', '\\', 'path.txt', '\\path.txt'];

--- a/src/ReadOnly/ReadOnlyFilesystemAdapterTest.php
+++ b/src/ReadOnly/ReadOnlyFilesystemAdapterTest.php
@@ -38,7 +38,7 @@ class ReadOnlyFilesystemAdapterTest extends TestCase
         $this->assertInstanceOf(FileAttributes::class, $adapter->mimeType('foo/bar.txt'));
         $this->assertInstanceOf(FileAttributes::class, $adapter->lastModified('foo/bar.txt'));
         $this->assertInstanceOf(FileAttributes::class, $adapter->fileSize('foo/bar.txt'));
-        $this->assertCount(1, $adapter->listContents('foo', true));
+        $this->assertCount(1, iterator_to_array($adapter->listContents('foo', true)));
     }
 
     /**

--- a/src/WhitespacePathNormalizerTest.php
+++ b/src/WhitespacePathNormalizerTest.php
@@ -33,7 +33,7 @@ class WhitespacePathNormalizerTest extends TestCase
     /**
      * @return array<array<string>>
      */
-    public function pathProvider(): array
+    public static function pathProvider(): array
     {
         return [
             ['.', ''],
@@ -78,7 +78,7 @@ class WhitespacePathNormalizerTest extends TestCase
         $this->normalizer->normalizePath($path);
     }
 
-    public function dpFunkyWhitespacePaths(): iterable
+    public static function dpFunkyWhitespacePaths(): iterable
     {
         return [["some\0/path.txt"], ["s\x09i.php"]];
     }
@@ -86,7 +86,7 @@ class WhitespacePathNormalizerTest extends TestCase
     /**
      * @return array<array<string>>
      */
-    public function invalidPathProvider(): array
+    public static function invalidPathProvider(): array
     {
         return [
             ['something/../../../hehe'],

--- a/src/ZipArchive/NoRootPrefixZipArchiveAdapterTest.php
+++ b/src/ZipArchive/NoRootPrefixZipArchiveAdapterTest.php
@@ -7,7 +7,7 @@ namespace League\Flysystem\ZipArchive;
 /**
  * @group zip
  */
-final class NoRootPrefixZipArchiveAdapterTest extends ZipArchiveAdapterTest
+final class NoRootPrefixZipArchiveAdapterTest extends ZipArchiveAdapterTestCase
 {
     protected static function getRoot(): string
     {

--- a/src/ZipArchive/PrefixedRootZipArchiveAdapterTest.php
+++ b/src/ZipArchive/PrefixedRootZipArchiveAdapterTest.php
@@ -7,7 +7,7 @@ namespace League\Flysystem\ZipArchive;
 /**
  * @group zip
  */
-final class PrefixedRootZipArchiveAdapterTest extends ZipArchiveAdapterTest
+final class PrefixedRootZipArchiveAdapterTest extends ZipArchiveAdapterTestCase
 {
     protected static function getRoot(): string
     {

--- a/src/ZipArchive/ZipArchiveAdapterTestCase.php
+++ b/src/ZipArchive/ZipArchiveAdapterTestCase.php
@@ -22,7 +22,7 @@ use function iterator_to_array;
 /**
  * @group zip
  */
-abstract class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
+abstract class ZipArchiveAdapterTestCase extends FilesystemAdapterTestCase
 {
     private const ARCHIVE = __DIR__ . '/test.zip';
 
@@ -97,7 +97,7 @@ abstract class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
         });
     }
 
-    public function scenariosThatCauseWritesToFail(): Generator
+    public static function scenariosThatCauseWritesToFail(): Generator
     {
         yield "writing a file fails when writing" => [function () {
             static::$archiveProvider->stubbedZipArchive()->failNextWrite();
@@ -172,8 +172,8 @@ abstract class ZipArchiveAdapterTest extends FilesystemAdapterTestCase
         $this->givenWeHaveAnExistingFile('one/b.txt');
         $this->givenWeHaveAnExistingFile('two/a.txt');
 
-        $this->assertCount(6, $this->adapter()->listContents('', true));
-        $this->assertCount(3, $this->adapter()->listContents('', false));
+        $this->assertCount(6, iterator_to_array($this->adapter()->listContents('', true)));
+        $this->assertCount(3, iterator_to_array($this->adapter()->listContents('', false)));
     }
 
     /**


### PR DESCRIPTION
Allow to use `phpunit` v10 to run tests.

Main thing to change was to make the `dataProvider` functions static.

An abstract test class had to be renamed to `xxxTestCase` as the `Test` suffix for an abstract class triggered a warning.

The config file is not in v10 format, but is compatible with both v9 & v10.

I also had to revert a change in the `composer.json` file to be able to have an installable version (otherwise no `symfony/http-client` version could be resolved for php8.0)

