### PR TITLE
Add decorated adapter abstract class

### DIFF
--- a/src/DecoratedAdapter.php
+++ b/src/DecoratedAdapter.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem;
+
+use League\Flysystem\Config;
+use League\Flysystem\FileAttributes;
+
+abstract class DecoratedAdapter implements FilesystemAdapter
+{
+    public function __construct(protected FilesystemAdapter $adapter)
+    {
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return $this->adapter->fileExists($path);
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        return $this->adapter->directoryExists($path);
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        $this->adapter->write($path, $contents, $config);
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->adapter->writeStream($path, $contents, $config);
+    }
+
+    public function read(string $path): string
+    {
+        return $this->adapter->read($path);
+    }
+
+    public function readStream(string $path)
+    {
+        return $this->adapter->readStream($path);
+    }
+
+    public function delete(string $path): void
+    {
+        $this->adapter->delete($path);
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        $this->adapter->deleteDirectory($path);
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        $this->adapter->createDirectory($path, $config);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $this->adapter->setVisibility($path, $visibility);
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        return $this->adapter->visibility($path);
+    }
+
+    public function mimeType(string $path): FileAttributes
+    {
+        return $this->adapter->mimeType($path);
+    }
+
+    public function lastModified(string $path): FileAttributes
+    {
+        return $this->adapter->lastModified($path);
+    }
+
+    public function fileSize(string $path): FileAttributes
+    {
+        return $this->adapter->fileSize($path);
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return $this->adapter->listContents($path, $deep);
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        $this->adapter->move($source, $destination, $config);
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        $this->adapter->copy($source, $destination, $config);
+    }
+}

--- a/src/ReadOnly/ReadOnlyFilesystemAdapter.php
+++ b/src/ReadOnly/ReadOnlyFilesystemAdapter.php
@@ -6,7 +6,7 @@ use DateTimeInterface;
 use League\Flysystem\CalculateChecksumFromStream;
 use League\Flysystem\ChecksumProvider;
 use League\Flysystem\Config;
-use League\Flysystem\FileAttributes;
+use League\Flysystem\DecoratedAdapter;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
@@ -20,23 +20,9 @@ use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\UrlGeneration\PublicUrlGenerator;
 use League\Flysystem\UrlGeneration\TemporaryUrlGenerator;
 
-class ReadOnlyFilesystemAdapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumProvider, TemporaryUrlGenerator
+class ReadOnlyFilesystemAdapter extends DecoratedAdapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumProvider, TemporaryUrlGenerator
 {
     use CalculateChecksumFromStream;
-
-    public function __construct(private FilesystemAdapter $adapter)
-    {
-    }
-
-    public function fileExists(string $path): bool
-    {
-        return $this->adapter->fileExists($path);
-    }
-
-    public function directoryExists(string $path): bool
-    {
-        return $this->adapter->directoryExists($path);
-    }
 
     public function write(string $path, string $contents, Config $config): void
     {
@@ -46,16 +32,6 @@ class ReadOnlyFilesystemAdapter implements FilesystemAdapter, PublicUrlGenerator
     public function writeStream(string $path, $contents, Config $config): void
     {
         throw UnableToWriteFile::atLocation($path, 'This is a readonly adapter.');
-    }
-
-    public function read(string $path): string
-    {
-        return $this->adapter->read($path);
-    }
-
-    public function readStream(string $path)
-    {
-        return $this->adapter->readStream($path);
     }
 
     public function delete(string $path): void
@@ -76,31 +52,6 @@ class ReadOnlyFilesystemAdapter implements FilesystemAdapter, PublicUrlGenerator
     public function setVisibility(string $path, string $visibility): void
     {
         throw UnableToSetVisibility::atLocation($path, 'This is a readonly adapter.');
-    }
-
-    public function visibility(string $path): FileAttributes
-    {
-        return $this->adapter->visibility($path);
-    }
-
-    public function mimeType(string $path): FileAttributes
-    {
-        return $this->adapter->mimeType($path);
-    }
-
-    public function lastModified(string $path): FileAttributes
-    {
-        return $this->adapter->lastModified($path);
-    }
-
-    public function fileSize(string $path): FileAttributes
-    {
-        return $this->adapter->fileSize($path);
-    }
-
-    public function listContents(string $path, bool $deep): iterable
-    {
-        return $this->adapter->listContents($path, $deep);
     }
 
     public function move(string $source, string $destination, Config $config): void


### PR DESCRIPTION
Inspired by the old trait https://github.com/thephpleague/flysystem-adapter-decorator.

When working on my own adapters a bit, I was creating a sort of decorated adapter and was looking for way to reduce the boilerplate involved. I ran into the old trait, but found it was no longer up-to-date. Then I created an abstract base class of my own to achieve basically the same. Given that it might be useful to others and also can be used here for the `ReadOnly` adapter, I decided to create this PR.

Note: I'm not sure if there's enough interest in merging this and maintaining it here, given the old trait also looks discontinued. Feel free to close if it's not useful enough, then this can just be here as a reference for people looking into this.