### PR TITLE
Update SftpConnectionProvider.php

### DIFF
--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -35,7 +35,7 @@ class SftpConnectionProvider implements ConnectionProvider
         private ?string $password = null,
         private ?string $privateKey = null,
         private ?string $passphrase = null,
-        private int $port = 22,
+        private $port = 22,
         private bool $useAgent = false,
         private int $timeout = 10,
         private int $maxTries = 4,


### PR DESCRIPTION
this fix solves 

Argument #6 ($port) must be of type int, string given, called in /var/www/html/dev-helios/vendor/league/flysystem-sftp-v3/SftpConnectionProvider.php on line 158