### PR TITLE
fix(ftp): clear connection state when root resolution fails

### DIFF
--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -87,7 +87,15 @@ class FtpAdapter implements FilesystemAdapter
         start:
         if ( ! $this->hasFtpConnection()) {
             $this->connection = $this->connectionProvider->createConnection($this->connectionOptions);
-            $this->rootDirectory = $this->resolveConnectionRoot($this->connection);
+
+            try {
+                $this->rootDirectory = $this->resolveConnectionRoot($this->connection);
+            } catch (Throwable $e) {
+                $this->connection = false;
+                $this->rootDirectory = null;
+                throw $e;
+            }
+
             $this->prefixer = new PathPrefixer($this->rootDirectory);
 
             return $this->connection;

--- a/src/Ftp/FtpAdapterTest.php
+++ b/src/Ftp/FtpAdapterTest.php
@@ -112,6 +112,32 @@ class FtpAdapterTest extends FtpAdapterTestCase
         $adapter->delete('something');
     }
 
+    /**
+     * @test
+     */
+    public function retrying_root_resolution_after_failure(): void
+    {
+        $options = FtpConnectionOptions::fromArray([
+            'host' => 'localhost',
+            'port' => 2121,
+            'timestampsOnUnixListingsEnabled' => true,
+            'root' => '/invalid/root',
+            'username' => 'foo',
+            'password' => 'pass',
+        ]);
+
+        $adapter = new FtpAdapter($options);
+
+        try {
+            $adapter->delete('something');
+            $this->fail('The first attempt should have thrown an UnableToResolveConnectionRoot exception.');
+        } catch (UnableToResolveConnectionRoot $exception) {}
+
+        $this->expectExceptionObject(UnableToResolveConnectionRoot::itDoesNotExist('/invalid/root'));
+
+        $adapter->delete('something');
+    }
+
     protected function tearDown(): void
     {
         reset_function_mocks();


### PR DESCRIPTION
### Summary
When `resolveConnectionRoot()` throws, the connection is left in an invalid state, causing subsequent operations to crash. This PR ensures the adapter resets its state upon failure so it can cleanly re-attempt the connection lifecycle on the next request.

### Changes
- Clear the FTP connection and root directory when `resolveConnectionRoot()` throws
- Add a unit test verifying that the adapter retries root resolution after failure

Closes #1825