### PR TITLE
Do not fail deleting a local file that is already gone

### DIFF
--- a/mocked-functions.php
+++ b/mocked-functions.php
@@ -36,6 +36,15 @@ namespace League\Flysystem\Local {
 
         return return_mocked_value('filesize');
     }
+
+    function file_exists(...$arguments)
+    {
+        if ( ! is_mocked('file_exists')) {
+            return \file_exists(...$arguments);
+        }
+
+        return return_mocked_value('file_exists');
+    }
 }
 
 namespace League\Flysystem\InMemory {

--- a/src/Local/LocalFilesystemAdapter.php
+++ b/src/Local/LocalFilesystemAdapter.php
@@ -39,7 +39,6 @@ use function clearstatcache;
 use function dirname;
 use function error_clear_last;
 use function error_get_last;
-use function file_exists;
 use function file_put_contents;
 use function hash_file;
 use function is_dir;
@@ -144,7 +143,7 @@ class LocalFilesystemAdapter implements FilesystemAdapter, ChecksumProvider
 
         error_clear_last();
 
-        if ( ! @unlink($location)) {
+        if ( ! @unlink($location) && file_exists($location)) {
             throw UnableToDeleteFile::atLocation($location, error_get_last()['message'] ?? '');
         }
     }

--- a/src/Local/LocalFilesystemAdapterTest.php
+++ b/src/Local/LocalFilesystemAdapterTest.php
@@ -272,6 +272,19 @@ class LocalFilesystemAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function deleting_a_file_that_is_removed_by_another_process(): void
+    {
+        $this->givenWeHaveAnExistingFile('here.txt');
+        mock_function('unlink', false);
+        mock_function('file_exists', true, false);
+
+        $this->adapter()->delete('here.txt');
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
     public function checking_if_a_file_exists(): void
     {
         $adapter = new LocalFilesystemAdapter(static::ROOT);


### PR DESCRIPTION
Deleting a file that another process removed in the meantime throws `UnableToDeleteFile`. The `file_exists()` guard passes, the file disappears, and `unlink()` then fails. With several workers on EFS this happens often.

Clearing the stat cache before the guard does not help. `file_exists()` goes through `access()` and is not served from that cache. The race sits between the check and the unlink, so the failure is now only reported when the file is still on disk after `unlink()` returned false.

Fixes #1915