### PR TITLE
Fix: avoid deleting on s3 when destination is same as source

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -406,7 +406,10 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
     {
         try {
             $this->copy($source, $destination, $config);
-            $this->delete($source);
+            
+            if($destination !== $source){
+                $this->delete($source);
+            }
         } catch (FilesystemOperationFailed $exception) {
             throw UnableToMoveFile::fromLocationTo($source, $destination, $exception);
         }

--- a/src/AwsS3V3/AwsS3V3AdapterTest.php
+++ b/src/AwsS3V3/AwsS3V3AdapterTest.php
@@ -157,6 +157,20 @@ class AwsS3V3AdapterTest extends FilesystemAdapterTestCase
         $this->assertEquals('something/1/also/here.txt', $file->path());
     }
 
+    public function moving_to_same_destination(): void
+    {
+        $adapter = $this->adapter();
+        $adapter->write('source.txt', 'contents to be copied', new Config());
+        static::$stubS3Client->failOnNextCopy();
+
+        $adapter->move('source.txt', 'source.txt', new Config());
+
+        $this->assertTrue(
+            $adapter->fileExists('source.txt'),
+            'After moving a file to the same place the file should still exist.'
+        );
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
Hi,

An issue we encountered that is sort of an edge case in how the s3 move method works. But if the source is the same as the destination file, the actual file will be deleted. For me this is not expected behavior of the "move" command and is not the same result as the filesystem move would be.

Thanks