### PR TITLE
Abandon the azure blob storage adapter

### DIFF
--- a/src/AzureBlobStorage/composer.json
+++ b/src/AzureBlobStorage/composer.json
@@ -16,5 +16,6 @@
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "abandoned": "azure-oss/storage-blob-flysystem"
 }


### PR DESCRIPTION
We created an open source alternative to the official (deprecated) azure packages.

This would close the following issues
* https://github.com/thephpleague/flysystem/issues/1680
* https://github.com/thephpleague/flysystem/issues/1802
* https://github.com/thephpleague/flysystem/issues/1805
* https://github.com/thephpleague/flysystem/issues/1829