### PR TITLE
Honor an explicit ACL override when copying in the AwsS3V3 adapter

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -441,6 +441,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
 
         $options = $this->createOptionsFromConfig($config);
         $options['MetadataDirective'] = $config->get('MetadataDirective', 'COPY');
+        $acl = $options['params']['ACL'] ?? $this->visibility->visibilityToAcl($visibility ?: 'private');
 
         try {
             $this->client->copy(
@@ -448,7 +449,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
                 $this->prefixer->prefixPath($source),
                 $this->bucket,
                 $this->prefixer->prefixPath($destination),
-                $this->visibility->visibilityToAcl($visibility ?: 'private'),
+                $acl,
                 $options,
             );
         } catch (Throwable $exception) {

--- a/src/AwsS3V3/AwsS3V3AdapterTest.php
+++ b/src/AwsS3V3/AwsS3V3AdapterTest.php
@@ -459,6 +459,26 @@ class AwsS3V3AdapterTest extends FilesystemAdapterTestCase
         });
     }
 
+    /**
+     * @test
+     */
+    public function copying_a_file_with_an_explicit_acl(): void
+    {
+        $adapter = $this->adapter();
+        $prefixer = new PathPrefixer(static::$adapterPrefix);
+        $prefixedPath = $prefixer->prefixPath('destination.txt');
+
+        $adapter->write('source.txt', 'contents', new Config());
+        $adapter->copy('source.txt', 'destination.txt', new Config(['ACL' => 'bucket-owner-full-control']));
+
+        $arguments = ['Bucket' => getenv('FLYSYSTEM_AWS_S3_BUCKET'), 'Key' => $prefixedPath];
+        $command = static::$s3Client->getCommand('GetObjectAcl', $arguments);
+        $response = static::$s3Client->execute($command)->toArray();
+        $permission = $response['Grants'][0]['Permission'];
+
+        self::assertEquals('FULL_CONTROL', $permission);
+    }
+
     protected static function createFilesystemAdapter(bool $streaming = true, array $options = []): FilesystemAdapter
     {
         static::$stubS3Client = new S3ClientStub(static::s3Client());


### PR DESCRIPTION
The AwsS3V3 adapter's `copy()` always derived the ACL from the resolved visibility and ignored an explicit `ACL` passed through the config, so there was no way to override it the way `upload()` already allows. This makes `copy()` honor an `ACL` from the options (e.g. `bucket-owner-full-control`), which is needed to copy objects on buckets with ACLs disabled or across accounts.

Fixes #1904
