### PR TITLE
feat: Add SFTP connection reset method

### DIFF
--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -91,6 +91,13 @@ class SftpConnectionProvider implements ConnectionProvider
         }
     }
 
+    public function resetConnection(): SFTP
+    {
+        $this->disconnect();
+
+        return $this->setupConnection();
+    }
+
     private function setupConnection(): SFTP
     {
         $connection = new SFTP($this->host, $this->port, $this->timeout);

--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -95,7 +95,7 @@ class SftpConnectionProvider implements ConnectionProvider
     {
         $this->disconnect();
 
-        return $this->setupConnection();
+        return $this->connection = $this->setupConnection();
     }
 
     private function setupConnection(): SFTP

--- a/src/PhpseclibV3/SftpConnectionProviderTest.php
+++ b/src/PhpseclibV3/SftpConnectionProviderTest.php
@@ -92,6 +92,7 @@ class SftpConnectionProviderTest extends TestCase
         $resetConnection = $provider->resetConnection();
 
         $this->assertNotSame($connection, $resetConnection);
+        $this->assertSame($resetConnection, $provider->provideConnection());
     }
 
     /**

--- a/src/PhpseclibV3/SftpConnectionProviderTest.php
+++ b/src/PhpseclibV3/SftpConnectionProviderTest.php
@@ -78,6 +78,25 @@ class SftpConnectionProviderTest extends TestCase
     /**
      * @test
      */
+    public function reset_connection(): void
+    {
+        $provider = SftpConnectionProvider::fromArray(
+            [
+                'host' => 'localhost',
+                'username' => 'foo',
+                'password' => 'pass',
+                'port' => 2222,
+            ]
+        );
+        $connection = $provider->provideConnection();
+        $resetConnection = $provider->resetConnection();
+
+        $this->assertNotSame($connection, $resetConnection);
+    }
+
+    /**
+     * @test
+     */
     public function authenticating_with_a_private_key(): void
     {
         $provider = SftpConnectionProvider::fromArray([


### PR DESCRIPTION
## Adds
- A `League\Flysystem\PhpseclibV3\SftpConnectionProvider::resetConnection()` method which leverages existing public `disconnect()` and private `setupConnection()` methods.
- Test to assert that the initial connection from `provideConnection()` differs from that returned by `resetConnection()` and that subsequent calls to `provideConnection()` return the re-initiated connection.

## Reasoning
An application I work on has a Laravel/Symfony Command which is used to diagnose various connections to SFTP servers and we would prefer to keep the logs for each test action separate. Currently we need to flush and re-establish the connection for each step. This addition would allow us to configure the connection once and reset it for each test action.