### PR TITLE
Fix mimeType() returning null causing TypeError and add regression test

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -168,8 +168,16 @@ class Filesystem implements FilesystemOperator
 
     public function mimeType(string $path): string
     {
-        return $this->adapter->mimeType($this->pathNormalizer->normalizePath($path))->mimeType();
+        $normalizedPath = $this->pathNormalizer->normalizePath($path);
+        $attributes = $this->adapter->mimeType($normalizedPath);
+
+        if ($attributes->mimeType() === null) {
+            throw UnableToRetrieveMetadata::mimeType($path);
+        }
+
+        return $attributes->mimeType();
     }
+
 
     public function setVisibility(string $path, string $visibility): void
     {

--- a/src/FilesystemTest.php
+++ b/src/FilesystemTest.php
@@ -272,6 +272,23 @@ class FilesystemTest extends TestCase
 
         $this->assertEquals('text/plain', $mimeType);
     }
+    
+    /**
+     * @test
+     */
+    public function test_mime_type_throws_when_null_is_returned(): void
+    {
+        $adapter = $this->createMock(FilesystemAdapter::class);
+
+        $adapter->method('mimeType')
+            ->willReturn(new FileAttributes('foo.txt', null, null, null, null));
+
+        $filesystem = new Filesystem($adapter);
+
+        $this->expectException(UnableToRetrieveMetadata::class);
+
+        $filesystem->mimeType('foo.txt');
+    }
 
     /**
      * @test


### PR DESCRIPTION
This PR fixes a bug in Filesystem::mimeType() where a null mime type
returned by an adapter would cause a PHP TypeError due to the method’s
declared string return type.

Other Flysystem adapters already throw UnableToRetrieveMetadata when a
mime type cannot be determined. This change brings the core Filesystem
wrapper in line with the expected behavior across adapters.

Included is a regression test that mocks an adapter returning a
FileAttributes instance with a null mime type and asserts that
UnableToRetrieveMetadata::mimeType() is thrown.

All Filesystem tests pass.

Happy to adjust anything if needed.

Closes #1855
