### PR TITLE
[WebDAV] createDirectory - not throw if got 405

### DIFF
--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -233,6 +233,10 @@ class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
                 throw UnableToCreateDirectory::dueToFailure($path, $exception);
             }
 
+            if ($response['statusCode'] === 405) {
+                continue;
+            }
+
             if ($response['statusCode'] !== 201) {
                 throw UnableToCreateDirectory::atLocation($path, 'Failed to create directory at: ' . $location);
             }

--- a/src/WebDAV/WebDAVAdapterTestCase.php
+++ b/src/WebDAV/WebDAVAdapterTestCase.php
@@ -9,6 +9,7 @@ use League\Flysystem\Config;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\Visibility;
+use Sabre\DAV\Client;
 
 abstract class WebDAVAdapterTestCase extends FilesystemAdapterTestCase
 {
@@ -48,7 +49,7 @@ abstract class WebDAVAdapterTestCase extends FilesystemAdapterTestCase
     {
         $this->runScenario(function () {
             $adapter = $this->adapter();
-            $adapter->createDirectory('/some/directory/', new Config);
+            $adapter->createDirectory('/some/directory/', new Config());
 
             self::assertTrue($adapter->directoryExists('/some/directory/'));
         });
@@ -130,6 +131,30 @@ abstract class WebDAVAdapterTestCase extends FilesystemAdapterTestCase
 
         $this->runScenario(function () {
             $this->adapter()->move('source.txt', 'destination.txt', new Config());
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function part_of_prefix_already_exists(): void
+    {
+        $this->runScenario(function () {
+            $config = new Config();
+
+            $adapter1 = new WebDAVAdapter(
+                new Client(['baseUri' => 'http://localhost:4040/']),
+                'directory1/prefix1',
+            );
+            $adapter1->createDirectory('folder1', $config);
+            self::assertTrue($adapter1->directoryExists('/folder1'));
+
+            $adapter2 = new WebDAVAdapter(
+                new Client(['baseUri' => 'http://localhost:4040/']),
+                'directory1/prefix2',
+            );
+            $adapter2->createDirectory('folder2', $config);
+            self::assertTrue($adapter2->directoryExists('/folder2'));
         });
     }
 }


### PR DESCRIPTION
If a part of prefix path already exists then WebDAV server returns status 405 (The resource you tried to create already exists).

https://github.com/sabre-io/dav/blob/a6ff5932012d5064b4c04b4543be7c3d119a5199/lib/DAV/Server.php#L1184