### PR TITLE
Add MongoDB GridFS Adapter

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -25,6 +25,7 @@ env:
   FLYSYSTEM_AWS_S3_KEY: '${{ secrets.FLYSYSTEM_AWS_S3_KEY }}'
   FLYSYSTEM_AWS_S3_SECRET: '${{ secrets.FLYSYSTEM_AWS_S3_SECRET }}'
   FLYSYSTEM_AWS_S3_BUCKET: '${{ secrets.FLYSYSTEM_AWS_S3_BUCKET }}'
+  MONGODB_URI: 'mongodb://127.0.0.1:27017/'
   FLYSYSTEM_TEST_DANGEROUS_THINGS: "yes"
   FLYSYSTEM_TEST_SFTP: "yes"
 
@@ -70,6 +71,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: mongodb
           coverage: pcov
           tools: composer:v2
       - run: composer update --no-progress ${{ matrix.composer-flags }}

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "google/cloud-storage": "^1.23",
         "async-aws/s3": "^1.5 || ^2.0",
         "async-aws/simple-s3": "^1.1 || ^2.0",
+        "mongodb/mongodb": "^1.2",
         "sabre/dav": "^4.6.0",
         "guzzlehttp/psr7": "^2.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "ext-zip": "*",
         "ext-fileinfo": "*",
         "ext-ftp": "*",
+        "ext-mongodb": "^1.3",
         "microsoft/azure-storage-blob": "^1.1",
         "phpunit/phpunit": "^9.5.11|^10.0",
         "phpstan/phpstan": "^1.10",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 ---
 version: "3"
 services:
+  mongodb:
+    image: mongo:7
+    ports:
+      - "27017:27017"
   sabredav:
     image: php:8.1-alpine3.15
     restart: always

--- a/src/GridFS/.gitattributes
+++ b/src/GridFS/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+.github export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+**/*Test.php export-ignore
+**/*Stub.php export-ignore
+README.md export-ignore

--- a/src/GridFS/.github/workflows/close-subsplit-prs.yaml
+++ b/src/GridFS/.github/workflows/close-subsplit-prs.yaml
@@ -1,0 +1,30 @@
+---
+name: Close sub-split PRs
+
+on:
+  push:
+    branches:
+      - 2.x
+      - 3.x
+  pull_request:
+    branches:
+      - 2.x
+      - 3.x
+  schedule:
+    - cron: '30 7 * * *'
+
+jobs:
+  close_subsplit_prs:
+    runs-on: ubuntu-latest
+    name: Close sub-split PRs
+    steps:
+      - uses: frankdejonge/action-close-subsplit-pr@0.1.0
+        with:
+          close_pr: 'yes'
+          target_branch_match: '^(?!master).+$'
+          message: |
+            Hi :wave:,
+
+            Thank you for contributing to Flysystem. Unfortunately, you've sent a PR to a read-only sub-split repository.
+
+            All pull requests should be directed towards: https://github.com/thephpleague/flysystem

--- a/src/GridFS/GridFSAdapter.php
+++ b/src/GridFS/GridFSAdapter.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\GridFS;
+
+use League\Flysystem\Config;
+use League\Flysystem\DirectoryAttributes;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\PathPrefixer;
+use League\Flysystem\UnableToCopyFile;
+use League\Flysystem\UnableToCreateDirectory;
+use League\Flysystem\UnableToDeleteFile;
+use League\Flysystem\UnableToMoveFile;
+use League\Flysystem\UnableToReadFile;
+use League\Flysystem\UnableToRetrieveMetadata;
+use League\Flysystem\UnableToSetVisibility;
+use League\Flysystem\UnableToWriteFile;
+use League\MimeTypeDetection\FinfoMimeTypeDetector;
+use League\MimeTypeDetection\MimeTypeDetector;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\Regex;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Driver\Exception\Exception;
+use MongoDB\GridFS\Bucket;
+
+class GridFSAdapter implements FilesystemAdapter
+{
+    private const METADATA_DIRECTORY = 'flysystem_directory';
+    private const METADATA_VISIBILITY = 'flysystem_visibility';
+    private const METADATA_MIMETYPE = 'contentType';
+
+    private Bucket $bucket;
+
+    private PathPrefixer $prefixer;
+
+    private MimeTypeDetector $mimeTypeDetector;
+
+    public function __construct(
+        Bucket $bucket,
+        string $prefix = '',
+        ?MimeTypeDetector $mimeTypeDetector = null,
+    ) {
+        $this->bucket = $bucket;
+        $this->prefixer = new PathPrefixer($prefix);
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
+    }
+
+    public function fileExists(string $path): bool
+    {
+        $file = $this->findFile($path);
+
+        return $file !== null;
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        // A directory exists if at least one file exists with a path starting with the directory name
+        $files = $this->listContents($path, true);
+
+        foreach ($files as $file) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        if (str_ends_with($path, '/')) {
+            throw UnableToWriteFile::atLocation($path, 'file path cannot end with a slash');
+        }
+
+        $filename = $this->prefixer->prefixPath($path);
+        $options = [
+            'metadata' => $config->get('metadata', []),
+        ];
+        if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
+            $options['metadata'][self::METADATA_VISIBILITY] = $visibility;
+        }
+        if (($mimeType = $config->get('mimetype')) || ($mimeType = $this->mimeTypeDetector->detectMimeType($path, $contents))) {
+            $options['metadata'][self::METADATA_MIMETYPE] = $mimeType;
+        }
+
+        try {
+            $stream = $this->bucket->openUploadStream($filename, $options);
+            fwrite($stream, $contents);
+            fclose($stream);
+        } catch (Exception $exception) {
+            throw UnableToWriteFile::atLocation($path, $exception->getMessage(), $exception);
+        }
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        if (str_ends_with($path, '/')) {
+            throw UnableToWriteFile::atLocation($path, 'file path cannot end with a slash');
+        }
+
+        $filename = $this->prefixer->prefixPath($path);
+        $options = [];
+        if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
+            $options['metadata'][self::METADATA_VISIBILITY] = $visibility;
+        }
+        if (($mimetype = $config->get('mimetype')) || ($mimetype = $this->mimeTypeDetector->detectMimeTypeFromPath($path))) {
+            $options['metadata'][self::METADATA_MIMETYPE] = $mimetype;
+        }
+
+        try {
+            $this->bucket->uploadFromStream($filename, $contents, $options);
+        } catch (Exception $exception) {
+            throw UnableToWriteFile::atLocation($path, $exception->getMessage(), $exception);
+        }
+    }
+
+    public function read(string $path): string
+    {
+        return stream_get_contents($this->readStream($path));
+    }
+
+    public function readStream(string $path)
+    {
+        if (str_ends_with($path, '/')) {
+            throw UnableToReadFile::fromLocation($path, 'file path cannot end with a slash');
+        }
+
+        $file = $this->findFile($path);
+
+        if ($file === null) {
+            throw UnableToReadFile::fromLocation($path, 'file does not exist');
+        }
+
+        try {
+            return $this->bucket->openDownloadStream($file['_id']);
+        } catch (Exception $exception) {
+            throw UnableToReadFile::fromLocation($path, $exception->getMessage(), $exception);
+        }
+    }
+
+    public function delete(string $path): void
+    {
+        if (str_ends_with($path, '/')) {
+            throw UnableToDeleteFile::atLocation($path, 'file path cannot end with a slash');
+        }
+
+        // Deleting a file that does not exist is no-op
+        while ($file = $this->findFile($path)) {
+            try {
+                $this->bucket->delete($file['_id']);
+            } catch (Exception $exception) {
+                throw UnableToDeleteFile::atLocation($path, $exception->getMessage(), $exception);
+            }
+        }
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        foreach ($this->listContents($path, true) as $file) {
+            $this->bucket->delete($file->extraMetadata()['_id']);
+        }
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        $dirname = $this->prefixer->prefixDirectoryPath($path);
+
+        $options = [
+            'metadata' => $config->get('metadata', []) + [self::METADATA_DIRECTORY => true],
+        ];
+
+        if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
+            $options['metadata'][self::METADATA_VISIBILITY] = $visibility;
+        }
+
+        try {
+            $stream = $this->bucket->openUploadStream($dirname, $options);
+            fwrite($stream, '');
+            fclose($stream);
+        } catch (Exception $exception) {
+            throw UnableToCreateDirectory::atLocation($path, $exception->getMessage(), $exception);
+        }
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $file = $this->findFile($path);
+
+        if ($file === null) {
+            throw UnableToSetVisibility::atLocation($path, 'file does not exist');
+        }
+
+        try {
+            $this->bucket->getFilesCollection()->updateOne(
+                ['_id' => $file['_id']],
+                ['$set' => ['metadata.' . self::METADATA_VISIBILITY => $visibility]],
+            );
+        } catch (Exception $exception) {
+            throw UnableToSetVisibility::atLocation($path, $exception->getMessage(), $exception);
+        }
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        $file = $this->findFile($path);
+
+        if ($file === null) {
+            throw UnableToRetrieveMetadata::mimeType($path, 'file does not exist');
+        }
+
+        return new FileAttributes($path, null, $file['metadata'][self::METADATA_VISIBILITY] ?? null);
+    }
+
+    public function mimeType(string $path): FileAttributes
+    {
+        if (str_ends_with($path, '/')) {
+            throw UnableToRetrieveMetadata::mimeType($path, 'file path cannot end with a slash');
+        }
+
+        $file = $this->findFile($path);
+
+        if ($file === null) {
+            throw UnableToRetrieveMetadata::mimeType($path, 'file does not exist');
+        }
+
+        if ( ! isset($file['metadata'][self::METADATA_MIMETYPE])) {
+            throw UnableToRetrieveMetadata::mimeType($path, 'unknown');
+        }
+
+        return new FileAttributes($path, null, null, null, $file['metadata'][self::METADATA_MIMETYPE]);
+    }
+
+    public function lastModified(string $path): FileAttributes
+    {
+        if (str_ends_with($path, '/')) {
+            throw UnableToRetrieveMetadata::lastModified($path, 'file path cannot end with a slash');
+        }
+
+        $file = $this->findFile($path);
+
+        if ($file === null) {
+            throw UnableToRetrieveMetadata::lastModified($path, 'file does not exist');
+        }
+
+        return new FileAttributes($path, null, null, $file['uploadDate']->toDateTime()->getTimestamp());
+    }
+
+    public function fileSize(string $path): FileAttributes
+    {
+        if (str_ends_with($path, '/')) {
+            throw UnableToRetrieveMetadata::fileSize($path, 'file path cannot end with a slash');
+        }
+
+        $file = $this->findFile($path);
+
+        if ($file === null) {
+            throw UnableToRetrieveMetadata::fileSize($path, 'file does not exist');
+        }
+
+        return new FileAttributes($path, $file['length']);
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        $path = $this->prefixer->prefixDirectoryPath($path);
+
+        $pathdeep = 0;
+        $pipeline = [];
+        if ($path !== '') {
+            $pathdeep = substr_count($path, '/');
+            // Exclude files that do not start with the expected path
+            $pipeline[] = ['$match' => ['filename' => ['$regex' => new Regex('^' . preg_quote($path))]]];
+        }
+        // Get the last revision of each file
+        $pipeline[] = ['$sort' => ['filename' => 1, 'uploadDate' => -1]];
+
+        if ($deep === false) {
+            $pipeline[] = ['$addFields' => ['splitpath' => ['$split' => ['$filename', '/']]]];
+            $pipeline[] = ['$group' => [
+                // The same name could be used as a filename and as part of the path of other files
+                '_id' => [
+                    'basename' => ['$arrayElemAt' => ['$splitpath', $pathdeep]],
+                    'isDir' => ['$ne' => [['$size' => '$splitpath'], $pathdeep + 1]],
+                ],
+                // Get the metadata of the last revision of each file
+                'file' => ['$first' => '$$ROOT'],
+                // The "lastModified" date is the date of the last uploaded file in the directory
+                'uploadDate' => ['$max' => '$uploadDate'],
+            ]];
+
+            $files = $this->bucket->getFilesCollection()->aggregate(
+                $pipeline,
+                ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
+            );
+
+            foreach ($files as $file) {
+                if ($file['_id']['isDir']) {
+                    yield new DirectoryAttributes(
+                        $this->prefixer->stripDirectoryPrefix($path . $file['_id']['basename']),
+                        null,
+                        $file['uploadDate']->toDateTime()->getTimestamp(),
+                    );
+                } else {
+                    $file = $file['file'];
+                    yield new FileAttributes(
+                        $this->prefixer->stripPrefix($file['filename']),
+                        $file['length'],
+                        $file['metadata'][self::METADATA_VISIBILITY] ?? null,
+                        $file['uploadDate']->toDateTime()->getTimestamp(),
+                        $file['metadata'][self::METADATA_MIMETYPE] ?? null,
+                        $file,
+                    );
+                }
+            }
+        } else {
+            // Get the metadata of the last revision of each file
+            $pipeline[] = ['$group' => [
+                '_id' => '$filename',
+                'file' => ['$first' => '$$ROOT'],
+            ]];
+
+            $files = $this->bucket->getFilesCollection()->aggregate(
+                $pipeline,
+                ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']],
+            );
+
+            foreach ($files as $file) {
+                $file = $file['file'];
+                if (str_ends_with($file['filename'], '/')) {
+                    // Empty files with a trailing slash are markers for directories, for Flysystem
+                    yield new DirectoryAttributes(
+                        $this->prefixer->stripDirectoryPrefix($file['filename']),
+                        $file['metadata'][self::METADATA_VISIBILITY] ?? null,
+                        $file['uploadDate']->toDateTime()->getTimestamp(),
+                        $file,
+                    );
+                } else {
+                    yield new FileAttributes(
+                        $this->prefixer->stripPrefix($file['filename']),
+                        $file['length'],
+                        $file['metadata'][self::METADATA_VISIBILITY] ?? null,
+                        $file['uploadDate']->toDateTime()->getTimestamp(),
+                        $file['metadata'][self::METADATA_MIMETYPE] ?? null,
+                        $file,
+                    );
+                }
+            }
+        }
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        $file = $this->findFile($source);
+
+        if ($file === null) {
+            throw UnableToMoveFile::because('file does not exist', $source, $destination);
+        }
+
+        try {
+            $this->bucket->getFilesCollection()->updateMany(
+                ['filename' => $file['filename']],
+                ['$set' => ['filename' => $this->prefixer->prefixPath($destination)]],
+            );
+        } catch (Exception $exception) {
+            throw UnableToMoveFile::fromLocationTo($source, $destination, $exception);
+        }
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        $file = $this->findFile($source);
+
+        if ($file === null) {
+            throw UnableToCopyFile::fromLocationTo(
+                $source,
+                $destination,
+            );
+        }
+
+        $options = [];
+        if (($visibility = $config->get(Config::OPTION_VISIBILITY)) || $visibility = $file['metadata'][self::METADATA_VISIBILITY] ?? null) {
+            $options['metadata'][self::METADATA_VISIBILITY] = $visibility;
+        }
+        if (($mimetype = $config->get('mimetype')) || $mimetype = $file['metadata'][self::METADATA_MIMETYPE] ?? null) {
+            $options['metadata'][self::METADATA_MIMETYPE] = $mimetype;
+        }
+
+        try {
+            $stream = $this->bucket->openDownloadStream($file['_id']);
+            $this->bucket->uploadFromStream($this->prefixer->prefixPath($destination), $stream, $options);
+        } catch (Exception $exception) {
+            throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);
+        }
+    }
+
+    /**
+     * @return array{_id:ObjectId, length:int, chunkSize:int, uploadDate:UTCDateTime, filename:string, metadata?:array{contentType?:string, flysystem_visibility?:string}}|null
+     */
+    private function findFile(string $path): ?array
+    {
+        $filename = $this->prefixer->prefixPath($path);
+        $files = $this->bucket->find(
+            ['filename' => $filename],
+            [
+                'sort' => ['uploadDate' => -1],
+                'limit' => 1,
+                'typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array'],
+            ],
+        );
+
+        return $files->toArray()[0] ?? null;
+    }
+}

