### PR TITLE
Add support for multiple host fingerprints

### DIFF
--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -126,7 +126,7 @@ class SftpConnectionProvider implements ConnectionProvider
             : [$this->hostFingerprint];
 
         foreach ($expectedFingerprints as $expectedFingerprint) {
-            if (0 !== strcasecmp($expectedFingerprint, $fingerprint)) {
+            if (0 === strcasecmp($expectedFingerprint, $fingerprint)) {
                 return;
             }
         }

--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -39,7 +39,7 @@ class SftpConnectionProvider implements ConnectionProvider
         private bool $useAgent = false,
         private int $timeout = 10,
         private int $maxTries = 4,
-        private ?string $hostFingerprint = null,
+        private string|array|null $hostFingerprint = null,
         ?ConnectivityChecker $connectivityChecker = null,
         private array $preferredAlgorithms = [],
         private bool $disableStatCache = true,
@@ -121,10 +121,17 @@ class SftpConnectionProvider implements ConnectionProvider
         }
 
         $fingerprint = $this->getFingerprintFromPublicKey($publicKey);
+        $expectedFingerprints = is_array($this->hostFingerprint)
+            ? $this->hostFingerprint
+            : [$this->hostFingerprint];
 
-        if (0 !== strcasecmp($this->hostFingerprint, $fingerprint)) {
-            throw UnableToEstablishAuthenticityOfHost::becauseTheAuthenticityCantBeEstablished($this->host);
+        foreach ($expectedFingerprints as $expectedFingerprint) {
+            if (0 !== strcasecmp($expectedFingerprint, $fingerprint)) {
+                return;
+            }
         }
+
+        throw UnableToEstablishAuthenticityOfHost::becauseTheAuthenticityCantBeEstablished($this->host);
     }
 
     private function getFingerprintFromPublicKey(string $publicKey): string

--- a/src/PhpseclibV3/SftpConnectionProviderTest.php
+++ b/src/PhpseclibV3/SftpConnectionProviderTest.php
@@ -228,6 +228,31 @@ class SftpConnectionProviderTest extends TestCase
     /**
      * @test
      */
+    public function verifying_multiple_fingerprints(): void
+    {
+        $key = file_get_contents(__DIR__ . '/../../test_files/sftp/ssh_host_ed25519_key.pub');
+        $fingerPrint = $this->computeFingerPrint($key);
+
+        $provider = SftpConnectionProvider::fromArray(
+            [
+                'host' => 'localhost',
+                'username' => 'foo',
+                'password' => 'pass',
+                'port' => 2222,
+                'hostFingerprint' => ['invalid:fingerprint', $fingerPrint],
+            ]
+        );
+
+        $connection = null;
+        $this->runWithRetries(function () use ($provider, &$connection) {
+            $connection = $provider->provideConnection();
+        });
+        $this->assertInstanceOf(SFTP::class, $connection);
+    }
+
+    /**
+     * @test
+     */
     public function providing_an_invalid_fingerprint(): void
     {
         $this->expectException(UnableToEstablishAuthenticityOfHost::class);


### PR DESCRIPTION
Previously, only a single host fingerprint string was accepted for server verification.
During rollouts the servers alternate between old and new host keys, which could lead to connection failures.

This change updates the behavior such that either a single string or an array of strings is accepted, allowing multiple valid fingerprints to be configured. The connection is accepted if any match is found.

This maintains full backwards compatibility with existing single fingerprint configurations.

on-behalf-of: @e-solutions-GmbH <info@esolutions.de>