### PR TITLE
Adding a clearFsStatCache flag to the local filesystem adapter for NFS cache issues

### DIFF
--- a/mocked-functions.php
+++ b/mocked-functions.php
@@ -36,6 +36,60 @@ namespace League\Flysystem\Local {
 
         return return_mocked_value('filesize');
     }
+
+    function glob(...$arguments)
+    {
+        if ( ! is_mocked('glob')) {
+            return \glob(...$arguments);
+        }
+
+        return return_mocked_value('glob');
+    }
+
+    function fopen(...$arguments)
+    {
+        if ( ! is_mocked('fopen')) {
+            return \fopen(...$arguments);
+        }
+
+        return return_mocked_value('fopen');
+    }
+
+    function fclose(...$arguments)
+    {
+        if ( ! is_mocked('fclose')) {
+            return \fclose(...$arguments);
+        }
+
+        return return_mocked_value('fclose');
+    }
+
+    function opendir(...$arguments)
+    {
+        if ( ! is_mocked('opendir')) {
+            return \opendir(...$arguments);
+        }
+
+        return return_mocked_value('opendir');
+    }
+
+    function closedir(...$arguments)
+    {
+        if ( ! is_mocked('closedir')) {
+            return \closedir(...$arguments);
+        }
+
+        return return_mocked_value('closedir');
+    }
+
+    function readdir(...$arguments)
+    {
+        if ( ! is_mocked('readdir')) {
+            return \readdir(...$arguments);
+        }
+
+        return return_mocked_value('readdir');
+    }
 }
 
 namespace League\Flysystem\InMemory {

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -90,7 +90,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
         $this->prefixer = new PathPrefixer($location, DIRECTORY_SEPARATOR);
         $visibility ??= new PortableVisibilityConverter();
         $this->visibility = $visibility;
-        $this->rootLocation = $location;
+        $this->rootLocation = $this->prefixer->prefixDirectoryPath('');
         $this->mimeTypeDetector = $mimeTypeDetector ?? new FallbackMimeTypeDetector(
             detector: new FinfoMimeTypeDetector(),
             useInconclusiveMimeTypeFallback: $useInconclusiveMimeTypeFallback,

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -36,15 +36,18 @@ use SplFileInfo;
 use Throwable;
 use function chmod;
 use function clearstatcache;
+use function closedir;
 use function dirname;
 use function error_clear_last;
 use function error_get_last;
+use function fclose;
 use function file_exists;
 use function file_put_contents;
 use function hash_file;
 use function is_dir;
 use function is_file;
 use function mkdir;
+use function readdir;
 use function rename;
 
 class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
@@ -69,6 +72,11 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
      */
     private $rootLocationIsSetup = false;
 
+    /**
+     * @var bool
+     */
+    private $clearFsStatCache = false;
+
     public function __construct(
         string $location,
         ?VisibilityConverter $visibility = null,
@@ -77,6 +85,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
         ?MimeTypeDetector $mimeTypeDetector = null,
         bool $lazyRootCreation = false,
         bool $useInconclusiveMimeTypeFallback = false,
+        bool $clearFsStatCache = false,
     ) {
         $this->prefixer = new PathPrefixer($location, DIRECTORY_SEPARATOR);
         $visibility ??= new PortableVisibilityConverter();
@@ -86,6 +95,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
             detector: new FinfoMimeTypeDetector(),
             useInconclusiveMimeTypeFallback: $useInconclusiveMimeTypeFallback,
         );
+        $this->clearFsStatCache = $clearFsStatCache;
 
         if ( ! $lazyRootCreation) {
             $this->ensureRootDirectoryExists();
@@ -340,6 +350,10 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
     {
         $location = $this->prefixer->prefixPath($location);
         clearstatcache();
+        if ($this->clearFsStatCache) {
+            $this->warmDentryCache($location);
+        }
+
         return is_file($location);
     }
 
@@ -347,6 +361,10 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
     {
         $location = $this->prefixer->prefixPath($location);
         clearstatcache();
+        if ($this->clearFsStatCache) {
+            $this->warmDentryCache($location);
+        }
+
         return is_dir($location);
     }
 
@@ -385,6 +403,10 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
         $location = $this->prefixer->prefixPath($path);
         clearstatcache(false, $location);
         error_clear_last();
+        if ($this->clearFsStatCache) {
+            $this->warmAttributeCache($location);
+        }
+
         $fileperms = @fileperms($location);
 
         if ($fileperms === false) {
@@ -427,6 +449,9 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
         $location = $this->prefixer->prefixPath($path);
         clearstatcache();
         error_clear_last();
+        if ($this->clearFsStatCache) {
+            $this->warmAttributeCache($location);
+        }
         $lastModified = @filemtime($location);
 
         if ($lastModified === false) {
@@ -441,6 +466,9 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
         $location = $this->prefixer->prefixPath($path);
         clearstatcache();
         error_clear_last();
+        if ($this->clearFsStatCache) {
+            $this->warmAttributeCache($location);
+        }
 
         if (is_file($location) && ($fileSize = @filesize($location)) !== false) {
             return new FileAttributes($path, $fileSize);
@@ -483,5 +511,33 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
             $extraMessage = error_get_last()['message'] ?? '';
             throw UnableToSetVisibility::atLocation($this->prefixer->stripPrefix($location), $extraMessage);
         }
+    }
+
+    private function warmAttributeCache(string $location): void
+    {
+        $this->warmDentryCache($location);
+        $isFile = is_file($location);
+        $handle = match($isFile) {
+            true => @fopen($location, 'r'),
+            false => @opendir($location),
+        };
+        if ($handle === false) {
+            return;
+        }
+        if ($isFile) {
+            fclose($handle);
+        } else {
+            readdir($handle);
+            closedir($handle);
+        }
+    }
+
+    private function warmDentryCache(string $location): void
+    {
+        if ($location === $this->rootLocation) {
+            return;
+        }
+        // @phpstan-ignore function.resultUnused (does trigger a side effect, an NFS LOOKUP RPC)
+        glob(dirname($location));
     }
 }

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -776,6 +776,181 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
         $adapter->readStream('path.txt');
     }
 
+    /**
+     * @test
+     */
+    public function file_exists_does_not_warm_up_by_default(): void
+    {
+        mock_function('glob', 'should never be called');
+        $adapter = $this->adapter();
+        $adapter->write('path.txt', 'contents', new Config());
+        $adapter->fileExists('path.txt');
+        $this->assertSame(return_mocked_value('glob'), 'should never be called');
+    }
+
+    /**
+     * @test
+     */
+    public function file_exists_warms_up_dentry_cache(): void
+    {
+        mock_function('glob', 'should be called');
+        $adapter = $this->createFsCacheClearingFilesystemAdapter();
+        $adapter->write('path.txt', 'contents', new Config());
+        $adapter->fileExists('path.txt');
+        $this->assertSame(return_mocked_value('glob'), null);
+    }
+
+    /**
+     * @test
+     */
+    public function directory_exists_does_not_warm_up_by_default(): void
+    {
+        mock_function('glob', 'should never be called');
+        $adapter = $this->adapter();
+        $adapter->createDirectory('path', new Config());
+        $adapter->directoryExists('path');
+        $this->assertSame(return_mocked_value('glob'), 'should never be called');
+    }
+
+    /**
+     * @test
+     */
+    public function directory_exists_warms_up_dentry_cache(): void
+    {
+        mock_function('glob', 'should be called');
+        $adapter = $this->createFsCacheClearingFilesystemAdapter();
+        $adapter->createDirectory('path', new Config());
+        $adapter->directoryExists('path');
+        $this->assertSame(return_mocked_value('glob'), null);
+    }
+
+    /**
+     * @test
+     */
+    public function directory_exists_does_not_warm_up_dentry_cache_for_root(): void
+    {
+        mock_function('glob', 'should never be called');
+        $adapter = $this->createFsCacheClearingFilesystemAdapter();
+        $adapter->directoryExists(DIRECTORY_SEPARATOR);
+        $adapter->directoryExists('');
+        $this->assertSame(return_mocked_value('glob'), 'should never be called');
+    }
+
+    /**
+     * @test
+     */
+    public function retrieving_visibility_doesnt_warm_dentry_and_attribute_cache_by_default(): void
+    {
+        mock_function('glob', 'should never be called');
+        mock_function('fopen', 'should never be called');
+        $adapter = $this->adapter();
+        $adapter->write('path.txt', 'contents', new Config());
+        $adapter->visibility('path.txt');
+        $this->assertSame(return_mocked_value('glob'), 'should never be called');
+        $this->assertSame(return_mocked_value('fopen'), 'should never be called');
+
+        mock_function('glob', 'should never be called');
+        mock_function('opendir', 'should never be called');
+        $adapter->createDirectory('path', new Config());
+        $adapter->visibility('path');
+        $this->assertSame(return_mocked_value('glob'), 'should never be called');
+        $this->assertSame(return_mocked_value('opendir'), 'should never be called');
+    }
+
+    /**
+     * @test
+     */
+    public function retrieving_visibility_warms_dentry_and_attribute_cache(): void
+    {
+        $adapter = $this->createFsCacheClearingFilesystemAdapter();
+        $adapter->write('path.txt', 'contents', new Config());
+
+        mock_function('glob', 'should be called');
+        mock_function('fopen', \fopen(self::ROOT . DIRECTORY_SEPARATOR . 'path.txt', 'r'));
+        $adapter->visibility('path.txt');
+        $this->assertSame(return_mocked_value('glob'), null);
+        $this->assertSame(return_mocked_value('fopen'), null);
+
+        $adapter->createDirectory('path', new Config());
+        mock_function('glob', 'should be called');
+        mock_function('opendir', \opendir(self::ROOT . DIRECTORY_SEPARATOR . 'path'));
+        $adapter->visibility('path');
+        $this->assertSame(return_mocked_value('glob'), null);
+        $this->assertSame(return_mocked_value('opendir'), null);
+    }
+
+    /**
+     * @test
+     */
+    public function retrieving_last_modified_doesnt_warm_dentry_and_attribute_cache_by_default(): void
+    {
+        mock_function('glob', 'should never be called');
+        mock_function('fopen', 'should never be called');
+        $adapter = $this->adapter();
+        $adapter->write('path.txt', 'contents', new Config());
+        $adapter->lastModified('path.txt');
+        $this->assertSame(return_mocked_value('glob'), 'should never be called');
+        $this->assertSame(return_mocked_value('fopen'), 'should never be called');
+
+        mock_function('glob', 'should never be called');
+        mock_function('opendir', 'should never be called');
+        $adapter->createDirectory('path', new Config());
+        $adapter->lastModified('path');
+        $this->assertSame(return_mocked_value('glob'), 'should never be called');
+        $this->assertSame(return_mocked_value('opendir'), 'should never be called');
+    }
+
+    /**
+     * @test
+     */
+    public function retrieving_last_modified_warms_dentry_and_attribute_cache(): void
+    {
+        $adapter = $this->createFsCacheClearingFilesystemAdapter();
+        $adapter->write('path.txt', 'contents', new Config());
+
+        mock_function('glob', 'should be called');
+        mock_function('fopen', \fopen(self::ROOT . DIRECTORY_SEPARATOR . 'path.txt', 'r'));
+        $adapter->lastModified('path.txt');
+        $this->assertSame(return_mocked_value('glob'), null);
+        $this->assertSame(return_mocked_value('fopen'), null);
+
+        $adapter->createDirectory('path', new Config());
+        mock_function('glob', 'should be called');
+        mock_function('opendir', \opendir(self::ROOT . DIRECTORY_SEPARATOR . 'path'));
+        $adapter->lastModified('path');
+        $this->assertSame(return_mocked_value('glob'), null);
+        $this->assertSame(return_mocked_value('opendir'), null);
+    }
+
+    /**
+     * @test
+     */
+    public function retrieving_file_size_doesnt_warm_dentry_and_attribute_cache_by_default(): void
+    {
+        mock_function('glob', 'should never be called');
+        mock_function('fopen', 'should never be called');
+        $adapter = $this->adapter();
+        $adapter->write('path.txt', 'contents', new Config());
+        $adapter->fileSize('path.txt');
+        $this->assertSame(return_mocked_value('glob'), 'should never be called');
+        $this->assertSame(return_mocked_value('fopen'), 'should never be called');
+    }
+
+    /**
+     * @test
+     */
+    public function retrieving_file_size_warms_dentry_and_attribute_cache(): void
+    {
+        $adapter = $this->createFsCacheClearingFilesystemAdapter();
+        $adapter->write('path.txt', 'contents', new Config());
+
+        mock_function('glob', 'should be called');
+        mock_function('fopen', \fopen(self::ROOT . DIRECTORY_SEPARATOR . 'path.txt', 'r'));
+        $adapter->fileSize('path.txt');
+        $this->assertSame(return_mocked_value('glob'), null);
+        $this->assertSame(return_mocked_value('fopen'), null);
+    }
+
     /* //////////////////////
     // These are the utils //
     ////////////////////// */
@@ -805,6 +980,11 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
     protected static function createFilesystemAdapter(): FilesystemAdapter
     {
         return new LocalFilesystemAdapter(static::ROOT);
+    }
+
+    protected static function createFsCacheClearingFilesystemAdapter(): FilesystemAdapter
+    {
+        return new LocalFilesystemAdapter(static::ROOT, clearFsStatCache: true);
     }
 
     /**


### PR DESCRIPTION
This is my first PR here, I ran into an issue and instead of just reporting it I thought I would contribute a potential solution, apologies if that's not appropriate and you would rather I went through other channels, I'm very happy to do that.

The issue I ran into was that `is_dir` as called in the `directoryExists` method of the local adapter was returning false in my AWS EFS setup for a directory that exists, and I could make it appear by calling `ls`.  After some digging I found that NFS has a cache layer that isn't cleared by `is_dir` (which uses stat under the hood) but it is possible to warm that cache with other commands.

I don't think the behaviour I am adding in appropriate for most circumstances, it is adding extra file system calls to some pretty basic requests, which only really make sense in an NFS context.  So I thought it would make sense as a constructor boolean option, and it could be activated by people using network file systems who want to cache-bust and are willing to pay the performance cost.

Like I have said, very open to feedback or to modify this.