### PR TITLE
Node20 actions upgrade

### DIFF
--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -16,18 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish package sub-splits
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           persist-credentials: 'false'
-      - uses: frankdejonge/use-github-token@1.0.2
+      - uses: frankdejonge/use-github-token@1
         with:
           authentication: 'frankdejonge:${{ secrets.PERSONAL_ACCESS_TOKEN }}'
           user_name: 'Frank de Jonge'
           user_email: 'info@frenky.net'
       - name: Cache splitsh-lite
         id: splitsh-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: './.splitsh'
           key: '${{ runner.os }}-splitsh'

--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: '0'
           persist-credentials: 'false'
-      - uses: frankdejonge/use-github-token@1
+      - uses: frankdejonge/use-github-token@1.1.0
         with:
           authentication: 'frankdejonge:${{ secrets.PERSONAL_ACCESS_TOKEN }}'
           user_name: 'Frank de Jonge'
@@ -31,7 +31,7 @@ jobs:
         with:
           path: './.splitsh'
           key: '${{ runner.os }}-splitsh'
-      - uses: frankdejonge/use-subsplit-publish@1.0.0
+      - uses: frankdejonge/use-subsplit-publish@1.1.0
         with:
           source-branch: '3.x'
           config-path: './config.subsplit-publish.json'

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: docker-compose -f docker-compose.yml up -d
       - name: Start an SSH Agent
-        uses: frankdejonge/use-ssh-agent@1
+        uses: frankdejonge/use-ssh-agent@1.1.0
       - run: chmod 0400 ./test_files/sftp/id_*
       - id: ssh_agent
         run: ssh-add ./test_files/sftp/id_rsa

--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -55,10 +55,10 @@ jobs:
             phpstan: false
             phpunit-flags: '--no-coverage'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker-compose -f docker-compose.yml up -d
       - name: Start an SSH Agent
-        uses: frankdejonge/use-ssh-agent@1.0.2
+        uses: frankdejonge/use-ssh-agent@1
       - run: chmod 0400 ./test_files/sftp/id_*
       - id: ssh_agent
         run: ssh-add ./test_files/sftp/id_rsa

--- a/.github/workflows/set-subsplit-default-branch.yml
+++ b/.github/workflows/set-subsplit-default-branch.yml
@@ -8,11 +8,11 @@ jobs:
     name: Set default git branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           persist-credentials: 'false'
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           script: |


### PR DESCRIPTION
This PR updates several `uses` in the GitHub Actions workflow in this repository to no longer run on Node16.

You can checkout https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/#what-you-need-to-do for more reasoning about the replacements.