### PR TITLE
Use visibility on copy/move operations in local adapter

### DIFF
--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -250,6 +250,10 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
         if ( ! @rename($sourcePath, $destinationPath)) {
             throw UnableToMoveFile::because(error_get_last()['message'] ?? 'unknown reason', $source, $destination);
         }
+
+        if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
+            $this->setVisibility($destination, (string) $visibility);
+        }
     }
 
     public function copy(string $source, string $destination, Config $config): void
@@ -264,6 +268,10 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
 
         if ( ! @copy($sourcePath, $destinationPath)) {
             throw UnableToCopyFile::because(error_get_last()['message'] ?? 'unknown', $source, $destination);
+        }
+
+        if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
+            $this->setVisibility($destination, (string) $visibility);
         }
     }
 

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -539,6 +539,20 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function moving_a_file_with_visibility(): void
+    {
+        $adapter = new LocalFilesystemAdapter(static::ROOT, new PortableVisibilityConverter());
+        $adapter->write('first.txt', 'contents', new Config());
+        $this->assertFileExists(static::ROOT . '/first.txt');
+        $this->assertFileHasPermissions(static::ROOT . '/first.txt', 0644);
+        $adapter->move('first.txt', 'second.txt', new Config(['visibility' => 'private']));
+        $this->assertFileExists(static::ROOT . '/second.txt');
+        $this->assertFileHasPermissions(static::ROOT . '/second.txt', 0600);
+    }
+
+    /**
+     * @test
+     */
     public function not_being_able_to_move_a_file(): void
     {
         $this->expectException(UnableToMoveFile::class);
@@ -556,6 +570,20 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         $adapter->copy('first.txt', 'second.txt', new Config());
         $this->assertFileExists(static::ROOT . '/second.txt');
         $this->assertFileExists(static::ROOT . '/first.txt');
+    }
+
+    /**
+     * @test
+     */
+    public function copying_a_file_with_visibility(): void
+    {
+        $adapter = new LocalFilesystemAdapter(static::ROOT, new PortableVisibilityConverter());
+        $adapter->write('first.txt', 'contents', new Config());
+        $adapter->copy('first.txt', 'second.txt', new Config(['visibility' => 'private']));
+        $this->assertFileExists(static::ROOT . '/first.txt');
+        $this->assertFileHasPermissions(static::ROOT . '/first.txt', 0644);
+        $this->assertFileExists(static::ROOT . '/second.txt');
+        $this->assertFileHasPermissions(static::ROOT . '/second.txt', 0600);
     }
 
     /**


### PR DESCRIPTION
This PR alters the `copy` and `move` methods on the `LocalFilesystemAdapter` to use the visibility if passed in the config, to match the behavior of the `write`, `writeStream` and `createDirectory` methods and result in more consistent behavior.

Note: this indirectly conflicts with #1721, not respecting the newly introduced configuration option there; that should be adressed at some point.