### PR TITLE
fix: [AsyncAwsS3] update simpleS3 for test and adjust getPresignedUrl declaration

### DIFF
--- a/src/AsyncAwsS3/S3ClientStub.php
+++ b/src/AsyncAwsS3/S3ClientStub.php
@@ -181,7 +181,7 @@ class S3ClientStub extends SimpleS3Client
         return $this->actualClient->getUrl($bucket, $key);
     }
 
-    public function getPresignedUrl(string $bucket, string $key, ?DateTimeImmutable $expires = null): string
+    public function getPresignedUrl(string $bucket, string $key, ?DateTimeImmutable $expires = null, ?string $versionId = null): string
     {
         return $this->actualClient->getPresignedUrl($bucket, $key, $expires);
     }

--- a/src/AsyncAwsS3/composer.json
+++ b/src/AsyncAwsS3/composer.json
@@ -15,11 +15,10 @@
         "async-aws/s3": "^1.5 || ^2.0"
     },
     "require-dev": {
-        "async-aws/simple-s3": "^1.1 || ^2.0"
+        "async-aws/simple-s3": "^2.1"
     },
     "conflict": {
-        "symfony/http-client": "<5.2",
-        "async-aws/simple-s3": "<1.1"
+        "symfony/http-client": "<5.2"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Fixes the tests.

> PHP Fatal error:  Declaration of League\Flysystem\AsyncAwsS3\S3ClientStub::getPresignedUrl(string $bucket, string $key, ?DateTimeImmutable $expires = null): string must be compatible with AsyncAws\SimpleS3\SimpleS3Client::getPresignedUrl(string $bucket, string $key, ?DateTimeImmutable $expires = null, ?string $versionId = null): string in /home/runner/work/flysystem/flysystem/src/AsyncAwsS3/S3ClientStub.php on line 184

webdav is fixed here https://github.com/thephpleague/flysystem/pull/1746