### PR TITLE
[GridFS] Allow installation with mongodb lib v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-zip": "*",
         "ext-fileinfo": "*",
         "ext-ftp": "*",
-        "ext-mongodb": "^1.3",
+        "ext-mongodb": "^1.3|^2",
         "microsoft/azure-storage-blob": "^1.1",
         "phpunit/phpunit": "^9.5.11|^10.0",
         "phpstan/phpstan": "^1.10",
@@ -36,7 +36,7 @@
         "google/cloud-storage": "^1.23",
         "async-aws/s3": "^1.5 || ^2.0",
         "async-aws/simple-s3": "^1.1 || ^2.0",
-        "mongodb/mongodb": "^1.2",
+        "mongodb/mongodb": "^1.2|^2",
         "sabre/dav": "^4.6.0",
         "guzzlehttp/psr7": "^2.6"
     },

--- a/src/GridFS/composer.json
+++ b/src/GridFS/composer.json
@@ -7,9 +7,9 @@
     },
     "require": {
         "php": "^8.0.2",
-        "ext-mongodb": "^1.3",
+        "ext-mongodb": "^1.3|^2",
         "league/flysystem": "^3.10.0",
-        "mongodb/mongodb": "^1.2"
+        "mongodb/mongodb": "^1.2|^2"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
The extension mongodb and the library mongodb/mongodb will soon have a version 2.0 that brings breaking changes (see [extension changes](https://jira.mongodb.org/issues/?jql=project%20%3D%20PHPC%20AND%20fixVersion%20%3D%202.0.0) and [library changes](https://jira.mongodb.org/issues/?jql=project%20%3D%20PHPLIB%20AND%20fixVersion%20%3D%202.0.0)).

There is no change required for this GridFS adapter.