### PR TITLE
fix: update sabre/dav to fix return type annotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "google/cloud-storage": "^1.23",
         "async-aws/s3": "^1.5 || ^2.0",
         "async-aws/simple-s3": "^1.1 || ^2.0",
-        "sabre/dav": "^4.3.1"
+        "sabre/dav": "^4.6.0"
     },
     "conflict": {
         "async-aws/core": "<1.19.0",

--- a/src/WebDAV/UrlPrefixingClientStub.php
+++ b/src/WebDAV/UrlPrefixingClientStub.php
@@ -7,7 +7,10 @@ use Sabre\DAV\Client;
 
 class UrlPrefixingClientStub extends Client
 {
-    public function propFind($url, array $properties, $depth = 0)
+    /**
+     * @param string $url
+     */
+    public function propFind($url, array $properties, $depth = 0): array
     {
         $response = parent::propFind($url, $properties, $depth);
 

--- a/src/WebDAV/composer.json
+++ b/src/WebDAV/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.0.2",
         "league/flysystem": "^3.6.0",
-        "sabre/dav": "^4.3.1"
+        "sabre/dav": "^4.6.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
> PHP Fatal error:  Declaration of League\Flysystem\WebDAV\UrlPrefixingClientStub::propFind($url, array $properties, $depth = 0) must be compatible with Sabre\DAV\Client::propFind($url, array $properties, $depth = 0): array in /home/runner/work/flysystem/flysystem/src/WebDAV/UrlPrefixingClientStub.php on line 10