### PR TITLE
Add option to disconnect on destruct

### DIFF
--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -41,6 +41,7 @@ class SftpAdapter implements FilesystemAdapter
         ?VisibilityConverter $visibilityConverter = null,
         ?MimeTypeDetector $mimeTypeDetector = null,
         private bool $detectMimeTypeUsingPath = false,
+        private bool $disconnectOnDestruct = false,
     ) {
         $this->prefixer = new PathPrefixer($root);
         $this->visibilityConverter = $visibilityConverter ?? new PortableVisibilityConverter();
@@ -358,6 +359,13 @@ class SftpAdapter implements FilesystemAdapter
                 @fclose($readStream);
             }
             throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);
+        }
+    }
+
+    public function __destruct()
+    {
+        if ($this->disconnectOnDestruct) {
+            $this->connectionProvider->disconnect();
         }
     }
 }


### PR DESCRIPTION
When using flysystem in worker (never stopped) the connection stay active. Add an option to disconnect on object destruction.