### PR TITLE
feat(gcs): Allow custom public URL for GoogleCloudStorageAdapter

### DIFF
--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapter.php
@@ -55,6 +55,8 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter, PublicUrlGenerator
         'etag' => 'etag',
     ];
 
+    private const DEFAULT_PUBLIC_URL = 'https://storage.googleapis.com';
+
     public function __construct(
         private Bucket $bucket,
         string $prefix = '',
@@ -62,6 +64,7 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter, PublicUrlGenerator
         private string $defaultVisibility = Visibility::PRIVATE,
         ?MimeTypeDetector $mimeTypeDetector = null,
         private bool $streamReads = false,
+        private ?string $publicUrl = null,
     ) {
         $this->prefixer = new PathPrefixer($prefix);
         $this->visibilityHandler = $visibilityHandler ?? new PortableVisibilityHandler();
@@ -71,8 +74,13 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter, PublicUrlGenerator
     public function publicUrl(string $path, Config $config): string
     {
         $location = $this->prefixer->prefixPath($path);
+        $baseUrl = rtrim($this->publicUrl ?? self::DEFAULT_PUBLIC_URL, '/');
 
-        return 'https://storage.googleapis.com/' . $this->bucket->name() . '/' . ltrim($location, '/');
+        if ($this->publicUrl !== null) {
+            return $baseUrl . '/' . ltrim($location, '/');
+        }
+
+        return $baseUrl . '/' . $this->bucket->name() . '/' . ltrim($location, '/');
     }
 
     public function fileExists(string $path): bool

--- a/src/GoogleCloudStorage/GoogleCloudStorageAdapterTest.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageAdapterTest.php
@@ -178,4 +178,52 @@ class GoogleCloudStorageAdapterTest extends FilesystemAdapterTestCase
 
         $adapter->visibility('filename.txt');
     }
+
+    /**
+     * @test
+     */
+    public function generating_a_public_url_with_default_base(): void
+    {
+        $adapter = $this->adapter();
+
+        $url = $adapter->publicUrl('some/path.txt', new Config());
+
+        $this->assertStringStartsWith('https://storage.googleapis.com/', $url);
+        $this->assertStringContainsString('some/path.txt', $url);
+    }
+
+    /**
+     * @test
+     */
+    public function generating_a_public_url_with_custom_base(): void
+    {
+        $adapter = new GoogleCloudStorageAdapter(
+            static::$bucket,
+            static::$adapterPrefix,
+            publicUrl: 'https://cdn.example.com',
+        );
+
+        $url = $adapter->publicUrl('some/path.txt', new Config());
+
+        $this->assertStringStartsWith('https://cdn.example.com/', $url);
+        $this->assertStringContainsString('some/path.txt', $url);
+        $this->assertStringNotContainsString(self::bucketName(), $url);
+    }
+
+    /**
+     * @test
+     */
+    public function generating_a_public_url_with_custom_base_trailing_slash(): void
+    {
+        $adapter = new GoogleCloudStorageAdapter(
+            static::$bucket,
+            static::$adapterPrefix,
+            publicUrl: 'https://cdn.example.com/',
+        );
+
+        $url = $adapter->publicUrl('some/path.txt', new Config());
+
+        $this->assertStringStartsWith('https://cdn.example.com/', $url);
+        $this->assertStringNotContainsString('//', rtrim($url, '/'));
+    }
 }


### PR DESCRIPTION
## Summary

Adds an optional `publicUrl` constructor parameter to `GoogleCloudStorageAdapter` to override the default `https://storage.googleapis.com` base URL used when generating public URLs.

## Motivation

Google Cloud Storage supports [custom domains](https://cloud.google.com/storage/docs/request-endpoints#cname) for buckets. Currently the public URL is hardcoded, making it impossible to use a custom domain.

Closes #1878

## Changes

- Added optional `publicUrl` parameter to the constructor
- When a custom URL is provided, the bucket name is omitted from the generated URL (the custom domain already maps to the correct bucket)
- Added tests for default and custom URL generation
- Backward compatible — default behavior is unchanged