### PR TITLE
Fix: create SFTP root directory when missing (#1832)

### DIFF
--- a/src/PhpseclibV2/SftpAdapter.php
+++ b/src/PhpseclibV2/SftpAdapter.php
@@ -56,7 +56,7 @@ class SftpAdapter implements FilesystemAdapter
 
     public function __construct(
         ConnectionProvider $connectionProvider,
-        string $root,
+        private string $root,
         ?VisibilityConverter $visibilityConverter = null,
         ?MimeTypeDetector $mimeTypeDetector = null,
         private bool $detectMimeTypeUsingPath = false,
@@ -115,12 +115,17 @@ class SftpAdapter implements FilesystemAdapter
     {
         $parentDirectory = dirname($path);
 
+        /** @var string $visibility */
+        $visibility = $config->get(Config::OPTION_DIRECTORY_VISIBILITY);
+
         if ($parentDirectory === '' || $parentDirectory === '.') {
+            if ($this->root !== '') {
+                $this->makeDirectory('', $visibility);
+            }
+
             return;
         }
 
-        /** @var string $visibility */
-        $visibility = $config->get(Config::OPTION_DIRECTORY_VISIBILITY);
         $this->makeDirectory($parentDirectory, $visibility);
     }
 

--- a/src/PhpseclibV2/SftpAdapterTest.php
+++ b/src/PhpseclibV2/SftpAdapterTest.php
@@ -207,6 +207,26 @@ class SftpAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function writing_a_file_creates_the_root_directory_when_it_is_missing(): void
+    {
+        $root = '/upload/missing-root-' . bin2hex(random_bytes(4));
+        $adapter = $this->useAdapter(new SftpAdapter(static::connectionProvider(), $root));
+
+        try {
+            $this->assertFalse($adapter->directoryExists(''), 'Precondition: root directory should not exist yet.');
+
+            $adapter->write('file.txt', 'contents', new Config());
+
+            $this->assertTrue($adapter->directoryExists(''));
+            $this->assertTrue($adapter->fileExists('file.txt'));
+        } finally {
+            $adapter->deleteDirectory('');
+        }
+    }
+
+    /**
+     * @test
+     */
     public function list_contents_directory_does_not_exist(): void
     {
         $contents = $this->adapter()->listContents('/does_not_exist', false);

--- a/src/PhpseclibV3/SftpAdapter.php
+++ b/src/PhpseclibV3/SftpAdapter.php
@@ -37,7 +37,7 @@ class SftpAdapter implements FilesystemAdapter
 
     public function __construct(
         private ConnectionProvider $connectionProvider,
-        string $root,
+        private string $root,
         ?VisibilityConverter $visibilityConverter = null,
         ?MimeTypeDetector $mimeTypeDetector = null,
         private bool $detectMimeTypeUsingPath = false,
@@ -101,12 +101,17 @@ class SftpAdapter implements FilesystemAdapter
     {
         $parentDirectory = dirname($path);
 
+        /** @var string $visibility */
+        $visibility = $config->get(Config::OPTION_DIRECTORY_VISIBILITY);
+
         if ($parentDirectory === '' || $parentDirectory === '.') {
+            if ($this->root !== '') {
+                $this->makeDirectory('', $visibility);
+            }
+
             return;
         }
 
-        /** @var string $visibility */
-        $visibility = $config->get(Config::OPTION_DIRECTORY_VISIBILITY);
         $this->makeDirectory($parentDirectory, $visibility);
     }
 

--- a/src/PhpseclibV3/SftpAdapterTest.php
+++ b/src/PhpseclibV3/SftpAdapterTest.php
@@ -209,6 +209,26 @@ class SftpAdapterTest extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function writing_a_file_creates_the_root_directory_when_it_is_missing(): void
+    {
+        $root = '/upload/missing-root-' . bin2hex(random_bytes(4));
+        $adapter = $this->useAdapter(new SftpAdapter(static::connectionProvider(), $root));
+
+        try {
+            $this->assertFalse($adapter->directoryExists(''), 'Precondition: root directory should not exist yet.');
+
+            $adapter->write('file.txt', 'contents', new Config());
+
+            $this->assertTrue($adapter->directoryExists(''));
+            $this->assertTrue($adapter->fileExists('file.txt'));
+        } finally {
+            $adapter->deleteDirectory('');
+        }
+    }
+
+    /**
+     * @test
+     */
     public function list_contents_directory_does_not_exist(): void
     {
         $contents = $this->adapter()->listContents('/does_not_exist', false);


### PR DESCRIPTION
Fixes #1832

## Summary

`SftpAdapter::write()` (both `PhpseclibV2` and `PhpseclibV3` variants) only creates missing directories via `ensureParentDirectoryExists()`, which computes `dirname($path)`. When writing directly to the adapter's root (e.g. `write('file.txt', ...)`), `dirname()` returns `'.'`, and the method returned early without creating anything — so if the configured root directory itself didn't exist on the remote server, the write failed with `UnableToWriteFile`.

Writing to a subdirectory (e.g. `write('parent_folder/file.txt', ...)`) worked fine because `makeDirectory()` is called with `mkdir(..., recursive: true)`, which implicitly creates the root along with the subdirectory.

### Fix

- Stored the configured `$root` as an adapter property.
- When `ensureParentDirectoryExists()` detects the write target is at adapter root (`dirname === '' || '.'`), it now also ensures the root directory itself exists (via the existing `makeDirectory()` path, reusing the same directory-visibility handling), matching the behavior subdirectories already had.
- Guarded on `$root !== ''` so adapters constructed with an empty root (i.e. no root restriction, using the connection's current working directory) keep their existing behavior and don't attempt to `is_dir('')`/`mkdir('')` against an empty path.
- Applied the same fix to both `League\Flysystem\PhpseclibV2\SftpAdapter` (deprecated but still shipped) and `League\Flysystem\PhpseclibV3\SftpAdapter` for consistency.

## Test plan

- Added `writing_a_file_creates_the_root_directory_when_it_is_missing()` to both `SftpAdapterTest` suites (`PhpseclibV2` and `PhpseclibV3`), following the existing test patterns in this suite (real SFTP connection via `StubSftpConnectionProvider`/`SftpStub` against the project's docker-based SFTP test server, `useAdapter()` for a one-off adapter instance, cleanup via `deleteDirectory()`).
- Test constructs an adapter pointed at a freshly-generated, not-yet-existing root path under `/upload`, asserts the root does not exist, writes a file directly to the adapter root, then asserts both the root directory and the file now exist.

**Disclosure: I could not run PHPUnit locally** — this environment has no PHP runtime available, so these tests are unverified locally. They're written to match the existing suite's conventions (same base class, same connection provider/stub, same `useAdapter`/cleanup pattern used elsewhere in this file) and should be validated by CI, which already has phpseclib3 and phpseclib and the SFTP docker test server configured for this test group (`@group sftp`).