### PR TITLE
fix: update aws/aws-sdk-php to newest version to fix CVE-2023-51651

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpunit/phpunit": "^9.5.11|^10.0",
         "phpstan/phpstan": "^1.10",
         "phpseclib/phpseclib": "^3.0.34",
-        "aws/aws-sdk-php": "^3.220.0",
+        "aws/aws-sdk-php": "^3.295.10",
         "composer/semver": "^3.0",
         "friendsofphp/php-cs-fixer": "^3.5",
         "google/cloud-storage": "^1.23",

--- a/src/AwsS3V3/composer.json
+++ b/src/AwsS3V3/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0.2",
         "league/flysystem": "^3.10.0",
         "league/mime-type-detection": "^1.0.0",
-        "aws/aws-sdk-php": "^3.220.0"
+        "aws/aws-sdk-php": "^3.295.10"
     },
     "conflict": {
         "guzzlehttp/ringphp": "<1.1.1",


### PR DESCRIPTION
Updated the aws/aws-sdk-php package to the newest version to fix the given CVE:

![Screenshot from 2024-01-12 10-24-44](https://github.com/thephpleague/flysystem/assets/8778012/fe4a9ba3-5ab3-4255-8747-254b4eb27e86)

This issue has been patched in version 3.288.1.

https://nvd.nist.gov/vuln/detail/CVE-2023-51651