### PR TITLE
DirectoryListing: fix generic declarations

### DIFF
--- a/src/DirectoryListing.php
+++ b/src/DirectoryListing.php
@@ -10,7 +10,8 @@ use IteratorAggregate;
 use Traversable;
 
 /**
- * @template T
+ * @template-covariant T of StorageAttributes
+ * @implements IteratorAggregate<T>
  */
 class DirectoryListing implements IteratorAggregate
 {
@@ -40,7 +41,7 @@ class DirectoryListing implements IteratorAggregate
     }
 
     /**
-     * @template R
+     * @template R of StorageAttributes
      *
      * @param callable(T): R $mapper
      *


### PR DESCRIPTION
* marks `T` as covariant, this is required to make `DirectoryListing<FileAttributes>` subtype of `DirectoryListing<StorageAttributes>`
* add missing upper bound for `T`, because `sortByPath` relies on items being subtypes of `StorageAttributes`
* add missing generic parameter for implemented interface `IteratorAggregate`

---

[playground](https://phpstan.org/r/e0b5066f-b3e6-4fa6-a349-44904e586226)