### PR TITLE
Fix minor typo on Path Prefixing Adapter Decorator page

### DIFF
--- a/docs/adapter/path-prefixed.md
+++ b/docs/adapter/path-prefixed.md
@@ -20,7 +20,7 @@ composer require league/flysystem-path-prefixing:^3.3
 $adapter = new League\Flysystem\InMemory\InMemoryFilesystemAdapter();
 
 // Turn it into a path-prefixed adapter
-$adapter = new League\Flysystem\PathPrefixng\PathPrefixedAdapter($adapter, 'a/path/prefix');
+$adapter = new League\Flysystem\PathPrefixing\PathPrefixedAdapter($adapter, 'a/path/prefix');
 
 // Instantiate the filesystem
 $filesystem = new League\Flysystem\Filesystem($adapter);


### PR DESCRIPTION
One of the Usage examples is missing an "i" in the "PathPrefixing" namespace segment.