### PR TITLE
Add config key constant for retain_visibility

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -318,7 +318,7 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
 
             $visibility = $config->get(Config::OPTION_VISIBILITY);
 
-            if ($visibility === null && $config->get('retain_visibility', true)) {
+            if ($visibility === null && $config->get(Config::OPTION_RETAIN_VISIBILITY, true)) {
                 $visibility = $this->visibility($source)->visibility();
             }
         } catch (Throwable $exception) {

--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -197,8 +197,8 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
 
     public function createDirectory(string $path, Config $config): void
     {
-        $defaultVisibility = $config->get('directory_visibility', $this->visibility->defaultForDirectories());
-        $config = $config->withDefaults(['visibility' => $defaultVisibility]);
+        $defaultVisibility = $config->get(Config::OPTION_DIRECTORY_VISIBILITY, $this->visibility->defaultForDirectories());
+        $config = $config->withDefaults([Config::OPTION_VISIBILITY => $defaultVisibility]);
         $this->upload(rtrim($path, '/') . '/', '', $config);
     }
 

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -417,7 +417,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         try {
             $visibility = $config->get(Config::OPTION_VISIBILITY);
 
-            if ($visibility === null && $config->get('retain_visibility', true)) {
+            if ($visibility === null && $config->get(Config::OPTION_RETAIN_VISIBILITY, true)) {
                 $visibility = $this->visibility($source)->visibility();
             }
         } catch (Throwable $exception) {

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -244,8 +244,8 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
 
     public function createDirectory(string $path, Config $config): void
     {
-        $defaultVisibility = $config->get('directory_visibility', $this->visibility->defaultForDirectories());
-        $config = $config->withDefaults(['visibility' => $defaultVisibility]);
+        $defaultVisibility = $config->get(Config::OPTION_DIRECTORY_VISIBILITY, $this->visibility->defaultForDirectories());
+        $config = $config->withDefaults([Config::OPTION_VISIBILITY => $defaultVisibility]);
         $this->upload(rtrim($path, '/') . '/', '', $config);
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -14,6 +14,7 @@ class Config
     public const OPTION_MOVE_IDENTICAL_PATH = 'move_destination_same_as_source';
     public const OPTION_VISIBILITY = 'visibility';
     public const OPTION_DIRECTORY_VISIBILITY = 'directory_visibility';
+    public const OPTION_RETAIN_VISIBILITY = 'retain_visibility';
 
     public function __construct(private array $options = [])
     {

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -264,7 +264,7 @@ class Filesystem implements FilesystemOperator
 
     private function resolveConfigForMoveAndCopy(array $config): Config
     {
-        $retainVisibility = $this->config->get('retain_visibility', $config['retain_visibility'] ?? true);
+        $retainVisibility = $this->config->get(Config::OPTION_RETAIN_VISIBILITY, $config[Config::OPTION_RETAIN_VISIBILITY] ?? true);
         $fullConfig = $this->config->extend($config);
 
         /*

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -559,7 +559,7 @@ class FtpAdapter implements FilesystemAdapter
             $readStream = $this->readStream($source);
             $visibility = $config->get(Config::OPTION_VISIBILITY);
 
-            if ($visibility === null && $config->get('retain_visibility', true)) {
+            if ($visibility === null && $config->get(Config::OPTION_RETAIN_VISIBILITY, true)) {
                 $config = $config->withSetting(Config::OPTION_VISIBILITY, $this->visibility($source)->visibility());
             }
 

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -251,7 +251,7 @@ class FtpAdapter implements FilesystemAdapter
 
     public function createDirectory(string $path, Config $config): void
     {
-        $this->ensureDirectoryExists($path, $config->get('directory_visibility', $config->get('visibility')));
+        $this->ensureDirectoryExists($path, $config->get(Config::OPTION_DIRECTORY_VISIBILITY, $config->get(Config::OPTION_VISIBILITY)));
     }
 
     public function setVisibility(string $path, string $visibility): void

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -349,7 +349,7 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter, PublicUrlGenerator
         try {
             $visibility = $config->get(Config::OPTION_VISIBILITY);
 
-            if ($visibility === null && $config->get('retain_visibility', true)) {
+            if ($visibility === null && $config->get(Config::OPTION_RETAIN_VISIBILITY, true)) {
                 $visibility = $this->visibility($source)->visibility();
             }
 

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -272,7 +272,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
 
         $visibility = $config->get(
             Config::OPTION_VISIBILITY,
-            $config->get('retain_visibility', true)
+            $config->get(Config::OPTION_RETAIN_VISIBILITY, true)
                 ? $this->visibility($source)->visibility()
                 : null,
         );

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -374,7 +374,7 @@ class MountManager implements FilesystemOperator
     ): void {
         $config = $this->config->extend($config);
         $retainVisibility = (bool) $config->get(Config::OPTION_RETAIN_VISIBILITY, true);
-        $visibility = $config->get('visibility');
+        $visibility = $config->get(Config::OPTION_VISIBILITY);
 
         try {
             if ($visibility == null && $retainVisibility) {
@@ -382,7 +382,7 @@ class MountManager implements FilesystemOperator
             }
 
             $stream = $sourceFilesystem->readStream($sourcePath);
-            $destinationFilesystem->writeStream($destinationPath, $stream, $visibility ? compact('visibility') : []);
+            $destinationFilesystem->writeStream($destinationPath, $stream, $visibility ? compact(Config::OPTION_VISIBILITY) : []);
         } catch (UnableToRetrieveMetadata | UnableToReadFile | UnableToWriteFile $exception) {
             throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);
         }

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -373,7 +373,7 @@ class MountManager implements FilesystemOperator
         array $config,
     ): void {
         $config = $this->config->extend($config);
-        $retainVisibility = (bool) $config->get('retain_visibility', true);
+        $retainVisibility = (bool) $config->get(Config::OPTION_RETAIN_VISIBILITY, true);
         $visibility = $config->get('visibility');
 
         try {

--- a/src/PhpseclibV2/SftpAdapter.php
+++ b/src/PhpseclibV2/SftpAdapter.php
@@ -348,7 +348,7 @@ class SftpAdapter implements FilesystemAdapter
         try {
             $readStream = $this->readStream($source);
             $visibility = $this->visibility($source)->visibility();
-            $this->writeStream($destination, $readStream, new Config(compact('visibility')));
+            $this->writeStream($destination, $readStream, new Config(compact(Config::OPTION_VISIBILITY)));
         } catch (Throwable $exception) {
             if (isset($readStream) && is_resource($readStream)) {
                 @fclose($readStream);

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -329,7 +329,7 @@ class SftpAdapter implements FilesystemAdapter
             $readStream = $this->readStream($source);
             $visibility = $config->get(Config::OPTION_VISIBILITY);
 
-            if ($visibility === null && $config->get('retain_visibility', true)) {
+            if ($visibility === null && $config->get(Config::OPTION_RETAIN_VISIBILITY, true)) {
                 $config = $config->withSetting(Config::OPTION_VISIBILITY, $this->visibility($source)->visibility());
             }
 


### PR DESCRIPTION
While working on #1730 I noticed some inconsistent choice in referring to various config options by string vs. by constant. This MR makes the code more consistent, by adding a constant key for the `retain_visibility` option and replacing various string keys by their constant counterparts.

Note that test files were excluded due to more consistently using string keys and this possibly being a pattern that should be left in place.