### PR TITLE
Allow v2 of `google/cloud-storage`

### DIFF
--- a/src/GoogleCloudStorage/composer.json
+++ b/src/GoogleCloudStorage/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": "^8.0.2",
-        "google/cloud-storage": "^1.23",
+        "google/cloud-storage": "^1.23 || ^2.0",
         "league/flysystem": "^3.10.0",
         "league/mime-type-detection": "^1.0.0"
     },


### PR DESCRIPTION
Release notes:

https://github.com/googleapis/google-cloud-php-storage/releases/tag/v2.0.0
