### PR TITLE
Fix: Prefer inconclusive mimetype over null

### DIFF
--- a/src/Local/FallbackMimeTypeDetector.php
+++ b/src/Local/FallbackMimeTypeDetector.php
@@ -46,6 +46,6 @@ class FallbackMimeTypeDetector implements MimeTypeDetector
             return $mimeType;
         }
 
-        return $this->detector->detectMimeTypeFromPath($path);
+        return $this->detector->detectMimeTypeFromPath($path) ?? $mimeType;
     }
 }


### PR DESCRIPTION
This fixes the scenario where `detectMimeTypeFromFile()` detects an inconclusive mimetype, so we fallback to `detectMimeTypeFromPath()`, which returns null.

Instead of returning null (which will result in `LocalFilesystemAdapter` throwing a `UnableToRetrieveMetadata` exception), we should return the inconclusive result. Valid but inconclusive is better than an exception.

Related issue:
- https://github.com/thephpleague/flysystem/issues/1468