### PR TITLE
ensure error when deleting entire storage or deleting directory by delete method instead of deleteDirectory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "google/cloud-storage": "^1.23",
         "async-aws/s3": "^1.5 || ^2.0",
         "async-aws/simple-s3": "^1.1 || ^2.0",
-        "sabre/dav": "^4.3.1"
+        "sabre/dav": "^4.6.0"
     },
     "conflict": {
         "async-aws/core": "<1.19.0",

--- a/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
+++ b/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Flysystem\AdapterTestUtilities;
 
-use League\Flysystem\UnableToDeleteFile;
 use const PHP_EOL;
 use DateInterval;
 use DateTimeImmutable;
@@ -15,6 +14,7 @@ use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\StorageAttributes;
+use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToProvideChecksum;
 use League\Flysystem\UnableToReadFile;

--- a/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
+++ b/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Flysystem\AdapterTestUtilities;
 
+use League\Flysystem\UnableToDeleteFile;
 use const PHP_EOL;
 use DateInterval;
 use DateTimeImmutable;
@@ -870,5 +871,51 @@ abstract class FilesystemAdapterTestCase extends TestCase
         $this->expectException(UnableToProvideChecksum::class);
 
         $adapter->checksum('dir', new Config());
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_delete_directory_over_delete(): void
+    {
+        $this->runScenario(function () {
+            $adapter = $this->adapter();
+
+            $adapter->write(
+                'test/text.txt',
+                'contents',
+                new Config()
+            );
+
+            $this->assertTrue($adapter->fileExists('test/text.txt'));
+
+            $this->expectException(UnableToDeleteFile::class);
+            $adapter->delete('test/');
+
+            $this->assertTrue($adapter->fileExists('test/text.txt'));
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_delete_with_empty_path(): void
+    {
+        $this->runScenario(function () {
+            $adapter = $this->adapter();
+
+            $adapter->write(
+                'test/text.txt',
+                'contents',
+                new Config()
+            );
+
+            $this->assertTrue($adapter->fileExists('test/text.txt'));
+
+            $this->expectException(UnableToDeleteFile::class);
+            $adapter->delete('');
+
+            $this->assertTrue($adapter->fileExists('test/text.txt'));
+        });
     }
 }

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -639,9 +639,10 @@ class FtpAdapter implements FilesystemAdapter
 
     public function directoryExists(string $path): bool
     {
+        $location = $this->prefixer()->prefixPath($path);
         $connection = $this->connection();
 
-        return @ftp_chdir($connection, $path) === true;
+        return @ftp_chdir($connection, $location) === true;
     }
 
     /**

--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -213,10 +213,25 @@ class FtpAdapter implements FilesystemAdapter
      */
     private function deleteFile(string $path, $connection): void
     {
+        if (empty($path)) {
+            throw UnableToDeleteFile::atLocation($path);
+        }
+
+        $fileExists = $this->fileExists($path);
+
+        if ($fileExists === false) {
+            if ($this->directoryExists($path)) {
+                throw UnableToDeleteFile::atLocation($path);
+            }
+
+            return;
+        }
+
         $location = $this->prefixer()->prefixPath($path);
+
         $success = @ftp_delete($connection, $location);
 
-        if ($success === false && ftp_size($connection, $location) !== -1) {
+        if ($success === false && $this->fileExists($path)) {
             throw UnableToDeleteFile::atLocation($path, 'the file still exists');
         }
     }
@@ -275,7 +290,7 @@ class FtpAdapter implements FilesystemAdapter
 
         $object = @ftp_raw($this->connection(), 'STAT ' . $location);
 
-        if (empty($object) || count($object) < 3 || substr($object[1], 0, 5) === "ftpd:") {
+        if (empty($object) || count($object) < 3 || str_starts_with($object[1], "ftpd:")) {
             throw UnableToRetrieveMetadata::create($path, $type, error_get_last()['message'] ?? '');
         }
 
@@ -450,7 +465,7 @@ class FtpAdapter implements FilesystemAdapter
 
     private function listingItemIsDirectory(string $permissions): bool
     {
-        return substr($permissions, 0, 1) === 'd';
+        return str_starts_with($permissions, 'd');
     }
 
     private function normalizeUnixTimestamp(string $month, string $day, string $timeOrYear): int
@@ -459,14 +474,12 @@ class FtpAdapter implements FilesystemAdapter
             $year = $timeOrYear;
             $hour = '00';
             $minute = '00';
-            $seconds = '00';
         } else {
             $year = date('Y');
             [$hour, $minute] = explode(':', $timeOrYear);
-            $seconds = '00';
         }
 
-        $dateTime = DateTime::createFromFormat('Y-M-j-G:i:s', "{$year}-{$month}-{$day}-{$hour}:{$minute}:{$seconds}");
+        $dateTime = DateTime::createFromFormat('Y-M-j-G:i:s', "{$year}-{$month}-{$day}-{$hour}:{$minute}:00");
 
         return $dateTime->getTimestamp();
     }
@@ -484,7 +497,7 @@ class FtpAdapter implements FilesystemAdapter
         $parts = str_split($permissions, 3);
 
         // convert the groups
-        $mapper = function ($part) {
+        $mapper = static function ($part) {
             return array_sum(str_split($part));
         };
 
@@ -492,11 +505,6 @@ class FtpAdapter implements FilesystemAdapter
         return octdec(implode('', array_map($mapper, $parts)));
     }
 
-    /**
-     * @inheritdoc
-     *
-     * @param string $directory
-     */
     private function listDirectoryContentsRecursive(string $directory): Generator
     {
         $location = $this->prefixer()->prefixPath($directory);
@@ -583,9 +591,6 @@ class FtpAdapter implements FilesystemAdapter
         $this->ensureDirectoryExists($dirname, $visibility);
     }
 
-    /**
-     * @param string $dirname
-     */
     private function ensureDirectoryExists(string $dirname, ?string $visibility): void
     {
         $connection = $this->connection();

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -20,7 +20,6 @@ use League\MimeTypeDetection\MimeTypeDetector;
 
 use function array_keys;
 use function rtrim;
-use function strpos;
 
 class InMemoryFilesystemAdapter implements FilesystemAdapter
 {
@@ -217,7 +216,7 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
                     continue;
                 }
 
-                if ($deep === true || !str_contains($subPath, '/')) {
+                if ($deep === true || ! str_contains($subPath, '/')) {
                     yield new FileAttributes(ltrim($filePath, '/'), $file->fileSize(), $file->visibility(), $file->lastModified(), $file->mimeType());
                 }
             }

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -23,7 +23,7 @@ use function strpos;
 
 class InMemoryFilesystemAdapter implements FilesystemAdapter
 {
-    const DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST = '______DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST';
+    public const DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST = '______DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST';
 
     /**
      * @var InMemoryFile[]
@@ -85,14 +85,14 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         unset($this->files[$this->preparePath($path)]);
     }
 
-    public function deleteDirectory(string $prefix): void
+    public function deleteDirectory(string $path): void
     {
-        $prefix = $this->preparePath($prefix);
+        $prefix = $this->preparePath($path);
         $prefix = rtrim($prefix, '/') . '/';
 
-        foreach (array_keys($this->files) as $path) {
-            if (strpos($path, $prefix) === 0) {
-                unset($this->files[$path]);
+        foreach (array_keys($this->files) as $filePath) {
+            if (str_starts_with($filePath, $prefix)) {
+                unset($this->files[$filePath]);
             }
         }
     }
@@ -108,8 +108,8 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         $prefix = $this->preparePath($path);
         $prefix = rtrim($prefix, '/') . '/';
 
-        foreach (array_keys($this->files) as $path) {
-            if (strpos($path, $prefix) === 0) {
+        foreach (array_keys($this->files) as $filePath) {
+            if (str_starts_with($filePath, $prefix)) {
                 return true;
             }
         }
@@ -184,9 +184,9 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         $prefixLength = strlen($prefix);
         $listedDirectories = [];
 
-        foreach ($this->files as $path => $file) {
-            if (substr($path, 0, $prefixLength) === $prefix) {
-                $subPath = substr($path, $prefixLength);
+        foreach ($this->files as $filePath => $file) {
+            if (str_starts_with($filePath, $prefix)) {
+                $subPath = substr($filePath, $prefixLength);
                 $dirname = dirname($subPath);
 
                 if ($dirname !== '.') {
@@ -208,12 +208,12 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
                 }
 
                 $dummyFilename = self::DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST;
-                if (substr($path, -strlen($dummyFilename)) === $dummyFilename) {
+                if (str_ends_with($filePath, $dummyFilename)) {
                     continue;
                 }
 
-                if ($deep === true || strpos($subPath, '/') === false) {
-                    yield new FileAttributes(ltrim($path, '/'), $file->fileSize(), $file->visibility(), $file->lastModified(), $file->mimeType());
+                if ($deep === true || !str_contains($subPath, '/')) {
+                    yield new FileAttributes(ltrim($filePath, '/'), $file->fileSize(), $file->visibility(), $file->lastModified(), $file->mimeType());
                 }
             }
         }

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -9,6 +9,7 @@ use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\UnableToCopyFile;
+use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
@@ -82,6 +83,10 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
 
     public function delete(string $path): void
     {
+        if (empty($path) || $this->directoryExists($path)) {
+            throw UnableToDeleteFile::atLocation($path);
+        }
+
         unset($this->files[$this->preparePath($path)]);
     }
 

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -15,6 +15,7 @@ use League\Flysystem\UnableToCheckDirectoryExistence;
 use League\Flysystem\UnableToCheckFileExistence;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
+use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
@@ -176,9 +177,24 @@ class SftpAdapter implements FilesystemAdapter
 
     public function delete(string $path): void
     {
+        if (empty($path)) {
+            throw UnableToDeleteFile::atLocation($path);
+        }
+
+        $fileExists = $this->fileExists($path);
+
+        if ($fileExists === false) {
+            if ($this->directoryExists($path)) {
+                throw UnableToDeleteFile::atLocation($path);
+            }
+
+            return;
+        }
+
         $location = $this->prefixer->prefixPath($path);
         $connection = $this->connectionProvider->provideConnection();
-        $connection->delete($location);
+
+        $connection->delete($location, false);
     }
 
     public function deleteDirectory(string $path): void

--- a/src/WebDAV/UrlPrefixingClientStub.php
+++ b/src/WebDAV/UrlPrefixingClientStub.php
@@ -7,6 +7,9 @@ use Sabre\DAV\Client;
 
 class UrlPrefixingClientStub extends Client
 {
+    /**
+     * @param string $url
+     */
     public function propFind($url, array $properties, $depth = 0): array
     {
         $response = parent::propFind($url, $properties, $depth);

--- a/src/WebDAV/UrlPrefixingClientStub.php
+++ b/src/WebDAV/UrlPrefixingClientStub.php
@@ -7,7 +7,7 @@ use Sabre\DAV\Client;
 
 class UrlPrefixingClientStub extends Client
 {
-    public function propFind($url, array $properties, $depth = 0)
+    public function propFind($url, array $properties, $depth = 0): array
     {
         $response = parent::propFind($url, $properties, $depth);
 

--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -176,6 +176,16 @@ class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
 
     public function delete(string $path): void
     {
+        $fileExists = $this->fileExists($path);
+
+        if ($fileExists === false) {
+            if ($this->directoryExists($path)) {
+                throw UnableToDeleteFile::atLocation($path);
+            }
+
+            return;
+        }
+
         $location = $this->encodePath($this->prefixer->prefixPath($path));
 
         try {

--- a/src/WebDAV/composer.json
+++ b/src/WebDAV/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.0.2",
         "league/flysystem": "^3.6.0",
-        "sabre/dav": "^4.3.1"
+        "sabre/dav": "^4.6.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -169,7 +169,7 @@ final class ZipArchiveAdapter implements FilesystemAdapter
 
             $itemPath = $stats['name'];
 
-            if (!str_starts_with($itemPath, $prefixedPath)) {
+            if ( ! str_starts_with($itemPath, $prefixedPath)) {
                 continue;
             }
 

--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -132,6 +132,20 @@ final class ZipArchiveAdapter implements FilesystemAdapter
 
     public function delete(string $path): void
     {
+        if (empty($path) || \str_ends_with($path, '/')) {
+            throw UnableToDeleteFile::atLocation($path);
+        }
+
+        $fileExists = $this->fileExists($path);
+
+        if ($fileExists === false) {
+            if ($this->directoryExists($path)) {
+                throw UnableToDeleteFile::atLocation($path);
+            }
+
+            return;
+        }
+
         $prefixedPath = $this->pathPrefixer->prefixPath($path);
         $zipArchive = $this->zipArchiveProvider->createZipArchive();
         $success = $zipArchive->locateName($prefixedPath) === false || $zipArchive->deleteName($prefixedPath);
@@ -155,7 +169,7 @@ final class ZipArchiveAdapter implements FilesystemAdapter
 
             $itemPath = $stats['name'];
 
-            if (strpos($itemPath, $prefixedPath) !== 0) {
+            if (!str_starts_with($itemPath, $prefixedPath)) {
                 continue;
             }
 


### PR DESCRIPTION
I saw some custom adapters not managing these inputs. E.g. S3 and local adapter throw these exceptions.

I'd like to see these checks in the AdapterTestUtilities to ensure better quality.