### PR TITLE
Fix: AWS Copy SSE-C Options +  Send all options to copy instead of just params

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -73,9 +73,9 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
         'Tagging',
         'WebsiteRedirectLocation',
         'ChecksumAlgorithm',
-        'CopySSECustomerAlgorithm',
-        'CopySSECustomerKey',
-        'CopySSECustomerKeyMD5',
+        'CopySourceSSECustomerAlgorithm',
+        'CopySourceSSECustomerKey',
+        'CopySourceSSECustomerKeyMD5',
     ];
 
     /**

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -438,7 +438,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
                 $this->bucket,
                 $this->prefixer->prefixPath($destination),
                 $this->visibility->visibilityToAcl($visibility ?: 'private'),
-                $this->createOptionsFromConfig($config)['params']
+                $this->createOptionsFromConfig($config)
             );
         } catch (Throwable $exception) {
             throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);

--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -68,9 +68,9 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         'Tagging',
         'WebsiteRedirectLocation',
         'ChecksumAlgorithm',
-        'CopySSECustomerAlgorithm',
-        'CopySSECustomerKey',
-        'CopySSECustomerKeyMD5',
+        'CopySourceSSECustomerAlgorithm',
+        'CopySourceSSECustomerKey',
+        'CopySourceSSECustomerKeyMD5',
     ];
     /**
      * @var string[]


### PR DESCRIPTION
Hi @frankdejonge,
This is the right MR with all changes.

I tested in with the official S3 SDK, not with AsyncAWS.
Not sure we have to do changes for params with AsyncAWS.

Thanks in advance for review :pray: 