### PR TITLE
Replace various short-ternary operators with null coalescing ones

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -112,8 +112,8 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
         array $metadataFields = self::EXTRA_METADATA_FIELDS,
     ) {
         $this->prefixer = new PathPrefixer($prefix);
-        $this->visibility = $visibility ?: new PortableVisibilityConverter();
-        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
+        $this->visibility = $visibility ?? new PortableVisibilityConverter();
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
         $this->forwardedOptions = $forwardedOptions;
         $this->metadataFields = $metadataFields;
     }
@@ -316,7 +316,7 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
     {
         try {
             /** @var string $visibility */
-            $visibility = $config->get(Config::OPTION_VISIBILITY) ?: $this->visibility($source)->visibility();
+            $visibility = $config->get(Config::OPTION_VISIBILITY) ?? $this->visibility($source)->visibility();
         } catch (Throwable $exception) {
             throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);
         }

--- a/src/AsyncAwsS3/S3ClientStub.php
+++ b/src/AsyncAwsS3/S3ClientStub.php
@@ -59,7 +59,7 @@ class S3ClientStub extends SimpleS3Client
 
     public function throwExceptionWhenExecutingCommand(string $commandName, Exception $exception = null): void
     {
-        $this->stagedExceptions[$commandName] = $exception ?: new NetworkException();
+        $this->stagedExceptions[$commandName] = $exception ?? new NetworkException();
     }
 
     public function stageResultForCommand(string $commandName, Result $result): void

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -108,8 +108,8 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         private array $multipartUploadOptions = self::MUP_AVAILABLE_OPTIONS,
     ) {
         $this->prefixer = new PathPrefixer($prefix);
-        $this->visibility = $visibility ?: new PortableVisibilityConverter();
-        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
+        $this->visibility = $visibility ?? new PortableVisibilityConverter();
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
     }
 
     public function fileExists(string $path): bool
@@ -397,8 +397,8 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         $resultPaginator = $this->client->getPaginator('ListObjectsV2', $options + $this->options);
 
         foreach ($resultPaginator as $result) {
-            yield from ($result->get('CommonPrefixes') ?: []);
-            yield from ($result->get('Contents') ?: []);
+            yield from ($result->get('CommonPrefixes') ?? []);
+            yield from ($result->get('Contents') ?? []);
         }
     }
 
