### PR TITLE
AsyncAws S3: Replace special characters by XML entity codes

### DIFF
--- a/src/AsyncAwsS3/AsyncAwsS3Adapter.php
+++ b/src/AsyncAwsS3/AsyncAwsS3Adapter.php
@@ -188,7 +188,7 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
             foreach ($result->getContents() as $item) {
                 $key = $item->getKey();
                 if (null !== $key) {
-                    $objects[] = new ObjectIdentifier(['Key' => $key]);
+                    $objects[] = $this->createObjectIdentifierForXmlRequest($key);
                 }
             }
 
@@ -525,6 +525,17 @@ class AsyncAwsS3Adapter implements FilesystemAdapter, PublicUrlGenerator, Checks
         } catch (Throwable $exception) {
             throw UnableToReadFile::fromLocation($path, $exception->getMessage(), $exception);
         }
+    }
+
+    private function createObjectIdentifierForXmlRequest(string $key): ObjectIdentifier
+    {
+        $escapedKey = htmlentities($key, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+
+        if ($escapedKey === '') {
+            throw new \RuntimeException(sprintf('Cannot escape key "%s" for XML request, htmlentities() returned an empty string.', $key));
+        }
+
+        return new ObjectIdentifier(['Key' => $escapedKey]);
     }
 
     public function publicUrl(string $path, Config $config): string

--- a/src/AsyncAwsS3/AsyncAwsS3AdapterTest.php
+++ b/src/AsyncAwsS3/AsyncAwsS3AdapterTest.php
@@ -9,8 +9,10 @@ use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\S3\Result\HeadObjectOutput;
+use AsyncAws\S3\Result\ListObjectsV2Output;
 use AsyncAws\S3\Result\PutObjectOutput;
 use AsyncAws\S3\S3Client;
+use AsyncAws\S3\ValueObject\AwsObject;
 use AsyncAws\SimpleS3\SimpleS3Client;
 use Exception;
 use League\Flysystem\AdapterTestUtilities\FilesystemAdapterTestCase;
@@ -21,6 +23,7 @@ use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCheckFileExistence;
+use League\Flysystem\UnableToDeleteDirectory;
 use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToListContents;
 use League\Flysystem\UnableToMoveFile;
@@ -226,6 +229,37 @@ class AsyncAwsS3AdapterTest extends FilesystemAdapterTestCase
             $this->assertFalse($adapter->fileExists($object));
             $this->assertFalse($adapter->directoryExists($directory));
         });
+    }
+
+    /**
+     * @test
+     */
+    public function delete_directory_throws_exception_if_object_key_can_not_be_escaped_correctly(): void
+    {
+        $listObjectsMock = $this->getMockBuilder(ListObjectsV2Output::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getContents'])
+            ->getMock();
+
+        $listObjectsMock->expects(self::once())
+            ->method('getContents')
+            ->willReturn([new AwsObject(['Key' => "\x8F.txt"])]);
+
+        $s3Client = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['ListObjectsV2'])
+            ->getMock();
+
+        $s3Client->expects(self::once())
+            ->method('ListObjectsV2')
+            ->willReturn($listObjectsMock);
+
+        $filesystem = new AsyncAwsS3Adapter($s3Client, 'my-bucket');
+
+        $this->expectException(UnableToDeleteDirectory::class);
+        $this->expectExceptionMessageMatches('/htmlentities\(\) returned an empty string/');
+
+        $filesystem->deleteDirectory('directory/containing/objects/with/un-escapable/key');
     }
 
     /**

--- a/src/AsyncAwsS3/AsyncAwsS3AdapterTest.php
+++ b/src/AsyncAwsS3/AsyncAwsS3AdapterTest.php
@@ -208,6 +208,29 @@ class AsyncAwsS3AdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function delete_directory_replaces_special_characters_by_xml_entity_codes(): void
+    {
+        $this->runScenario(function () {
+            $directory = 'to-delete';
+            $object = sprintf('/%s/\'\"&<>.txt', $directory);
+
+            $adapter = $this->adapter();
+            $adapter->write(
+                $object,
+                '',
+                new Config()
+            );
+
+            $adapter->deleteDirectory($directory);
+
+            $this->assertFalse($adapter->fileExists($object));
+            $this->assertFalse($adapter->directoryExists($directory));
+        });
+    }
+
+    /**
+     * @test
+     */
     public function fetching_unknown_mime_type_of_a_file(): void
     {
         $this->adapter();


### PR DESCRIPTION
When calling `deleteDirectory()`, we want to make sure that special characters (`'`, `"`, `&`, `<` and `>`) are replaced by their XML entity code. If not, the following code will result in the error below:

```php
$client = new AsyncAws\S3\S3Client([
    'accessKeyId' => '...',
    'accessKeySecret' => '...',
    'region' => 'eu-west-1',
]);

$adapter = new League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter($client, 'urlencode-test');
$filesystem = new League\Flysystem\Filesystem($adapter);

$filesystem->write('dir-to-delete/\'"&<>.json', '{"foo": "bar"}');
$filesystem->deleteDirectory('dir-to-delete');
```

This will result in:

```
Warning: DOMDocument::createElement(): unterminated entity reference         <>.json in flysystem/vendor/async-aws/s3/src/ValueObject/ObjectIdentifier.php on line 124

Fatal error: Uncaught AsyncAws\Core\Exception\Http\ClientException: HTTP 400 returned for "https://urlencode-test.s3.eu-west-3.amazonaws.com/?delete=".

Code:    UserKeyMustBeSpecified
Message: User key must be specified.
```

Also see AWS docs here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints