### PR TITLE
Add multiple fingerprint formats

### DIFF
--- a/src/PhpseclibV3/SftpConnectionProvider.php
+++ b/src/PhpseclibV3/SftpConnectionProvider.php
@@ -13,8 +13,13 @@ use phpseclib3\System\SSH\Agent;
 use Throwable;
 
 use function base64_decode;
-use function implode;
-use function str_split;
+use function bin2hex;
+use function hash;
+use function hash_equals;
+use function preg_match;
+use function rtrim;
+use function str_replace;
+use function strtolower;
 
 class SftpConnectionProvider implements ConnectionProvider
 {
@@ -120,13 +125,12 @@ class SftpConnectionProvider implements ConnectionProvider
             throw UnableToEstablishAuthenticityOfHost::becauseTheAuthenticityCantBeEstablished($this->host);
         }
 
-        $fingerprint = $this->getFingerprintFromPublicKey($publicKey);
         $expectedFingerprints = is_array($this->hostFingerprint)
             ? $this->hostFingerprint
             : [$this->hostFingerprint];
 
         foreach ($expectedFingerprints as $expectedFingerprint) {
-            if (0 === strcasecmp($expectedFingerprint, $fingerprint)) {
+            if ($this->fingerprintMatchesPublicKey($expectedFingerprint, $publicKey)) {
                 return;
             }
         }
@@ -134,12 +138,40 @@ class SftpConnectionProvider implements ConnectionProvider
         throw UnableToEstablishAuthenticityOfHost::becauseTheAuthenticityCantBeEstablished($this->host);
     }
 
-    private function getFingerprintFromPublicKey(string $publicKey): string
+    private function fingerprintMatchesPublicKey(string $expectedFingerprint, string $publicKey): bool
     {
         $content = explode(' ', $publicKey, 3);
-        $algo = $content[0] === 'ssh-rsa' ? 'md5' : 'sha512';
+        $binaryKey = base64_decode($content[1]);
 
-        return implode(':', str_split(hash($algo, base64_decode($content[1])), 2));
+        $algorithms = ['md5', 'sha1', 'sha256', 'sha512'];
+
+        if (preg_match('/^(md5|sha1|sha256|sha512):(.+)$/i', $expectedFingerprint, $matches)) {
+            $algorithms = [strtolower($matches[1])];
+            $expectedFingerprint = $matches[2];
+        }
+
+        foreach ($algorithms as $algorithm) {
+            $binaryHash = hash($algorithm, $binaryKey, true);
+
+            // Hex form: normalise by dropping the colon separators and lowercasing
+            // so both "AB:CD" and "abcd" match a lowercase hex digest.
+            $hexHash = bin2hex($binaryHash);
+            $expectedHex = strtolower(str_replace(':', '', $expectedFingerprint));
+
+            if (hash_equals($hexHash, $expectedHex)) {
+                return true;
+            }
+
+            // Base64 form (OpenSSH SHA256 style), tolerating stripped padding.
+            $base64Hash = rtrim(base64_encode($binaryHash), '=');
+            $expectedBase64 = rtrim($expectedFingerprint, '=');
+
+            if (hash_equals($base64Hash, $expectedBase64)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function authenticate(SFTP $connection): void

--- a/src/PhpseclibV3/SftpConnectionProviderTest.php
+++ b/src/PhpseclibV3/SftpConnectionProviderTest.php
@@ -9,12 +9,14 @@ use PHPUnit\Framework\TestCase;
 use Throwable;
 
 use function base64_decode;
+use function base64_encode;
 use function class_exists;
 use function explode;
 use function getenv;
 use function hash;
 use function implode;
 use function is_a;
+use function rtrim;
 use function sleep;
 use function str_split;
 
@@ -223,6 +225,52 @@ class SftpConnectionProviderTest extends TestCase
             $connection = $provider->provideConnection();
         });
         $this->assertInstanceOf(SFTP::class, $connection);
+    }
+
+    /**
+     * @test
+     * @dataProvider fingerprintFormatProvider
+     */
+    public function verifying_a_fingerprint_in_various_formats(callable $format): void
+    {
+        $key = file_get_contents(__DIR__ . '/../../test_files/sftp/ssh_host_ed25519_key.pub');
+        $rawKey = base64_decode(explode(' ', $key, 3)[1]);
+        $fingerPrint = $format($rawKey);
+
+        $provider = SftpConnectionProvider::fromArray(
+            [
+                'host' => 'localhost',
+                'username' => 'foo',
+                'password' => 'pass',
+                'port' => 2222,
+                'hostFingerprint' => $fingerPrint,
+            ]
+        );
+
+        $connection = null;
+        $this->runWithRetries(function () use ($provider, &$connection) {
+            $connection = $provider->provideConnection();
+        });
+        $this->assertInstanceOf(SFTP::class, $connection);
+    }
+
+    public static function fingerprintFormatProvider(): iterable
+    {
+        yield 'md5 hex (colon separated)' => [
+            fn (string $raw): string => implode(':', str_split(hash('md5', $raw), 2)),
+        ];
+        yield 'md5 prefixed' => [
+            fn (string $raw): string => 'MD5:' . implode(':', str_split(hash('md5', $raw), 2)),
+        ];
+        yield 'sha256 hex (no colons)' => [
+            fn (string $raw): string => hash('sha256', $raw),
+        ];
+        yield 'sha256 base64 (OpenSSH)' => [
+            fn (string $raw): string => 'SHA256:' . rtrim(base64_encode(hash('sha256', $raw, true)), '='),
+        ];
+        yield 'sha512 hex (legacy default)' => [
+            fn (string $raw): string => implode(':', str_split(hash('sha512', $raw), 2)),
+        ];
     }
 
     /**


### PR DESCRIPTION
Currently the way that the library determines the provider fingerprint type as either md5 or sha512 is a bit limited. We updated the code so the library should recognize and work with multiple fingerprint formats.