@@ -416,7 +416,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
     {
         try {
             /** @var string $visibility */
-            $visibility = $config->get(Config::OPTION_VISIBILITY) ?: $this->visibility($source)->visibility();
+            $visibility = $config->get(Config::OPTION_VISIBILITY) ?? $this->visibility($source)->visibility();
         } catch (Throwable $exception) {
             throw UnableToCopyFile::fromLocationTo(
                 $source,

--- a/src/AwsS3V3/S3ClientStub.php
+++ b/src/AwsS3V3/S3ClientStub.php
@@ -71,7 +71,7 @@ class S3ClientStub implements S3ClientInterface
 
     public function throwExceptionWhenExecutingCommand(string $commandName, S3Exception $exception = null): void
     {
-        $this->stagedExceptions[$commandName] = $exception ?: new S3Exception($commandName, new Command($commandName));
+        $this->stagedExceptions[$commandName] = $exception ?? new S3Exception($commandName, new Command($commandName));
     }
 
     public function throw500ExceptionWhenExecutingCommand(string $commandName): void

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -29,7 +29,7 @@ class Filesystem implements FilesystemOperator
         private ?TemporaryUrlGenerator $temporaryUrlGenerator = null,
     ) {
         $this->config = new Config($config);
-        $this->pathNormalizer = $pathNormalizer ?: new WhitespacePathNormalizer();
+        $this->pathNormalizer = $pathNormalizer ?? new WhitespacePathNormalizer();
     }
 
     public function fileExists(string $location): bool
@@ -183,7 +183,7 @@ class Filesystem implements FilesystemOperator
     public function publicUrl(string $path, array $config = []): string
     {
         $this->publicUrlGenerator ??= $this->resolvePublicUrlGenerator()
-            ?: throw UnableToGeneratePublicUrl::noGeneratorConfigured($path);
+            ?? throw UnableToGeneratePublicUrl::noGeneratorConfigured($path);
         $config = $this->config->extend($config);
 
         return $this->publicUrlGenerator->publicUrl($path, $config);
@@ -191,7 +191,7 @@ class Filesystem implements FilesystemOperator
 
     public function temporaryUrl(string $path, DateTimeInterface $expiresAt, array $config = []): string
     {
-        $generator = $this->temporaryUrlGenerator ?: $this->adapter;
+        $generator = $this->temporaryUrlGenerator ?? $this->adapter;
 
         if ($generator instanceof TemporaryUrlGenerator) {
             return $generator->temporaryUrl($path, $expiresAt, $this->config->extend($config));

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -62,10 +62,10 @@ class FtpAdapter implements FilesystemAdapter
         private bool $detectMimeTypeUsingPath = false,
     ) {
         $this->systemType = $this->connectionOptions->systemType();
-        $this->connectionProvider = $connectionProvider ?: new FtpConnectionProvider();
-        $this->connectivityChecker = $connectivityChecker ?: new NoopCommandConnectivityChecker();
-        $this->visibilityConverter = $visibilityConverter ?: new PortableVisibilityConverter();
-        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
+        $this->connectionProvider = $connectionProvider ?? new FtpConnectionProvider();
+        $this->connectivityChecker = $connectivityChecker ?? new NoopCommandConnectivityChecker();
+        $this->visibilityConverter = $visibilityConverter ?? new PortableVisibilityConverter();
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
         $this->useRawListOptions = $connectionOptions->useRawListOptions();
     }
 

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -64,8 +64,8 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter, PublicUrlGenerator
         MimeTypeDetector $mimeTypeDetector = null
     ) {
         $this->prefixer = new PathPrefixer($prefix);
-        $this->visibilityHandler = $visibilityHandler ?: new PortableVisibilityHandler();
-        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
+        $this->visibilityHandler = $visibilityHandler ?? new PortableVisibilityHandler();
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
     }
 
     public function publicUrl(string $path, Config $config): string

--- a/src/GoogleCloudStorage/StubRiggedBucket.php
+++ b/src/GoogleCloudStorage/StubRiggedBucket.php
@@ -38,7 +38,7 @@ class StubRiggedBucket extends Bucket
 
     private function setupTrigger(string $method, string $name, ?Throwable $throwable): void
     {
-        $this->triggers[$method][$name] = $throwable ?: new LogicException('unknown error');
+        $this->triggers[$method][$name] = $throwable ?? new LogicException('unknown error');
     }
 
     private function pushTrigger(string $method, string $name): void

--- a/src/InMemory/InMemoryFile.php
+++ b/src/InMemory/InMemoryFile.php
@@ -19,7 +19,7 @@ class InMemoryFile
     public function updateContents(string $contents, ?int $timestamp): void
     {
         $this->contents = $contents;
-        $this->lastModified = $timestamp ?: time();
+        $this->lastModified = $timestamp ?? time();
     }
 
     public function lastModified(): int

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -35,7 +35,7 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         private string $defaultVisibility = Visibility::PUBLIC,
         MimeTypeDetector $mimeTypeDetector = null
     ) {
-        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
     }
 
     public function fileExists(string $path): bool

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -81,7 +81,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
         $visibility ??= new PortableVisibilityConverter();
         $this->visibility = $visibility;
         $this->rootLocation = $location;
-        $this->mimeTypeDetector = $mimeTypeDetector ?: new FallbackMimeTypeDetector(new FinfoMimeTypeDetector());
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FallbackMimeTypeDetector(new FinfoMimeTypeDetector());
 
         if ( ! $lazyRootCreation) {
             $this->ensureRootDirectoryExists();

--- a/src/PhpseclibV2/SftpAdapter.php
+++ b/src/PhpseclibV2/SftpAdapter.php
@@ -63,8 +63,8 @@ class SftpAdapter implements FilesystemAdapter
     ) {
         $this->connectionProvider = $connectionProvider;
         $this->prefixer = new PathPrefixer($root);
-        $this->visibilityConverter = $visibilityConverter ?: new PortableVisibilityConverter();
-        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
+        $this->visibilityConverter = $visibilityConverter ?? new PortableVisibilityConverter();
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
     }
 
     public function fileExists(string $path): bool

--- a/src/PhpseclibV2/SftpConnectionProvider.php
+++ b/src/PhpseclibV2/SftpConnectionProvider.php
@@ -97,7 +97,7 @@ class SftpConnectionProvider implements ConnectionProvider
         $this->port = $port;
         $this->timeout = $timeout;
         $this->hostFingerprint = $hostFingerprint;
-        $this->connectivityChecker = $connectivityChecker ?: new SimpleConnectivityChecker();
+        $this->connectivityChecker = $connectivityChecker ?? new SimpleConnectivityChecker();
         $this->maxTries = $maxTries;
     }
 

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -43,8 +43,8 @@ class SftpAdapter implements FilesystemAdapter
         private bool $detectMimeTypeUsingPath = false,
     ) {
         $this->prefixer = new PathPrefixer($root);
-        $this->visibilityConverter = $visibilityConverter ?: new PortableVisibilityConverter();
-        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
+        $this->visibilityConverter = $visibilityConverter ?? new PortableVisibilityConverter();
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
     }
 
     public function fileExists(string $path): bool

--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -44,7 +44,7 @@ class SftpConnectionProvider implements ConnectionProvider
         private array $preferredAlgorithms = [],
         private bool $disableStatCache = true,
     ) {
-        $this->connectivityChecker = $connectivityChecker ?: new SimpleConnectivityChecker();
+        $this->connectivityChecker = $connectivityChecker ?? new SimpleConnectivityChecker();
     }
 
     public function provideConnection(): SFTP


### PR DESCRIPTION
Given that the PHP version for this package allows using the null coalescing operators, I think this should be preferred whenever applicable.