### PR TITLE
Populate the failure reason on AwsS3V3Adapter exceptions

### DIFF
--- a/src/AwsS3V3/AwsS3V3Adapter.php
+++ b/src/AwsS3V3/AwsS3V3Adapter.php
@@ -229,7 +229,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         try {
             $this->client->execute($command);
         } catch (Throwable $exception) {
-            throw UnableToDeleteFile::atLocation($path, '', $exception);
+            throw UnableToDeleteFile::atLocation($path, $exception->getMessage(), $exception);
         }
     }
 
@@ -241,7 +241,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         try {
             $this->client->deleteMatchingObjects($this->bucket, $prefix);
         } catch (Throwable $exception) {
-            throw UnableToDeleteDirectory::atLocation($path, '', $exception);
+            throw UnableToDeleteDirectory::atLocation($path, $exception->getMessage(), $exception);
         }
     }
 
@@ -264,7 +264,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         try {
             $this->client->execute($command);
         } catch (Throwable $exception) {
-            throw UnableToSetVisibility::atLocation($path, '', $exception);
+            throw UnableToSetVisibility::atLocation($path, $exception->getMessage(), $exception);
         }
     }
 
@@ -276,7 +276,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         try {
             $result = $this->client->execute($command);
         } catch (Throwable $exception) {
-            throw UnableToRetrieveMetadata::visibility($path, '', $exception);
+            throw UnableToRetrieveMetadata::visibility($path, $exception->getMessage(), $exception);
         }
 
         $visibility = $this->visibility->aclToVisibility((array) $result->get('Grants'));
@@ -292,7 +292,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         try {
             $result = $this->client->execute($command);
         } catch (Throwable $exception) {
-            throw UnableToRetrieveMetadata::create($path, $type, '', $exception);
+            throw UnableToRetrieveMetadata::create($path, $type, $exception->getMessage(), $exception);
         }
 
         $attributes = $this->mapS3ObjectMetadata($result->toArray(), $path);
@@ -470,7 +470,7 @@ class AwsS3V3Adapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumP
         try {
             return $this->client->execute($command)->get('Body');
         } catch (Throwable $exception) {
-            throw UnableToReadFile::fromLocation($path, '', $exception);
+            throw UnableToReadFile::fromLocation($path, $exception->getMessage(), $exception);
         }
     }
 

--- a/src/AwsS3V3/AwsS3V3AdapterTest.php
+++ b/src/AwsS3V3/AwsS3V3AdapterTest.php
@@ -19,6 +19,7 @@ use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCheckFileExistence;
 use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToMoveFile;
+use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\Visibility;
@@ -216,6 +217,22 @@ class AwsS3V3AdapterTest extends FilesystemAdapterTestCase
         $this->expectException(UnableToDeleteFile::class);
 
         $adapter->delete('path.txt');
+    }
+
+    /**
+     * @test
+     */
+    public function failing_to_read_a_file_exposes_the_reason(): void
+    {
+        $adapter = $this->adapter();
+        static::$stubS3Client->throwExceptionWhenExecutingCommand('GetObject');
+
+        try {
+            $adapter->read('path.txt');
+            $this->fail('Reading should have failed.');
+        } catch (UnableToReadFile $exception) {
+            $this->assertNotSame('', $exception->reason());
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

`AwsS3V3Adapter` passes an empty `$reason` when converting an `AwsException` into a Flysystem exception, putting the underlying error only in `$previous`:

```php
// src/AwsS3V3/AwsS3V3Adapter.php:473
throw UnableToReadFile::fromLocation($path, '', $exception);
```

This is inconsistent *within the same adapter* — `write()` already does the right thing:

```php
// src/AwsS3V3/AwsS3V3Adapter.php:165
throw UnableToWriteFile::atLocation($path, $exception->getMessage(), $exception);
```

and inconsistent with the other adapters, which populate the reason:

| Adapter | `reason` on read failure |
|---|---|
| `Local` | `error_get_last()['message']` |
| `GoogleCloudStorage` | `$exception->getMessage()` |
| `AzureBlobStorage` | `$exception->getMessage()` |
| `AwsS3V3` | `''` |

So on S3 the message is just `Unable to read file from location: some/path.` with no indication of whether that was a missing object, a KMS/permission problem, or a transient 5xx.

## Why it matters beyond the message text

`reason()` is not only used for display — it is the value the library itself forwards:

- `MountManager` re-throws with `$exception->reason()` ([`MountManager.php:102`](https://github.com/thephpleague/flysystem/blob/3.x/src/MountManager.php#L102), and 8 other sites), so an empty reason propagates as an empty reason.
- `UnableToProvideChecksum` is constructed from `$exception->reason()` ([`AwsS3V3Adapter.php:499`](https://github.com/thephpleague/flysystem/blob/3.x/src/AwsS3V3/AwsS3V3Adapter.php#L499)).

This is also the underlying cause of what was reported in #1846. That issue was closed with "v2 is no longer supported, upgrade to v3 which has a `reason` field" — but on the S3 read path v3 still passes `''`, so upgrading does not actually surface the SDK error that the reporter was chasing.

## Change

Pass `$exception->getMessage()` at the six sites in `AwsS3V3Adapter` that currently pass `''`, matching the existing `write()` call in the same file. No signature or behavior changes beyond the reason string being populated.

## Tests

Added `failing_to_read_a_file_exposes_the_reason()`, modelled on the existing `failing_to_delete_a_file()` and using the same `S3ClientStub::throwExceptionWhenExecutingCommand()` mechanism.

I could not run the `AwsS3V3` suite locally as it needs live AWS credentials — happy to adjust if it doesn't pass in your CI.