### PR TITLE
add error_clear_last() to rename and copy

### DIFF
--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -252,6 +252,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
             $this->resolveDirectoryVisibility($config->get(Config::OPTION_DIRECTORY_VISIBILITY))
         );
 
+        error_clear_last();
         if ( ! @rename($sourcePath, $destinationPath)) {
             throw UnableToMoveFile::because(error_get_last()['message'] ?? 'unknown reason', $source, $destination);
         }
@@ -271,6 +272,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
             $this->resolveDirectoryVisibility($config->get(Config::OPTION_DIRECTORY_VISIBILITY))
         );
 
+        error_clear_last();
         if ($sourcePath !== $destinationPath && ! @copy($sourcePath, $destinationPath)) {
             throw UnableToCopyFile::because(error_get_last()['message'] ?? 'unknown', $source, $destination);
         }


### PR DESCRIPTION
All other methods which are using the error_get_last() function are already using error_clear_last().
This two methods are showing old errors when a unknown error happens:

```
Unable to move file from xxx/x/x.xml to xxx/x/x.xml.20251110082848.done, because file_get_contents(/var/www/html/.env): Failed to open stream: No such file or directory
```
