### PR TITLE
Fix FtpAdapter listing parser swallowing entries whose name ends in ":"

### DIFF
--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -371,7 +371,7 @@ class FtpAdapter implements FilesystemAdapter
                 continue;
             }
 
-            if (preg_match('#^.*:$#', $item)) {
+            if (preg_match('#^\S+:$#', $item)) {
                 $base = preg_replace('~^\./*|:$~', '', $item);
                 continue;
             }

--- a/src/Ftp/FtpAdapterTestCase.php
+++ b/src/Ftp/FtpAdapterTestCase.php
@@ -312,6 +312,30 @@ abstract class FtpAdapterTestCase extends FilesystemAdapterTestCase
 
     /**
      * @test
+     *
+     * @runInSeparateProcess
+     */
+    public function listing_a_unix_directory_entry_whose_name_ends_in_a_colon(): void
+    {
+        $response = [
+            'total 8',
+            'drwxr-xr-x   2 ftp      ftp          4096 May 19 07:32 C:',
+            '-rw-r--r--   1 ftp      ftp           409 May 19 07:32 sibling.txt',
+        ];
+        mock_function('ftp_rawlist', $response);
+
+        $this->runScenario(function () {
+            $adapter = $this->adapter();
+            $contents = iterator_to_array($adapter->listContents('/', false), false);
+
+            $this->assertCount(2, $contents);
+            $paths = array_map(fn (StorageAttributes $item) => $item->path(), $contents);
+            $this->assertSame(['C:', 'sibling.txt'], $paths);
+        });
+    }
+
+    /**
+     * @test
      */
     public function failing_to_get_the_file_size_of_a_directory(): void
     {


### PR DESCRIPTION
## Bug

`FtpAdapter::normalizeListing()` treats any listing line ending in `:` as a recursive-listing section header (`./subdir:` from `ls -lR`). The regex `^.*:$` also matches a regular `ls -l` row whose filename happens to end in `:` — e.g. a directory literally named `C:`:

```
drwxr-xr-x   2 1000 1000  4096 May 19 07:32 C:
```

The line is mistaken for a header, the entry is silently dropped, and `\$base` is set to the entire raw `ls -l` text. Every subsequent item in the same listing then yields with a garbage prefix like:

```
drwxr-xr-x   2 1000 1000  4096 May 19 07:32 C/sibling.txt
```

Following one of those paths back into `listContents()` either returns an empty list or throws `InvalidListResponseReceived` from the next parse.

## Fix

Tighten the regex to `^\S+:$`. Real recursive-listing section headers never contain whitespace (`./somedir:`, `./somedir/subdir:`, `.:`); regular `ls -l` rows always do. Existing recursive-listing behaviour is unchanged; directories whose names end in `:` now round-trip correctly.

## Reproducer

```php
\$adapter = new FtpAdapter(\$options);
\$adapter->createDirectory('parent/C:', new Config());
\$contents = iterator_to_array(\$adapter->listContents('parent', false), false);
// Before: \$contents is empty.
// After:  \$contents contains a DirectoryAttributes for 'parent/C:'.
```

## Test

Added a parser test in `FtpAdapterTestCase` alongside the existing `receiving_a_unix_listing` test, using the same `mock_function('ftp_rawlist', ...)` pattern.