### PR TITLE
Added supported 'add_content_md5' option to AwsS3V3Adapter.php

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -74,6 +74,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
      * @var string[]
      */
     public const MUP_AVAILABLE_OPTIONS = [
+        'add_content_md5',
         'before_upload',
         'concurrency',
         'mup_threshold',

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -51,7 +51,6 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         'ContentEncoding',
         'ContentLength',
         'ContentType',
-        'ContentMD5',
         'Expires',
         'GrantFullControl',
         'GrantRead',


### PR DESCRIPTION
As of January 2023, the `aws-sdk-php` for S3 now supports a 'add_content_md5` option for multipart uploads. (See [this commit](https://github.com/aws/aws-sdk-php/commit/91e8d4376b6c1805a2a83e4bd75b02aa79ae971c) and the [related issue](https://github.com/aws/aws-sdk-php/issues/2256).) 

On S3 buckets with object locks enabled, setting the option to true asks the SDK to automatically compute and send the required http header as part of the request. Without the header, AWS will return a `400 - Invalid Request` with the message "Content-MD5 OR x-amz-checksum- HTTP header is required for Put Part requests with Object Lock parameters"