### PR TITLE
Ignore visibility by default on copy/move in Filesystem

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -119,7 +119,9 @@ class Filesystem implements FilesystemOperator
 
     public function move(string $source, string $destination, array $config = []): void
     {
-        $config = $this->config->extend($config);
+        $config = $this->config
+            ->extend([Config::OPTION_VISIBILITY => null])
+            ->extend($config);
         $from = $this->pathNormalizer->normalizePath($source);
         $to = $this->pathNormalizer->normalizePath($destination);
 
@@ -138,7 +140,9 @@ class Filesystem implements FilesystemOperator
 
     public function copy(string $source, string $destination, array $config = []): void
     {
-        $config = $this->config->extend($config);
+        $config = $this->config
+            ->extend([Config::OPTION_VISIBILITY => null])
+            ->extend($config);
         $from = $this->pathNormalizer->normalizePath($source);
         $to = $this->pathNormalizer->normalizePath($destination);
 


### PR DESCRIPTION
With the current behavior, when creating a `Filesystem` instance with default visibility set (through passing the config); this will be enforced on any `copy`or `move` operation, where I would expect the default the be like the default adapter behavior (e.g. for `AwsS3V3Adapter`: keep the current visibility). This is due to the forced config merge taking place e.g. here:
https://github.com/thephpleague/flysystem/blob/532bb63356627b62607a821bc9c06f996b5baedc/src/Filesystem.php#L122

The following is a quick illustration of the somewhat confusing behavior:
```php
// File foo.txt with public visibility
$adapter = new AwsS3V3Adapter(...);
$adapter->copy('foo.txt', 'adapter-copy.txt', new Config([])); // adapter-copy.txt has the same visibility as foo.txt (public)
$filesystem = new Filesystem($adapter, ['visibility' => 'private']);
$filesystem->copy('foo.txt', 'filesystem-copy.txt'); // filesystem-copy.txt will have private visibility
```

I noticed this within the context of Laravel, which by default creates a `Filesystem` wrapper around any adapter before exposing it to the application; see also https://github.com/laravel/framework/blob/10.x/src/Illuminate/Filesystem/Filesystem.php.

This is marked as draft as I'd like to have some input about possible approaches and wether or not this is something that is open for behavioral changes. Some ideas about this:
- the current implementation is slightly hackish, by force-setting visibility to `null`
- alternatively, some method could be added to the `Config` class which unsets an option, which could be called here