### PR TITLE
Add CS rule to prevent regression on non-explicit nullable

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,5 +34,6 @@ return (new PhpCsFixer\Config())
         ],
         'no_extra_blank_lines' => true,
         'no_whitespace_in_blank_line' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder($finder);


### PR DESCRIPTION
Following #1772, the rule [`nullable_type_declaration_for_default_null_value`](https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html) ensure the code stays ready for PHP 8.4