### PR TITLE
Bumped aws/aws-sdk-php version to fix CVE-2023-51651

### DIFF
--- a/src/AwsS3V3/composer.json
+++ b/src/AwsS3V3/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0.2",
         "league/flysystem": "^3.10.0",
         "league/mime-type-detection": "^1.0.0",
-        "aws/aws-sdk-php": "^3.220.0"
+        "aws/aws-sdk-php": "^3.288.1"
     },
     "conflict": {
         "guzzlehttp/ringphp": "<1.1.1",


### PR DESCRIPTION
Our corporate security auditing mechanism found the CVE-2023-51651 issue in the aws/aws-sdk-php package, but we cannot fix it because flysystem is heavily based on version 3.220.0.

So I decide to make this pull request to fix this problem.