### PR TITLE
AsyncAws S3: URL-encode the CopySource argument 

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -357,7 +357,7 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
             'ACL' => $this->visibility->visibilityToAcl($visibility ?: 'private'),
             'Bucket' => $this->bucket,
             'Key' => $this->prefixer->prefixPath($destination),
-            'CopySource' => $this->bucket . '/' . $this->prefixer->prefixPath($source),
+            'CopySource' => rawurlencode($this->bucket . '/' . $this->prefixer->prefixPath($source)),
         ];
 
         try {

--- a/src/AsyncAwsS3/AsyncAwsS3AdapterTest.php
+++ b/src/AsyncAwsS3/AsyncAwsS3AdapterTest.php
@@ -389,6 +389,27 @@ class AsyncAwsS3AdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function copying_a_file_with_non_ascii_characters(): void
+    {
+        $this->runScenario(function () {
+            $adapter = $this->adapter();
+            $adapter->write(
+                'ıÇöü🤔.txt',
+                'contents to be copied',
+                new Config()
+            );
+
+            $adapter->copy('ıÇöü🤔.txt', 'ıÇöü🤔_copy.txt', new Config());
+
+            $this->assertTrue($adapter->fileExists('ıÇöü🤔.txt'));
+            $this->assertTrue($adapter->fileExists('ıÇöü🤔_copy.txt'));
+            $this->assertEquals('contents to be copied', $adapter->read('ıÇöü🤔_copy.txt'));
+        });
+    }
+
+    /**
+     * @test
+     */
     public function top_level_directory_excluded_from_listing(): void
     {
         $this->runScenario(function () {


### PR DESCRIPTION
We ran into an issue moving objects that have non-ASCII characters in their name. AWS S3 expects the  `CopySource` argument to be URL-encoded. For example:

```php
$client = new AsyncAws\S3\S3Client([
    'accessKeyId' => '...',
    'accessKeySecret' => '...',
    'region' => 'eu-west-1',
]);

$adapter = new League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter($client, 'urlencode-test');
$filesystem = new League\Flysystem\Filesystem($adapter);

$copyFrom = 'buıld_Çöü.json';
$filesystem->write($copyFrom, '{"foo": "bar"}');
$filesystem->copy($copyFrom, 'buıld_Çöü-copy.json');
```

will result in this error:

```
PHP Fatal error:  Uncaught AsyncAws\Core\Exception\Http\ClientException: HTTP 404 returned for "https://urlencode-test.s3.eu-west-3.amazonaws.com/bu%C4%B1ld_%C3%87%C3%B6%C3%BC-copy.json".

Code:    NoSuchKey
Message: The specified key does not exist.
``` 

URL-encoding the `CopySource` argument makes it work fine. 

According to the [CopyObject docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_RequestParameters) the `x-amz-copy-source` header, which is set to the value of the `CopySource` argument in the S3 client, must be URL-encoded. 

Note: [this older PR](https://github.com/thephpleague/flysystem/pull/1302/commits) previously removed the `rawurlencode()` method, so maybe URL-encoding should be made configurable instead? 

