### PR TITLE
Fix WebDAVAdapter createDirectory (fix #1689)

### DIFF
--- a/src/WebDAV/WebDAVAdapter.php
+++ b/src/WebDAV/WebDAVAdapter.php
@@ -216,14 +216,14 @@ class WebDAVAdapter implements FilesystemAdapter, PublicUrlGenerator
 
         foreach ($parts as $directory) {
             if ($directory === '.' || $directory === '') {
-                return;
+                continue;
             }
 
             $directoryParts[] = $directory;
             $directoryPath = implode('/', $directoryParts);
-            $location = $this->encodePath($directoryPath) . '/';
+            $location = '/' . $this->encodePath($directoryPath) . '/';
 
-            if ($this->directoryExists($this->prefixer->stripDirectoryPrefix($directoryPath))) {
+            if ($this->directoryExists($this->prefixer->stripDirectoryPrefix($location))) {
                 continue;
             }
 


### PR DESCRIPTION
This fixes several issue with directory creation:

1. #1689 stopping on first `""` (which is always the case when splitting the path beginning with a `\`)
2. When checking if the directory exists, the path prefixed with the DAV prefix does not contain the first `\`, resulting in the unprefixed path having its first char removed. Ex: "remote.php/webdav/user/directory" becomes "irectory".