### PR TITLE
Retain file visibility when copying in LocalAdapter

### DIFF
--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -270,7 +270,14 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
             throw UnableToCopyFile::because(error_get_last()['message'] ?? 'unknown', $source, $destination);
         }
 
-        if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
+        $visibility = $config->get(
+            Config::OPTION_VISIBILITY,
+            $config->get('retain_visibility', true)
+                ? $this->visibility($source)->visibility()
+                : null,
+        );
+
+        if ($visibility) {
             $this->setVisibility($destination, (string) $visibility);
         }
     }

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -592,6 +592,23 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function copying_a_file_retaining_visibility(): void
+    {
+        $adapter = new LocalFilesystemAdapter(static::ROOT, new PortableVisibilityConverter());
+        $adapter->write('first.txt', 'contents', new Config(['visibility' => 'private']));
+        $adapter->copy('first.txt', 'retain.txt', new Config());
+        $adapter->copy('first.txt', 'do-not-retain.txt', new Config(['retain_visibility' => false]));
+        $this->assertFileExists(static::ROOT . '/first.txt');
+        $this->assertFileHasPermissions(static::ROOT . '/first.txt', 0600);
+        $this->assertFileExists(static::ROOT . '/retain.txt');
+        $this->assertFileHasPermissions(static::ROOT . '/retain.txt', 0600);
+        $this->assertFileExists(static::ROOT . '/do-not-retain.txt');
+        $this->assertFileHasPermissions(static::ROOT . '/do-not-retain.txt', 0644);
+    }
+
+    /**
+     * @test
+     */
     public function not_being_able_to_copy_a_file(): void
     {
         $this->expectException(UnableToCopyFile::class);


### PR DESCRIPTION
This is a follow-up to both #1723 and #1721, that changes the visibility retainment behavior of `LocalAdapter` in the following way:
- retain the visibility of the copied file by default, matching behavior of various other adapters (e.g. the AWS and FTP adapters)
- allow passing a config key to disable this behavior