### PR TITLE
Update FtpAdapter.php, remove goto statement

### DIFF
--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -84,18 +84,20 @@ class FtpAdapter implements FilesystemAdapter
      */
     private function connection()
     {
-        start:
-        if ( ! $this->hasFtpConnection()) {
-            $this->connection = $this->connectionProvider->createConnection($this->connectionOptions);
-            $this->rootDirectory = $this->resolveConnectionRoot($this->connection);
-            $this->prefixer = new PathPrefixer($this->rootDirectory);
+        while (true) {
+            if ( ! $this->hasFtpConnection()) {
+                $this->connection = $this->connectionProvider->createConnection($this->connectionOptions);
+                $this->rootDirectory = $this->resolveConnectionRoot($this->connection);
+                $this->prefixer = new PathPrefixer($this->rootDirectory);
 
-            return $this->connection;
-        }
+                return $this->connection;
+            }
 
-        if ($this->connectivityChecker->isConnected($this->connection) === false) {
-            $this->connection = false;
-            goto start;
+            if ($this->connectivityChecker->isConnected($this->connection) === false) {
+                $this->connection = false;
+                continue;
+            }
+            break;
         }
 
         ftp_chdir($this->connection, $this->rootDirectory);


### PR DESCRIPTION
The goto statement can make the code's flow difficult to follow. PHP code is typically expected to have a more linear and understandable structure. For example, when using goto, it can jump from one part of the code to another in a non - sequential manner. This can lead to confusion for developers who are trying to understand the program's logic, especially in larger codebases.