### PR TITLE
Move league/flysystem-local to suggests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,11 @@
     },
     "require": {
         "php": "^8.0.2",
-        "league/flysystem-local":  "^3.0.0",
         "league/mime-type-detection": "^1.0.0"
     },
+    "suggests":{
+		"league/flysystem-local":  "^3.0.0"
+	},
     "require-dev": {
         "ext-zip": "*",
         "ext-fileinfo": "*",


### PR DESCRIPTION
Removing flysystem-local from the required list, because if we are using different adaptor like "league/flysystem-sftp-v3", then we don't necessarily require "local" adaptor.