### PR TITLE
MountFilesystem using mount filesystem dynamically

### DIFF
--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -296,7 +296,7 @@ class MountManager implements FilesystemOperator
         return $filesystem->checksum($path, $this->config->extend($config)->toArray());
     }
 
-    private function mountFilesystems(array $filesystems): void
+    public function mountFilesystems(array $filesystems): void
     {
         foreach ($filesystems as $key => $filesystem) {
             $this->guardAgainstInvalidMount($key, $filesystem);


### PR DESCRIPTION
https://github.com/anomalylabs/private_storage_adapter-extension/blob/cb93de399413e1c8609348afc1d28edffdc2ee1d/src/Command/LoadDisk.php#L63

` $flysystem->mountFilesystem($this->disk->getSlug(), $driver);`

I use it here by including the disk and calling app(MountManager::class) throughout the system. I need this method in public form.


https://github.com/anomalylabs/files-module/blob/47af0c1f96e26054b432733cba7aeaffc4092dc7/src/File/FileUploader.php#L127



 Or is there an alternative to this? I have uses in most parts of the system as follows.