### PR TITLE
New exception to capture NET_SSH2_DISCONNECT_BY_APPLICATION errors

### DIFF
--- a/src/PhpseclibV2/SftpConnectionProvider.php
+++ b/src/PhpseclibV2/SftpConnectionProvider.php
@@ -174,6 +174,12 @@ class SftpConnectionProvider implements ConnectionProvider
         } elseif ($this->useAgent) {
             $this->authenticateWithAgent($connection);
         } elseif ( ! $connection->login($this->username, $this->password)) {
+            if (UnableToConnect::matches($connection->getLastError())) {
+                throw UnableToConnect::disconnected(
+                    $connection->getLastError()
+                );
+            }
+
             throw UnableToAuthenticate::withPassword();
         }
     }

--- a/src/PhpseclibV2/UnableToConnect.php
+++ b/src/PhpseclibV2/UnableToConnect.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\PhpseclibV2;
+
+/**
+ * @deprecated The "League\Flysystem\PhpseclibV2\UnableToConnect" class is deprecated since Flysystem 3.0, use "League\Flysystem\PhpseclibV3\UnableToConnect" instead.
+ */
+class UnableToConnect extends UnableToAuthenticate
+{
+    protected const ERROR_PREFIX = 'SSH_MSG_DISCONNECT: ';
+
+    public static function disconnected(string $error): UnableToConnect
+    {
+        $cleanError = str_after(trim($error), self::ERROR_PREFIX);
+        $reason = str_after($cleanError, "\r\n");
+        $code = array_search(str_before($cleanError, "\r\n"), static::reasons());
+
+        return new UnableToConnect(
+            self::exceptionMessagePrefix() . $reason,
+            $code,
+        );
+    }
+
+    public static function matches($error): bool
+    {
+        return str_starts_with(trim($error), self::ERROR_PREFIX);
+    }
+
+    public function getReasonCode(): string
+    {
+        return static::reasons()[$this->getCode()];
+    }
+
+    public function getDisconnectReason(): string
+    {
+        return str_after(
+            $this->getMessage(),
+            self::exceptionMessagePrefix()
+        );
+    }
+
+    protected static function exceptionMessagePrefix(): string
+    {
+        return 'Unable to authenticate using a password. Disconnected by application: ';
+    }
+
+    protected static function reasons(): array
+    {
+        return [
+            1 => 'NET_SSH2_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT',
+            2 => 'NET_SSH2_DISCONNECT_PROTOCOL_ERROR',
+            3 => 'NET_SSH2_DISCONNECT_KEY_EXCHANGE_FAILED',
+            4 => 'NET_SSH2_DISCONNECT_RESERVED',
+            5 => 'NET_SSH2_DISCONNECT_MAC_ERROR',
+            6 => 'NET_SSH2_DISCONNECT_COMPRESSION_ERROR',
+            7 => 'NET_SSH2_DISCONNECT_SERVICE_NOT_AVAILABLE',
+            8 => 'NET_SSH2_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED',
+            9 => 'NET_SSH2_DISCONNECT_HOST_KEY_NOT_VERIFIABLE',
+            10 => 'NET_SSH2_DISCONNECT_CONNECTION_LOST',
+            11 => 'NET_SSH2_DISCONNECT_BY_APPLICATION',
+            12 => 'NET_SSH2_DISCONNECT_TOO_MANY_CONNECTIONS',
+            13 => 'NET_SSH2_DISCONNECT_AUTH_CANCELLED_BY_USER',
+            14 => 'NET_SSH2_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE',
+            15 => 'NET_SSH2_DISCONNECT_ILLEGAL_USER_NAME'
+        ];
+    }
+}

--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -125,6 +125,12 @@ class SftpConnectionProvider implements ConnectionProvider
         } elseif ($this->useAgent) {
             $this->authenticateWithAgent($connection);
         } elseif ( ! $connection->login($this->username, $this->password)) {
+            if (UnableToConnect::matches($connection->getLastError())) {
+                throw UnableToConnect::disconnected(
+                    $connection->getLastError()
+                );
+            }
+
             throw UnableToAuthenticate::withPassword();
         }
     }

--- a/src/PhpseclibV3/UnableToConnect.php
+++ b/src/PhpseclibV3/UnableToConnect.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\PhpseclibV3;
+
+class UnableToConnect extends UnableToAuthenticate
+{
+    protected const ERROR_PREFIX = 'SSH_MSG_DISCONNECT: ';
+
+    public static function disconnected(string $error): UnableToConnect
+    {
+        $cleanError = str_after(trim($error), self::ERROR_PREFIX);
+        $reason = str_after($cleanError, "\r\n");
+        $code = array_search(str_before($cleanError, "\r\n"), static::reasons());
+
+        return new UnableToConnect(
+            self::exceptionMessagePrefix() . $reason,
+            $code,
+        );
+    }
+
+    public static function matches($error): bool
+    {
+        return str_starts_with(trim($error), self::ERROR_PREFIX);
+    }
+
+    public function getReasonCode(): string
+    {
+        return static::reasons()[$this->getCode()];
+    }
+
+    public function getDisconnectReason(): string
+    {
+        return str_after(
+            $this->getMessage(),
+            self::exceptionMessagePrefix()
+        );
+    }
+
+    protected static function exceptionMessagePrefix(): string
+    {
+        return 'Unable to authenticate using a password. Disconnected by application: ';
+    }
+
+    protected static function reasons(): array
+    {
+        return [
+            1 => 'NET_SSH2_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT',
+            2 => 'NET_SSH2_DISCONNECT_PROTOCOL_ERROR',
+            3 => 'NET_SSH2_DISCONNECT_KEY_EXCHANGE_FAILED',
+            4 => 'NET_SSH2_DISCONNECT_RESERVED',
+            5 => 'NET_SSH2_DISCONNECT_MAC_ERROR',
+            6 => 'NET_SSH2_DISCONNECT_COMPRESSION_ERROR',
+            7 => 'NET_SSH2_DISCONNECT_SERVICE_NOT_AVAILABLE',
+            8 => 'NET_SSH2_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED',
+            9 => 'NET_SSH2_DISCONNECT_HOST_KEY_NOT_VERIFIABLE',
+            10 => 'NET_SSH2_DISCONNECT_CONNECTION_LOST',
+            11 => 'NET_SSH2_DISCONNECT_BY_APPLICATION',
+            12 => 'NET_SSH2_DISCONNECT_TOO_MANY_CONNECTIONS',
+            13 => 'NET_SSH2_DISCONNECT_AUTH_CANCELLED_BY_USER',
+            14 => 'NET_SSH2_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE',
+            15 => 'NET_SSH2_DISCONNECT_ILLEGAL_USER_NAME'
+        ];
+    }
+}


### PR DESCRIPTION
I'm trying to capture the following SFTP error:
```
SSH_MSG_DISCONNECT: NET_SSH2_DISCONNECT_BY_APPLICATION
Account is locked
```

@webmake also reported this here: https://github.com/thephpleague/flysystem-sftp-v3/issues/14

I'm unsure about the naming, but I think it's a start.

The exception message parsing tries to [reflect this](https://github.com/phpseclib/phpseclib/blob/2.0.14/phpseclib/Net/SSH2.php#L3453).