### PR TITLE
Fix FTP lastModified() reporting a future year

### DIFF
--- a/src/Ftp/FtpAdapter.php
+++ b/src/Ftp/FtpAdapter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace League\Flysystem\Ftp;
 
 use DateTime;
+use DateTimeInterface;
 use Generator;
 use League\Flysystem\Config;
 use League\Flysystem\DirectoryAttributes;
@@ -460,18 +461,28 @@ class FtpAdapter implements FilesystemAdapter
         return str_starts_with($permissions, 'd');
     }
 
-    private function normalizeUnixTimestamp(string $month, string $day, string $timeOrYear): int
+    private function normalizeUnixTimestamp(string $month, string $day, string $timeOrYear, ?DateTimeInterface $now = null): int
     {
+        $now ??= new DateTime();
+
         if (is_numeric($timeOrYear)) {
             $year = $timeOrYear;
             $hour = '00';
             $minute = '00';
+            $yearIsAssumed = false;
         } else {
-            $year = date('Y');
+            $year = $now->format('Y');
             [$hour, $minute] = explode(':', $timeOrYear);
+            $yearIsAssumed = true;
         }
 
         $dateTime = DateTime::createFromFormat('Y-M-j-G:i:s', "$year-$month-$day-$hour:$minute:00");
+
+        // Unix `ls`-style listings omit the year for recent entries, so we assume the current
+        // year. If that puts the date in the future, it actually belongs to last year.
+        if ($yearIsAssumed && $dateTime !== false && $dateTime > $now) {
+            $dateTime->modify('-1 year');
+        }
 
         return $dateTime->getTimestamp();
     }

--- a/src/Ftp/FtpAdapterTest.php
+++ b/src/Ftp/FtpAdapterTest.php
@@ -112,6 +112,68 @@ class FtpAdapterTest extends FtpAdapterTestCase
         $adapter->delete('something');
     }
 
+    /**
+     * @test
+     */
+    public function normalizing_a_unix_timestamp_without_year_uses_the_current_year(): void
+    {
+        $now = new \DateTime('2024-06-15 12:00:00');
+
+        $timestamp = $this->normalizeUnixTimestamp('Jun', '15', '10:00', $now);
+
+        $this->assertSame((new \DateTime('2024-06-15 10:00:00'))->getTimestamp(), $timestamp);
+    }
+
+    /**
+     * @test
+     */
+    public function normalizing_a_unix_timestamp_rolls_back_a_year_when_the_result_would_be_in_the_future(): void
+    {
+        // Reproduces the reported bug: a file modified 2024-09-30 12:58, listed by the FTP
+        // server without a year (as `ls`-style listings do for entries within ~6 months),
+        // viewed on 2025-02-19. Assuming the current year would report a future date.
+        $now = new \DateTime('2025-02-19 09:00:00');
+
+        $timestamp = $this->normalizeUnixTimestamp('Sep', '30', '12:58', $now);
+
+        $this->assertSame((new \DateTime('2024-09-30 12:58:00'))->getTimestamp(), $timestamp);
+    }
+
+    /**
+     * @test
+     */
+    public function normalizing_a_unix_timestamp_at_the_year_boundary(): void
+    {
+        // A file modified on December 31st of last year, listed without a year in early
+        // January, must not be interpreted as a date in the future.
+        $now = new \DateTime('2025-01-02 08:00:00');
+
+        $timestamp = $this->normalizeUnixTimestamp('Dec', '31', '23:45', $now);
+
+        $this->assertSame((new \DateTime('2024-12-31 23:45:00'))->getTimestamp(), $timestamp);
+    }
+
+    /**
+     * @test
+     */
+    public function normalizing_a_unix_timestamp_with_an_explicit_year_is_unaffected(): void
+    {
+        $now = new \DateTime('2019-06-01 00:00:00');
+
+        $timestamp = $this->normalizeUnixTimestamp('Jan', '1', '2019', $now);
+
+        $this->assertSame((new \DateTime('2019-01-01 00:00:00'))->getTimestamp(), $timestamp);
+    }
+
+    private function normalizeUnixTimestamp(string $month, string $day, string $timeOrYear, \DateTimeInterface $now): int
+    {
+        $adapter = static::createFilesystemAdapter();
+        $method = new \ReflectionMethod($adapter, 'normalizeUnixTimestamp');
+        $method->setAccessible(true);
+
+        return $method->invoke($adapter, $month, $day, $timeOrYear, $now);
+    }
+
     protected function tearDown(): void
     {
         reset_function_mocks();


### PR DESCRIPTION
Fixes #1857

## Problem

`FtpAdapter::normalizeUnixTimestamp()` always assumes the current calendar year whenever the FTP `LIST` output shows a time instead of a year. Unix `ls`-style listings omit the year for entries modified within roughly the last 6 months. When the code runs in a later calendar year than the file's actual modification year, this produces a date one year in the future.

Example from the issue: a file last modified 2024-09-30 is listed by the server as `Sep 30 12:58` (no year, since it's within the ~6 month window). `lastModified()` reports it as 2025-09-30 once viewed in 2025+.

## Fix

In `normalizeUnixTimestamp()`, after building the `DateTime` using the assumed current year, if the resulting date is in the future relative to now, roll it back one year — the standard technique for parsing year-less Unix `ls -l` dates.

The method also now accepts an optional `$now` parameter (defaulting to `new DateTime()`) purely to make the year-rollover behavior deterministically testable; the public `lastModified()` / listing behavior is unchanged.

## Tests

Added to `FtpAdapterTest`:
- `normalizing_a_unix_timestamp_without_year_uses_the_current_year` — normal case, no adjustment needed.
- `normalizing_a_unix_timestamp_rolls_back_a_year_when_the_result_would_be_in_the_future` — reproduces the exact scenario from #1857 (Sept 2024 file viewed in Feb 2025).
- `normalizing_a_unix_timestamp_at_the_year_boundary` — a Dec 31 entry viewed in early January must resolve to last year, not next year.
- `normalizing_a_unix_timestamp_with_an_explicit_year_is_unaffected` — listings that do include a year are untouched.

## Test status

Ran locally in a disposable PHP 8.2 CLI Docker container against `composer install`, with the repo's `docker-compose.yml` `ftp`/`ftpd` services running for the adapter's live-connection tests:

- `vendor/bin/phpunit --filter normalizing_a_unix_timestamp src/Ftp/FtpAdapterTest.php` — 4/4 pass.
- `vendor/bin/phpunit src/Ftp/FtpAdapterTest.php` — 90/90 pass (5 pre-existing skips, unrelated).
- `vendor/bin/phpunit src/Ftp/FtpdAdapterTest.php` — 82/82 pass (5 pre-existing skips, unrelated).
- `vendor/bin/phpstan analyse -l 6 src/Ftp/FtpAdapter.php src/Ftp/FtpAdapterTest.php` — no errors.

All containers/networks used for testing were torn down afterward.