### PR TITLE
Fix: Make fetching metaData and the download and response functions work with SSE-C in AwsS3V3

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -286,8 +286,8 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
 
     private function fetchFileMetadata(string $path, string $type): FileAttributes
     {
-        $arguments = ['Bucket' => $this->bucket, 'Key' => $this->prefixer->prefixPath($path)];
-        $command = $this->client->getCommand('HeadObject', $arguments);
+        $options = ['Bucket' => $this->bucket, 'Key' => $this->prefixer->prefixPath($path)];
+        $command = $this->client->getCommand('HeadObject', $options + $this->options);
 
         try {
             $result = $this->client->execute($command);


### PR DESCRIPTION
The S3 Command "HeadObject" that is used to fetch a files MetaData(mimeType, size, ...) does not work right now when SSE-C is used. This is because when SSE-C is enabled "HeadObject" requires the SSEC headers(SSECustomerAlgorithm, SSECustomerKey) to be present. Since fetchFileMedata is also used in the download and response functions, it is not possible right now to download a file when SSE-C is enabled. This pull request fixes this in that it adds the options also to the "HeadObject" command as it is already done in the readObject function (aka "GetObject" command).