### PR TITLE
Don't hide ftp_connect error behind ftp_close error

### DIFF
--- a/src/Ftp/FtpConnectionProvider.php
+++ b/src/Ftp/FtpConnectionProvider.php
@@ -30,7 +30,7 @@ class FtpConnectionProvider implements ConnectionProvider
             $this->ignorePassiveAddress($options, $connection);
             $this->makeConnectionPassive($options, $connection);
         } catch (FtpConnectionException $exception) {
-            ftp_close($connection);
+            @ftp_close($connection);
             throw $exception;
         }
 


### PR DESCRIPTION
If connection to an FTP-server fails, it should throw an execption with the original reason from `error_get_last()`.

But before we throw the exception, we try to close the (potentially not established) connection [here](https://github.com/thephpleague/flysystem/blob/60ce12e4cb19fd324038149aa02ca83c1278eba8/src/Ftp/FtpConnectionProvider.php#L33). If this fails itself, it will override the message from ftp_connect(), therefore hiding the real reason for the connection issue.

This fix will suppress the error, leading that the original reason is shown.

---

We noticed this, because we expected this error due to invalid credentials
```
Reason: Unable to login/authenticate with FTP
```

But instead we got
```
Reason: ftp_close(): SSL_read on shutdown: error:0A000126:SSL routines::unexpected eof while reading
```