### PR TITLE
Add Stringable on storage attributes

### DIFF
--- a/src/DirectoryAttributes.php
+++ b/src/DirectoryAttributes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace League\Flysystem;
 
-class DirectoryAttributes implements StorageAttributes
+class DirectoryAttributes implements StorageAttributes, \Stringable
 {
     use ProxyArrayAccessToProperties;
     private string $type = StorageAttributes::TYPE_DIRECTORY;
@@ -83,5 +83,10 @@ class DirectoryAttributes implements StorageAttributes
             StorageAttributes::ATTRIBUTE_LAST_MODIFIED => $this->lastModified,
             StorageAttributes::ATTRIBUTE_EXTRA_METADATA => $this->extraMetadata,
         ];
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s(%s)', $this->type, $this->path);
     }
 }

--- a/src/FileAttributes.php
+++ b/src/FileAttributes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace League\Flysystem;
 
-class FileAttributes implements StorageAttributes
+class FileAttributes implements StorageAttributes, \Stringable
 {
     use ProxyArrayAccessToProperties;
     private string $type = StorageAttributes::TYPE_FILE;
@@ -96,5 +96,10 @@ class FileAttributes implements StorageAttributes
             StorageAttributes::ATTRIBUTE_MIME_TYPE => $this->mimeType,
             StorageAttributes::ATTRIBUTE_EXTRA_METADATA => $this->extraMetadata,
         ];
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s(%s)', $this->type, $this->path);
     }
 }

--- a/src/StorageAttributes.php
+++ b/src/StorageAttributes.php
@@ -7,6 +7,9 @@ namespace League\Flysystem;
 use ArrayAccess;
 use JsonSerializable;
 
+/**
+ * @method string __toString() Stringable interface will be added in 4.0
+ */
 interface StorageAttributes extends JsonSerializable, ArrayAccess
 {
     public const ATTRIBUTE_PATH = 'path';


### PR DESCRIPTION
I didn't want to add the extends to the StorageAttributes interface to avoid breaking changes, but it can be done in the future if you want this feature