### PR TITLE
Allow v3 for `async-aws/s3`

### DIFF
--- a/src/AsyncAwsS3/composer.json
+++ b/src/AsyncAwsS3/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.0.2",
         "league/flysystem": "^3.10.0",
         "league/mime-type-detection": "^1.0.0",
-        "async-aws/s3": "^1.5 || ^2.0"
+        "async-aws/s3": "^1.5 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "async-aws/simple-s3": "^2.1"


### PR DESCRIPTION
Following the new version that was just released:
* https://github.com/async-aws/s3/releases/tag/3.0.0