--- a/src/GridFS/GridFSAdapter.php
+++ b/src/GridFS/GridFSAdapter.php
@@ -139,14 +139,12 @@ class GridFSAdapter implements FilesystemAdapter
             throw UnableToReadFile::fromLocation($path, 'file path cannot end with a slash');
         }
 
-        $file = $this->findFile($path);
-
-        if ($file === null) {
-            throw UnableToReadFile::fromLocation($path, 'file does not exist');
-        }
-
         try {
-            return $this->bucket->openDownloadStream($file['_id']);
+            $filename = $this->prefixer->prefixPath($path);
+
+            return $this->bucket->openDownloadStreamByName($filename);
+        } catch (FileNotFoundException $exception) {
+            throw UnableToReadFile::fromLocation($path, 'file does not exist', $exception);
         } catch (Exception $exception) {
             throw UnableToReadFile::fromLocation($path, $exception->getMessage(), $exception);
         }

--- a/src/GridFS/GridFSAdapter.php
+++ b/src/GridFS/GridFSAdapter.php
@@ -251,16 +251,16 @@ class GridFSAdapter implements FilesystemAdapter
         }
 
         $file = $this->findFile($path);
-
         if ($file === null) {
             throw UnableToRetrieveMetadata::mimeType($path, 'file does not exist');
         }
 
