### PR TITLE
feat: add dedicated test cases to ensure copy and move methods to always overwrite target

### DIFF
--- a/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
+++ b/src/AdapterTestUtilities/FilesystemAdapterTestCase.php
@@ -824,6 +824,58 @@ abstract class FilesystemAdapterTestCase extends TestCase
         });
     }
 
+    /**
+     * @test
+     */
+    public function moving_a_file_with_collision(): void
+    {
+        $this->runScenario(function () {
+            $adapter = $this->adapter();
+            $adapter->write('path.txt', 'new contents', new Config());
+            $adapter->write('new-path.txt', 'contents', new Config());
+
+            $adapter->move('path.txt', 'new-path.txt', new Config());
+
+            $oldFileExists = $adapter->fileExists('path.txt');
+            $this->assertFalse($oldFileExists);
+
+            $contents = $adapter->read('new-path.txt');
+            $this->assertEquals('new contents', $contents);
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function copying_a_file_with_same_destination(): void
+    {
+        $this->runScenario(function () {
+            $adapter = $this->adapter();
+            $adapter->write('path.txt', 'new contents', new Config());
+
+            $adapter->copy('path.txt', 'path.txt', new Config());
+            $contents = $adapter->read('path.txt');
+
+            $this->assertEquals('new contents', $contents);
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function moving_a_file_with_same_destination(): void
+    {
+        $this->runScenario(function () {
+            $adapter = $this->adapter();
+            $adapter->write('path.txt', 'new contents', new Config());
+
+            $adapter->move('path.txt', 'path.txt', new Config());
+
+            $contents = $adapter->read('path.txt');
+            $this->assertEquals('new contents', $contents);
+        });
+    }
+
     protected function assertFileExistsAtPath(string $path): void
     {
         $this->runScenario(function () use ($path) {

--- a/src/FilesystemTest.php
+++ b/src/FilesystemTest.php
@@ -504,9 +504,10 @@ class FilesystemTest extends TestCase
      */
     public function copying_from_and_to_the_same_location_fails(): void
     {
-        $this->expectExceptionObject(UnableToCopyFile::fromLocationTo('from.txt', 'from.txt'));
+        $this->expectExceptionObject(UnableToCopyFile::sourceAndDestinationAreTheSame('from.txt', 'from.txt'));
 
-        $this->filesystem->copy('from.txt', 'from.txt');
+        $config = [Config::OPTION_COPY_IDENTICAL_PATH => ResolveIdenticalPathConflict::FAIL];
+        $this->filesystem->copy('from.txt', 'from.txt', $config);
     }
 
     /**
@@ -516,7 +517,8 @@ class FilesystemTest extends TestCase
     {
         $this->expectExceptionObject(UnableToMoveFile::fromLocationTo('from.txt', 'from.txt'));
 
-        $this->filesystem->move('from.txt', 'from.txt');
+        $config = [Config::OPTION_MOVE_IDENTICAL_PATH => ResolveIdenticalPathConflict::FAIL];
+        $this->filesystem->move('from.txt', 'from.txt', $config);
     }
 
     /**

--- a/src/GridFS/GridFSAdapter.php
+++ b/src/GridFS/GridFSAdapter.php
@@ -345,6 +345,10 @@ class GridFSAdapter implements FilesystemAdapter
 
     public function move(string $source, string $destination, Config $config): void
     {
+        if ($source === $destination) {
+            return;
+        }
+
         try {
             $result = $this->bucket->getFilesCollection()->updateMany(
                 ['filename' => $this->prefixer->prefixPath($source)],

--- a/src/GridFS/GridFSAdapter.php
+++ b/src/GridFS/GridFSAdapter.php
@@ -349,6 +349,10 @@ class GridFSAdapter implements FilesystemAdapter
             return;
         }
 
+        if ($this->fileExists($destination)) {
+            $this->delete($destination);
+        }
+
         try {
             $result = $this->bucket->getFilesCollection()->updateMany(
                 ['filename' => $this->prefixer->prefixPath($source)],

--- a/src/GridFS/GridFSAdapterTest.php
+++ b/src/GridFS/GridFSAdapterTest.php
@@ -15,7 +15,6 @@ use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToWriteFile;
 use MongoDB\Client;
 use MongoDB\Database;
-use MongoDB\Driver\ReadPreference;
 use function getenv;
 
 /**

--- a/src/InMemory/InMemoryFilesystemAdapter.php
+++ b/src/InMemory/InMemoryFilesystemAdapter.php
@@ -223,12 +223,14 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
         $sourcePath = $this->preparePath($source);
         $destinationPath = $this->preparePath($destination);
 
-        if ( ! $this->fileExists($source) || $this->fileExists($destination)) {
+        if ( ! $this->fileExists($source)) {
             throw UnableToMoveFile::fromLocationTo($source, $destination);
         }
 
-        $this->files[$destinationPath] = $this->files[$sourcePath];
-        unset($this->files[$sourcePath]);
+        if ($sourcePath !== $destinationPath) {
+            $this->files[$destinationPath] = $this->files[$sourcePath];
+            unset($this->files[$sourcePath]);
+        }
 
         if ($visibility = $config->get(Config::OPTION_VISIBILITY)) {
             $this->setVisibility($destination, $visibility);

--- a/src/InMemory/InMemoryFilesystemAdapterTest.php
+++ b/src/InMemory/InMemoryFilesystemAdapterTest.php
@@ -193,18 +193,6 @@ class InMemoryFilesystemAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
-    public function moving_a_file_with_collision(): void
-    {
-        $this->expectException(UnableToMoveFile::class);
-        $adapter = $this->adapter();
-        $adapter->write('path.txt', 'contents', new Config());
-        $adapter->write('new-path.txt', 'contents', new Config());
-        $adapter->move('path.txt', 'new-path.txt', new Config());
-    }
-
-    /**
-     * @test
-     */
     public function trying_to_move_a_non_existing_file(): void
     {
         $this->expectException(UnableToMoveFile::class);

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -271,7 +271,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
             $this->resolveDirectoryVisibility($config->get(Config::OPTION_DIRECTORY_VISIBILITY))
         );
 
-        if ( ! @copy($sourcePath, $destinationPath)) {
+        if ($sourcePath !== $destinationPath && ! @copy($sourcePath, $destinationPath)) {
             throw UnableToCopyFile::because(error_get_last()['message'] ?? 'unknown', $source, $destination);
         }
 

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -323,6 +323,14 @@ class SftpAdapter implements FilesystemAdapter
             throw UnableToMoveFile::fromLocationTo($source, $destination, $exception);
         }
 
+        if ($sourceLocation === $destinationLocation) {
+            return;
+        }
+
+        if ($this->fileExists($destination)) {
+            $this->delete($destination);
+        }
+
         if ( ! $connection->rename($sourceLocation, $destinationLocation)) {
             throw UnableToMoveFile::fromLocationTo($source, $destination);
         }

--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -332,6 +332,10 @@ class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
 
     public function move(string $source, string $destination, Config $config): void
     {
+        if ($source === $destination) {
+            return;
+        }
+
         if ($this->manualMove) {
             $this->manualMove($source, $destination);
 
@@ -369,6 +373,10 @@ class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
 
     public function copy(string $source, string $destination, Config $config): void
     {
+        if ($source === $destination) {
+            return;
+        }
+
         if ($this->manualCopy) {
             $this->manualCopy($source, $destination);
 

--- a/src/ZipArchive/ZipArchiveAdapter.php
+++ b/src/ZipArchive/ZipArchiveAdapter.php
@@ -340,6 +340,13 @@ final class ZipArchiveAdapter implements FilesystemAdapter
         $archive = $this->zipArchiveProvider->createZipArchive();
 
         if ($archive->locateName($this->pathPrefixer->prefixPath($destination)) !== false) {
+            if ($source === $destination) {
+                //update the config of the file
+                $this->copy($source, $destination, $config);
+
+                return;
+            }
+
             $this->delete($destination);
             $this->copy($source, $destination, $config);
             $this->delete($source);


### PR DESCRIPTION
see https://github.com/thephpleague/flysystem/issues/1764

from docs: https://flysystem.thephpleague.com/docs/usage/filesystem-api/
> Moving and copying are both deterministic operations. This means they will always overwrite the target location, and parent directories are always created (if and when needed)

We might want to add more tests to ensure the config (e.g. visibility) is updated? I don't like to add these into this tests, but into seperate once like `copying_a_file_with_same_destination_with_updated_visibility` so, any adapter can overwrite/skip this test, while it does not support visibility.

Apart from this, this PR introduces tests for more reliable adapters.

What do you think?