-        if ( ! isset($file['metadata'][self::METADATA_MIMETYPE])) {
+        $attributes = $this->mapFileAttributes($file);
+        if ($attributes->mimeType() === null) {
             throw UnableToRetrieveMetadata::mimeType($path, 'unknown');
         }
 
-        return new FileAttributes($path, null, null, null, $file['metadata'][self::METADATA_MIMETYPE]);
+        return $attributes;
     }
 
     public function lastModified(string $path): FileAttributes

--- a/src/GridFS/GridFSAdapterTest.php
+++ b/src/GridFS/GridFSAdapterTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\Flysystem\GridFS;
+
+use League\Flysystem\AdapterTestUtilities\FilesystemAdapterTestCase as TestCase;
+use League\Flysystem\Config;
+use League\Flysystem\DirectoryAttributes;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\UnableToDeleteFile;
+use League\Flysystem\UnableToReadFile;
+use League\Flysystem\UnableToRetrieveMetadata;
+use League\Flysystem\UnableToWriteFile;
+use MongoDB\Client;
+use MongoDB\Database;
+use function getenv;
+
+/**
+ * @group gridfs
+ */
+class GridFSAdapterTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private static $adapterPrefix = 'test-prefix';
+
+    public static function tearDownAfterClass(): void
+    {
+        self::getDatabase()->drop();
+
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * @test
+     */
+    public function fetching_last_modified_of_a_directory(): void
+    {
+        $this->expectException(UnableToRetrieveMetadata::class);
+
+        $adapter = $this->adapter();
+
+        $this->runScenario(function () use ($adapter) {
+            $adapter->createDirectory('path', new Config());
+            $adapter->lastModified('path/');
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function fetching_mime_type_of_a_directory(): void
+    {
+        $this->expectException(UnableToRetrieveMetadata::class);
+
+        $adapter = $this->adapter();
+
+        $this->runScenario(function () use ($adapter) {
+            $adapter->createDirectory('path', new Config());
+            $adapter->mimeType('path/');
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function reading_a_file_with_trailing_slash(): void
+    {
+        $this->expectException(UnableToReadFile::class);
+        $this->adapter()->read('foo/');
+    }
+
+    /**
+     * @test
+     */
+    public function reading_a_file_stream_with_trailing_slash(): void
+    {
+        $this->expectException(UnableToReadFile::class);
+        $this->adapter()->readStream('foo/');
+    }
+
+    /**
+     * @test
+     */
+    public function writing_a_file_with_trailing_slash(): void
+    {
+        $this->expectException(UnableToWriteFile::class);
+        $this->adapter()->write('foo/', 'contents', new Config());
+    }
+
+    /**
+     * @test
+     */
+    public function writing_a_file_stream_with_trailing_slash(): void
+    {
+        $this->expectException(UnableToWriteFile::class);
+        $writeStream = stream_with_contents('contents');
+        $this->adapter()->writeStream('foo/', $writeStream, new Config());
+    }
+
+    /**
+     * @test
+     */
+    public function writing_a_file_with_a_invalid_stream(): void
+    {
+        $this->expectException(UnableToWriteFile::class);
+        // @phpstan-ignore argument.type
+        $this->adapter()->writeStream('file.txt', 'foo', new Config());
+    }
+
+    /**
+     * @test
+     */
+    public function delete_a_file_with_trailing_slash(): void
+    {
+        $this->expectException(UnableToDeleteFile::class);
+        $this->adapter()->delete('foo/');
+    }
+
+    /**
+     * @test
+     */
+    public function reading_last_revision(): void
+    {
+        $this->runScenario(
+            function () {
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
+
+                $this->assertSame('version 2', $this->adapter()->read('file.txt'));
+            }
+        );
+    }
+
+    /**
+     * @testWith [false]
+     *           [true]
+     *
+     * @test
+     */
+    public function listing_contents_last_revision(bool $deep): void
+    {
+        $this->runScenario(
+            function () use ($deep) {
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
+
+                $files = $this->adapter()->listContents('', $deep);
+                $files = iterator_to_array($files);
+
+                $this->assertCount(1, $files);
+                $file = $files[0];
+                $this->assertInstanceOf(FileAttributes::class, $file);
+                $this->assertSame('file.txt', $file->path());
+            }
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function listing_contents_directory_with_multiple_files(): void
+    {
+        $this->runScenario(
+            function () {
+                $this->givenWeHaveAnExistingFile('some/file-1.txt');
+                $this->givenWeHaveAnExistingFile('some/file-2.txt');
+                $this->givenWeHaveAnExistingFile('some/other/file-1.txt');
+
+                $files = $this->adapter()->listContents('', false);
+                $files = iterator_to_array($files);
+
+                $this->assertCount(1, $files);
+                $file = $files[0];
+                $this->assertInstanceOf(DirectoryAttributes::class, $file);
+                $this->assertSame('some', $file->path());
+            }
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function delete_all_revisions(): void
+    {
+        $this->runScenario(
+            function () {
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 3');
+
+                $this->adapter()->delete('file.txt');
+
+                $this->assertFalse($this->adapter()->fileExists('file.txt'), 'File does not exist');
+            }
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function move_all_revisions(): void
+    {
+        $this->runScenario(
+            function () {
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
+                $this->givenWeHaveAnExistingFile('file.txt', 'version 3');
+
+                $this->adapter()->move('file.txt', 'destination.txt', new Config());
+
+                $this->assertSame($this->adapter()->read('destination.txt'), 'version 3');
+                $this->assertFalse($this->adapter()->fileExists('file.txt'));
+
+            }
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        self::getDatabase()->selectGridFSBucket()->drop();
+
+        parent::tearDown();
+    }
+
+    protected static function createFilesystemAdapter(): FilesystemAdapter
+    {
+        $bucket = self::getDatabase()->selectGridFSBucket();
+        $prefix = getenv('FLYSYSTEM_MONGODB_PREFIX') ?: self::$adapterPrefix;
+
+        return new GridFSAdapter($bucket, $prefix);
+    }
+
+    private static function getDatabase(): Database
+    {
+        $uri = getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1:27017/';
+
+        $client = new Client($uri);
+
+        return $client->selectDatabase(getenv('MONGODB_DATABASE') ?: 'flysystem_tests');
+    }
+}

--- a/src/GridFS/GridFSAdapterTest.php
+++ b/src/GridFS/GridFSAdapterTest.php
@@ -15,6 +15,7 @@ use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToWriteFile;
 use MongoDB\Client;
 use MongoDB\Database;
+use MongoDB\Driver\ReadPreference;
 use function getenv;
 
 /**
@@ -146,7 +147,7 @@ class GridFSAdapterTest extends TestCase
         $this->runScenario(
             function () {
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
-                usleep(10);
+                usleep(1000);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
 
                 $this->assertSame('version 2', $this->adapter()->read('file.txt'));
@@ -165,7 +166,7 @@ class GridFSAdapterTest extends TestCase
         $this->runScenario(
             function () use ($deep) {
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
-                usleep(10);
+                usleep(1000);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
 
                 $files = $this->adapter()->listContents('', $deep);
@@ -209,7 +210,9 @@ class GridFSAdapterTest extends TestCase
         $this->runScenario(
             function () {
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
+                usleep(1000);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
+                usleep(1000);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 3');
 
                 $this->adapter()->delete('file.txt');
@@ -227,16 +230,15 @@ class GridFSAdapterTest extends TestCase
         $this->runScenario(
             function () {
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
-                usleep(10);
+                usleep(1000);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
-                usleep(10);
+                usleep(1000);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 3');
 
                 $this->adapter()->move('file.txt', 'destination.txt', new Config());
 
                 $this->assertFalse($this->adapter()->fileExists('file.txt'));
                 $this->assertSame($this->adapter()->read('destination.txt'), 'version 3');
-
             }
         );
     }
@@ -260,7 +262,9 @@ class GridFSAdapterTest extends TestCase
     {
         $uri = getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1:27017/';
 
-        $client = new Client($uri);
+        $client = new Client($uri, [], [
+            'readPreference' => new ReadPreference(ReadPreference::PRIMARY),
+        ]);
 
         return $client->selectDatabase(getenv('MONGODB_DATABASE') ?: 'flysystem_tests');
     }

--- a/src/GridFS/GridFSAdapterTest.php
+++ b/src/GridFS/GridFSAdapterTest.php
@@ -19,6 +19,8 @@ use function getenv;
 
 /**
  * @group gridfs
+ *
+ * @method GridFSAdapter adapter()
  */
 class GridFSAdapterTest extends TestCase
 {
@@ -32,6 +34,22 @@ class GridFSAdapterTest extends TestCase
         self::getDatabase()->drop();
 
         parent::tearDownAfterClass();
+    }
+
+    /**
+     * @test
+     */
+    public function fetching_contains_extra_metadata(): void
+    {
+        $adapter = $this->adapter();
+
+        $this->runScenario(function () use ($adapter) {
+            $this->givenWeHaveAnExistingFile('file.txt');
+            $fileAttributes = $adapter->lastModified('file.txt');
+            $extra = $fileAttributes->extraMetadata();
+            $this->assertArrayHasKey('_id', $extra);
+            $this->assertArrayHasKey('filename', $extra);
+        });
     }
 
     /**

--- a/src/GridFS/GridFSAdapterTest.php
+++ b/src/GridFS/GridFSAdapterTest.php
@@ -261,10 +261,7 @@ class GridFSAdapterTest extends TestCase
     private static function getDatabase(): Database
     {
         $uri = getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1:27017/';
-
-        $client = new Client($uri, [], [
-            'readPreference' => new ReadPreference(ReadPreference::PRIMARY),
-        ]);
+        $client = new Client($uri);
 
         return $client->selectDatabase(getenv('MONGODB_DATABASE') ?: 'flysystem_tests');
     }

--- a/src/GridFS/GridFSAdapterTest.php
+++ b/src/GridFS/GridFSAdapterTest.php
@@ -146,6 +146,7 @@ class GridFSAdapterTest extends TestCase
         $this->runScenario(
             function () {
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
+                usleep(10);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
 
                 $this->assertSame('version 2', $this->adapter()->read('file.txt'));
@@ -164,6 +165,7 @@ class GridFSAdapterTest extends TestCase
         $this->runScenario(
             function () use ($deep) {
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
+                usleep(10);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
 
                 $files = $this->adapter()->listContents('', $deep);
@@ -225,13 +227,15 @@ class GridFSAdapterTest extends TestCase
         $this->runScenario(
             function () {
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 1');
+                usleep(10);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 2');
+                usleep(10);
                 $this->givenWeHaveAnExistingFile('file.txt', 'version 3');
 
                 $this->adapter()->move('file.txt', 'destination.txt', new Config());
 
-                $this->assertSame($this->adapter()->read('destination.txt'), 'version 3');
                 $this->assertFalse($this->adapter()->fileExists('file.txt'));
+                $this->assertSame($this->adapter()->read('destination.txt'), 'version 3');
 
             }
         );

--- a/src/GridFS/LICENSE
+++ b/src/GridFS/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024 Frank de Jonge
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/GridFS/README.md
+++ b/src/GridFS/README.md
@@ -1,0 +1,9 @@
+## Sub-split for Flysystem's MongoDB GridFS Adapter
+
+> ⚠️ this is a sub-split, for pull requests and issues, visit: https://github.com/thephpleague/flysystem
+
+```bash
+composer require league/flysystem-gridfs
+```
+
+View the [documentation](https://flysystem.thephpleague.com/docs/adapter/gridfs/).

--- a/src/GridFS/composer.json
+++ b/src/GridFS/composer.json
@@ -7,7 +7,7 @@
     },
     "require": {
         "php": "^8.0.2",
-        "ext-mongodb": "^1.15",
+        "ext-mongodb": "^1.3",
         "league/flysystem": "^3.10.0",
         "mongodb/mongodb": "^1.2"
     },

--- a/src/GridFS/composer.json
+++ b/src/GridFS/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "league/flysystem-mongodb-gridfs",
+    "name": "league/flysystem-gridfs",
     "autoload": {
         "psr-4": {
             "League\\Flysystem\\GridFS\\": ""
@@ -14,8 +14,12 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Jérôme Tamarelle",
-            "email": "jerome.tamarelle@mongodb.com"
+            "name": "Frank de Jonge",
+            "email": "info@frankdejonge.nl"
+        },
+        {
+            "name": "MongoDB PHP",
+            "email": "driver-php@mongodb.com"
         }
     ]
 }

--- a/src/GridFS/composer.json
+++ b/src/GridFS/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "league/flysystem-mongodb-gridfs",
+    "autoload": {
+        "psr-4": {
+            "League\\Flysystem\\GridFS\\": ""
+        }
+    },
+    "require": {
+        "php": "^8.0.2",
+        "ext-mongodb": "^1.15",
+        "league/flysystem": "^3.10.0",
+        "mongodb/mongodb": "^1.2"
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jérôme Tamarelle",
+            "email": "jerome.tamarelle@mongodb.com"
+        }
+    ]
+}


### PR DESCRIPTION
[GridFS](https://www.mongodb.com/docs/manual/core/gridfs/) is a file system that uses MongoDB as storage. I would like to propose this adapter which uses the [MongoDB PHP Library](https://github.com/mongodb/mongo-php-library/).

Docs PR: https://github.com/thephpleague/flysystem/pull/1795

The [legacy GridFS Flysystem adapter](https://github.com/thephpleague/flysystem-gridfs) had some [significant number of installations](https://packagist.org/packages/league/flysystem-gridfs/stats), even if it used the legacy Mongo extension. It shows there's some interest.

Important notes:
- Directories does not exist in GridFS. I use the same technic as for S3 when explicitly creating a directory: an empty file with a trailing `/` is created. The creation of a file with a name ending in a `/` is therefore prohibited.
- Permissions are not supported by GridFS. When explicitly set, I store the visibility in the `metadata.flysystem_visibility` attribute of the file.
- GridFS' `contentType` attribute [is deprecated](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.md#design-rationale). The attribute `metadata.contentType` is used instead.
- GridFS supports versioning by default. Writing to an existing file creates a new revision. Deleting removes all the revisions. Moving renames all the revisions.
- For GitHub Action, the [mongodb extension](https://pecl.php.net/package/mongodb) is installed and a mongodb server is started using  Docker Compose.
- I added some tests in the shared `FilesystemAdapterTestCase` in order to improve coverage on `mimeType` and `visibility`.